### PR TITLE
Add Dependabot configuration and clean up imports in benchmark.py

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "pip" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"

--- a/benchmark.py
+++ b/benchmark.py
@@ -7,7 +7,6 @@ are produced, including per-size ranking tables and individual algorithm reports
 README file is rebuilt to reflect overall performance and any skipped algorithms.
 """
 
-import gc
 import csv
 import os
 import datetime


### PR DESCRIPTION
Introduce a Dependabot configuration for weekly updates of pip packages and remove an unused import in benchmark.py.