### PR TITLE
Add performance metrics and enhance CSV processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,30 +4,29 @@
 
 | Rank | Algorithms | Overall Average Time |
 | ---- | ---------- | -------------------- |
-| 1st | [Replacement Selection Sort](results/algorithms/Replacement_Selection_Sort.md) | 36us |
-| 2nd | [Cubesort](results/algorithms/Cubesort.md) | 38us |
-| 3rd | [Flash Sort](results/algorithms/Flash_Sort.md) | 49us |
-| 4th | [Burst Sort](results/algorithms/Burst_Sort.md) | 51us |
-| 5th | [Bucket Sort](results/algorithms/Bucket_Sort.md) | 52us |
-| 6th | [Shell Sort](results/algorithms/Shell_Sort.md) | 55us |
-| 7th | [Intro Sort](results/algorithms/Intro_Sort.md) | 56us |
-| 8th | [Spreadsort](results/algorithms/Spreadsort.md) | 58us |
-| 9th | [Merge Insertion Sort](results/algorithms/Merge_Insertion_Sort.md), [Patience Sort](results/algorithms/Patience_Sort.md) | 63us |
-| 11th | [Polyphase Merge Sort](results/algorithms/Polyphase_Merge_Sort.md) | 65us |
-| 12th | [Franceschini's Method](results/algorithms/Franceschini's_Method.md) | 69us |
-| 13th | [Tree Sort](results/algorithms/Tree_Sort.md) | 77us |
-| 14th | [Comb Sort](results/algorithms/Comb_Sort.md) | 78us |
-| 15th | [Tim Sort](results/algorithms/Tim_Sort.md) | 82us |
-| 16th | [Hyper Quick](results/algorithms/Hyper_Quick.md) | 92us |
-| 17th | [MSD Radix Sort](results/algorithms/MSD_Radix_Sort.md), [MSD Radix Sort In-Place](results/algorithms/MSD_Radix_Sort_In-Place.md) | 95us |
-| 19th | [Quick Sort](results/algorithms/Quick_Sort.md) | 105us |
-| 20th | [I Can't Believe It Can Sort](results/algorithms/I_Can't_Believe_It_Can_Sort.md) | 112us |
+| 1st | [Replacement Selection Sort](results/algorithms/Replacement_Selection_Sort.md) | 44us |
+| 2nd | [Cubesort](results/algorithms/Cubesort.md) | 47us |
+| 3rd | [Flash Sort](results/algorithms/Flash_Sort.md) | 64us |
+| 4th | [Burst Sort](results/algorithms/Burst_Sort.md) | 67us |
+| 5th | [Bucket Sort](results/algorithms/Bucket_Sort.md) | 69us |
+| 6th | [Spreadsort](results/algorithms/Spreadsort.md) | 73us |
+| 7th | [Intro Sort](results/algorithms/Intro_Sort.md) | 80us |
+| 8th | [Polyphase Merge Sort](results/algorithms/Polyphase_Merge_Sort.md), [Shell Sort](results/algorithms/Shell_Sort.md) | 88us |
+| 10th | [Merge Insertion Sort](results/algorithms/Merge_Insertion_Sort.md), [Patience Sort](results/algorithms/Patience_Sort.md) | 90us |
+| 12th | [Franceschini's Method](results/algorithms/Franceschini's_Method.md) | 98us |
+| 13th | [Tree Sort](results/algorithms/Tree_Sort.md) | 104us |
+| 14th | [Comb Sort](results/algorithms/Comb_Sort.md) | 115us |
+| 15th | [Tim Sort](results/algorithms/Tim_Sort.md) | 117us |
+| 16th | [Hyper Quick](results/algorithms/Hyper_Quick.md), [MSD Radix Sort](results/algorithms/MSD_Radix_Sort.md), [MSD Radix Sort In-Place](results/algorithms/MSD_Radix_Sort_In-Place.md) | 126us |
+| 19th | [I Can't Believe It Can Sort](results/algorithms/I_Can't_Believe_It_Can_Sort.md) | 155us |
+| 20th | [Quick Sort](results/algorithms/Quick_Sort.md) | 162us |
 
 ## Skipped Algorithms
 
 | Algorithm | Skipped At Size |
 | --------- | --------------- |
 | Bogo Sort | 12 |
+| Slowsort | 333 |
 
 ## Detailed Benchmark Results
 
@@ -190,4 +189,22 @@
 | 48th | Pigeonhole Sort | 2s 717ms | 2s 719ms |
 | 49th | Bead Sort | 48s 824ms | 48s 865ms |
 | 50th | Slowsort | 4min 1s 78ms | 4min 1s 549ms |
+
+### Array Size: 333
+
+| Rank | Algorithm(s) | Average Time | Median Time |
+| ---- | ------------ | ------------ | ----------- |
+| 1st | Replacement Selection Sort, Cubesort, Flash Sort, Spreadsort, Burst Sort, Bucket Sort, Intro Sort, Polyphase Merge Sort, Merge Insertion Sort, Patience Sort, Tree Sort, Franceschini's Method, Shell Sort, MSD Radix Sort, MSD Radix Sort In-Place, Tim Sort, Hyper Quick, Comb Sort, I Can't Believe It Can Sort, LSD Radix Sort, Merge Sort, Block Sort, Quick Sort, Merge Sort In-Place, Heap Sort, Radix Sort, Strand Sort, Postman Sort, Spaghetti Sort, Sample Sort, Library Sort | less than a ms | less than a ms |
+| 32nd | Insertion Sort, Sorting Network, Selection Sort | 3ms | 3ms |
+| 35th | Bitonic Sort Parallel, Exchange Sort, Tournament Sort, Pancake Sort, Cocktail Sort, Bubble Sort, Odd-Even Sort | 5ms | 4ms |
+| 42nd | Gnome Sort | 9ms | 8ms |
+| 43rd | Cycle Sort, Smooth Sort | 10ms | 9ms |
+| 45th | Counting Sort | 259ms | 256ms |
+| 46th | Stooge Sort | 1s 204ms | 1s 204ms |
+| 47th | Sleep Sort | 2s 23ms | 2s 23ms |
+| 48th | Pigeonhole Sort | 2s 635ms | 2s 673ms |
+| 49th | Bead Sort | 1min 5s 812ms | 1min 5s 321ms |
+| 50th | Slowsort | 28min 56s 728ms | 28min 47s 536ms |
+
+**Note:** The following algorithm were removed for this array size due to performance issues: Slowsort (at size 333)
 

--- a/README.md
+++ b/README.md
@@ -4,22 +4,23 @@
 
 | Rank | Algorithms | Overall Average Time |
 | ---- | ---------- | -------------------- |
-| 1st | [Replacement Selection Sort](results/algorithms/Replacement_Selection_Sort.md) | 44us |
-| 2nd | [Cubesort](results/algorithms/Cubesort.md) | 47us |
-| 3rd | [Flash Sort](results/algorithms/Flash_Sort.md) | 64us |
-| 4th | [Burst Sort](results/algorithms/Burst_Sort.md) | 67us |
-| 5th | [Bucket Sort](results/algorithms/Bucket_Sort.md) | 69us |
-| 6th | [Spreadsort](results/algorithms/Spreadsort.md) | 73us |
-| 7th | [Intro Sort](results/algorithms/Intro_Sort.md) | 80us |
-| 8th | [Polyphase Merge Sort](results/algorithms/Polyphase_Merge_Sort.md), [Shell Sort](results/algorithms/Shell_Sort.md) | 88us |
-| 10th | [Merge Insertion Sort](results/algorithms/Merge_Insertion_Sort.md), [Patience Sort](results/algorithms/Patience_Sort.md) | 90us |
-| 12th | [Franceschini's Method](results/algorithms/Franceschini's_Method.md) | 98us |
-| 13th | [Tree Sort](results/algorithms/Tree_Sort.md) | 104us |
-| 14th | [Comb Sort](results/algorithms/Comb_Sort.md) | 115us |
-| 15th | [Tim Sort](results/algorithms/Tim_Sort.md) | 117us |
-| 16th | [Hyper Quick](results/algorithms/Hyper_Quick.md), [MSD Radix Sort](results/algorithms/MSD_Radix_Sort.md), [MSD Radix Sort In-Place](results/algorithms/MSD_Radix_Sort_In-Place.md) | 126us |
-| 19th | [I Can't Believe It Can Sort](results/algorithms/I_Can't_Believe_It_Can_Sort.md) | 155us |
-| 20th | [Quick Sort](results/algorithms/Quick_Sort.md) | 162us |
+| 1st | [Replacement Selection Sort](results/algorithms/Replacement_Selection_Sort.md) | 53us |
+| 2nd | [Cubesort](results/algorithms/Cubesort.md) | 57us |
+| 3rd | [Flash Sort](results/algorithms/Flash_Sort.md), [Burst Sort](results/algorithms/Burst_Sort.md) | 83us |
+| 5th | [Bucket Sort](results/algorithms/Bucket_Sort.md) | 87us |
+| 6th | [Spreadsort](results/algorithms/Spreadsort.md) | 90us |
+| 7th | [Polyphase Merge Sort](results/algorithms/Polyphase_Merge_Sort.md) | 108us |
+| 8th | [Intro Sort](results/algorithms/Intro_Sort.md) | 119us |
+| 9th | [Merge Insertion Sort](results/algorithms/Merge_Insertion_Sort.md), [Shell Sort](results/algorithms/Shell_Sort.md), [Patience Sort](results/algorithms/Patience_Sort.md) | 130us |
+| 12th | [Tree Sort](results/algorithms/Tree_Sort.md) | 140us |
+| 13th | [Franceschini's Method](results/algorithms/Franceschini's_Method.md) | 147us |
+| 14th | [Tim Sort](results/algorithms/Tim_Sort.md) | 165us |
+| 15th | [Comb Sort](results/algorithms/Comb_Sort.md) | 166us |
+| 16th | [MSD Radix Sort](results/algorithms/MSD_Radix_Sort.md) | 167us |
+| 17th | [MSD Radix Sort In-Place](results/algorithms/MSD_Radix_Sort_In-Place.md) | 173us |
+| 18th | [Hyper Quick](results/algorithms/Hyper_Quick.md) | 179us |
+| 19th | [Quick Sort](results/algorithms/Quick_Sort.md) | 210us |
+| 20th | [I Can't Believe It Can Sort](results/algorithms/I_Can't_Believe_It_Can_Sort.md) | 219us |
 
 ## Skipped Algorithms
 
@@ -207,4 +208,22 @@
 | 50th | Slowsort | 28min 56s 728ms | 28min 47s 536ms |
 
 **Note:** The following algorithm were removed for this array size due to performance issues: Slowsort (at size 333)
+
+### Array Size: 500
+
+| Rank | Algorithm(s) | Average Time | Median Time |
+| ---- | ------------ | ------------ | ----------- |
+| 1st | Replacement Selection Sort, Cubesort, Burst Sort, Bucket Sort, Spreadsort, Flash Sort, Polyphase Merge Sort, Tree Sort, Intro Sort, Merge Insertion Sort, Patience Sort, Shell Sort, MSD Radix Sort, MSD Radix Sort In-Place, Franceschini's Method, Tim Sort, Quick Sort, Comb Sort, Hyper Quick, Postman Sort, LSD Radix Sort, Radix Sort, I Can't Believe It Can Sort, Merge Sort, Block Sort, Heap Sort, Merge Sort In-Place, Sample Sort, Strand Sort, Spaghetti Sort | less than a ms | less than a ms |
+| 31st | Sorting Network, Library Sort, Bitonic Sort Parallel | 3ms | 3ms |
+| 34th | Insertion Sort, Selection Sort | 6ms | 6ms |
+| 36th | Tournament Sort, Pancake Sort, Exchange Sort | 9ms | 9ms |
+| 39th | Cocktail Sort, Bubble Sort | 12ms | 12ms |
+| 41st | Odd-Even Sort | 13ms | 13ms |
+| 42nd | Gnome Sort | 18ms | 18ms |
+| 43rd | Smooth Sort, Cycle Sort | 19ms | 19ms |
+| 45th | Counting Sort | 213ms | 212ms |
+| 46th | Pigeonhole Sort | 1s 548ms | 1s 565ms |
+| 47th | Sleep Sort | 2s 53ms | 2s 54ms |
+| 48th | Stooge Sort | 3s 127ms | 3s 108ms |
+| 49th | Bead Sort | 1min 10s 78ms | 1min 6s 832ms |
 

--- a/benchmark/processor.py
+++ b/benchmark/processor.py
@@ -82,7 +82,9 @@ def process_size(
       tuple: (size_results, skip_list)
     """
     # Retrieve CSV file and current results.
-    csv_path, size_results, *_ = get_csv_results_for_size(size, expected_algs)
+    csv_path, size_results, *_ = get_csv_results_for_size(
+        size, expected_algs, max_iterations=iterations
+    )
 
     # Determine the number of worker processes.
     current_workers = get_num_workers()
@@ -113,7 +115,9 @@ def process_size(
     # Sort CSV for consistency.
     sort_csv_alphabetically(csv_path)
     # Re-read updated CSV and update overall results.
-    _, updated_results, *_ = get_csv_results_for_size(size, expected_algs)
+    _, updated_results, *_ = get_csv_results_for_size(
+        size, expected_algs, max_iterations=iterations
+    )
     update_overall_results(
         size,
         updated_results,

--- a/benchmark/utils.py
+++ b/benchmark/utils.py
@@ -34,8 +34,15 @@ def format_time(seconds, detailed=False):
     Returns:
       str: Formatted time string.
     """
-    if seconds is None or (isinstance(seconds, float) and math.isnan(seconds)):
+    try:
+        seconds = float(seconds)
+    except (ValueError, TypeError):
         return "NaN"
+
+    # Check if seconds is NaN.
+    if math.isnan(seconds):
+        return "NaN"
+
     if seconds < 1e-3:
         if detailed:
             us = int(round(seconds * 1e6))

--- a/details.md
+++ b/details.md
@@ -178,3 +178,21 @@
 
 **Note:** The following algorithm were removed for this array size due to performance issues: Slowsort (at size 333)
 
+## Array Size: 500
+
+| Rank | Algorithm(s) | Average Time | Median Time |
+| ---- | ------------ | ------------ | ----------- |
+| 1st | Replacement Selection Sort, Cubesort, Burst Sort, Bucket Sort, Spreadsort, Flash Sort, Polyphase Merge Sort, Tree Sort, Intro Sort, Merge Insertion Sort, Patience Sort, Shell Sort, MSD Radix Sort, MSD Radix Sort In-Place, Franceschini's Method, Tim Sort, Quick Sort, Comb Sort, Hyper Quick, Postman Sort, LSD Radix Sort, Radix Sort, I Can't Believe It Can Sort, Merge Sort, Block Sort, Heap Sort, Merge Sort In-Place, Sample Sort, Strand Sort, Spaghetti Sort | less than a ms | less than a ms |
+| 31st | Sorting Network, Library Sort, Bitonic Sort Parallel | 3ms | 3ms |
+| 34th | Insertion Sort, Selection Sort | 6ms | 6ms |
+| 36th | Tournament Sort, Pancake Sort, Exchange Sort | 9ms | 9ms |
+| 39th | Cocktail Sort, Bubble Sort | 12ms | 12ms |
+| 41st | Odd-Even Sort | 13ms | 13ms |
+| 42nd | Gnome Sort | 18ms | 18ms |
+| 43rd | Smooth Sort, Cycle Sort | 19ms | 19ms |
+| 45th | Counting Sort | 213ms | 212ms |
+| 46th | Pigeonhole Sort | 1s 548ms | 1s 565ms |
+| 47th | Sleep Sort | 2s 53ms | 2s 54ms |
+| 48th | Stooge Sort | 3s 127ms | 3s 108ms |
+| 49th | Bead Sort | 1min 10s 78ms | 1min 6s 832ms |
+

--- a/details.md
+++ b/details.md
@@ -160,3 +160,21 @@
 | 49th | Bead Sort | 48s 824ms | 48s 865ms |
 | 50th | Slowsort | 4min 1s 78ms | 4min 1s 549ms |
 
+## Array Size: 333
+
+| Rank | Algorithm(s) | Average Time | Median Time |
+| ---- | ------------ | ------------ | ----------- |
+| 1st | Replacement Selection Sort, Cubesort, Flash Sort, Spreadsort, Burst Sort, Bucket Sort, Intro Sort, Polyphase Merge Sort, Merge Insertion Sort, Patience Sort, Tree Sort, Franceschini's Method, Shell Sort, MSD Radix Sort, MSD Radix Sort In-Place, Tim Sort, Hyper Quick, Comb Sort, I Can't Believe It Can Sort, LSD Radix Sort, Merge Sort, Block Sort, Quick Sort, Merge Sort In-Place, Heap Sort, Radix Sort, Strand Sort, Postman Sort, Spaghetti Sort, Sample Sort, Library Sort | less than a ms | less than a ms |
+| 32nd | Insertion Sort, Sorting Network, Selection Sort | 3ms | 3ms |
+| 35th | Bitonic Sort Parallel, Exchange Sort, Tournament Sort, Pancake Sort, Cocktail Sort, Bubble Sort, Odd-Even Sort | 5ms | 4ms |
+| 42nd | Gnome Sort | 9ms | 8ms |
+| 43rd | Cycle Sort, Smooth Sort | 10ms | 9ms |
+| 45th | Counting Sort | 259ms | 256ms |
+| 46th | Stooge Sort | 1s 204ms | 1s 204ms |
+| 47th | Sleep Sort | 2s 23ms | 2s 23ms |
+| 48th | Pigeonhole Sort | 2s 635ms | 2s 673ms |
+| 49th | Bead Sort | 1min 5s 812ms | 1min 5s 321ms |
+| 50th | Slowsort | 28min 56s 728ms | 28min 47s 536ms |
+
+**Note:** The following algorithm were removed for this array size due to performance issues: Slowsort (at size 333)
+

--- a/results/results_333.csv
+++ b/results/results_333.csv
@@ -1,0 +1,25001 @@
+Algorithm,Array Size,Iteration,Elapsed Time (seconds)
+Bead Sort,333,1,64.70420220
+Bead Sort,333,2,64.58536730
+Bead Sort,333,3,63.96844450
+Bead Sort,333,4,65.69627730
+Bead Sort,333,5,63.27615480
+Bead Sort,333,6,63.10400430
+Bead Sort,333,7,64.55162890
+Bead Sort,333,8,64.03710790
+Bead Sort,333,9,64.54119180
+Bead Sort,333,10,63.52356420
+Bead Sort,333,11,71.85920650
+Bead Sort,333,12,64.64059390
+Bead Sort,333,13,65.09222730
+Bead Sort,333,14,63.43301420
+Bead Sort,333,15,63.96747770
+Bead Sort,333,16,65.33187550
+Bead Sort,333,17,67.06096360
+Bead Sort,333,18,64.96585150
+Bead Sort,333,19,64.71281000
+Bead Sort,333,20,67.44946560
+Bead Sort,333,21,65.09222480
+Bead Sort,333,22,63.09024970
+Bead Sort,333,23,63.63924370
+Bead Sort,333,24,64.51392820
+Bead Sort,333,25,63.35595980
+Bead Sort,333,26,65.07100690
+Bead Sort,333,27,63.94705150
+Bead Sort,333,28,72.87935780
+Bead Sort,333,29,65.31931110
+Bead Sort,333,30,64.35200850
+Bead Sort,333,31,64.50673390
+Bead Sort,333,32,65.56732890
+Bead Sort,333,33,63.71722570
+Bead Sort,333,34,65.01289320
+Bead Sort,333,35,65.12785900
+Bead Sort,333,36,64.45845630
+Bead Sort,333,37,65.04449380
+Bead Sort,333,38,64.53346410
+Bead Sort,333,39,66.00502360
+Bead Sort,333,40,61.23207870
+Bead Sort,333,41,65.01697630
+Bead Sort,333,42,71.30274260
+Bead Sort,333,43,64.96685290
+Bead Sort,333,44,64.73026450
+Bead Sort,333,45,66.40371620
+Bead Sort,333,46,63.10258030
+Bead Sort,333,47,63.11844780
+Bead Sort,333,48,66.51958800
+Bead Sort,333,49,65.97979480
+Bead Sort,333,50,64.36556060
+Bead Sort,333,51,66.16444820
+Bead Sort,333,52,64.89996240
+Bead Sort,333,53,63.05827500
+Bead Sort,333,54,65.45676850
+Bead Sort,333,55,65.49637330
+Bead Sort,333,56,70.57255040
+Bead Sort,333,57,71.77809540
+Bead Sort,333,58,67.26692720
+Bead Sort,333,59,65.07374680
+Bead Sort,333,60,66.40223960
+Bead Sort,333,61,65.35151770
+Bead Sort,333,62,66.28520800
+Bead Sort,333,63,63.08907960
+Bead Sort,333,64,64.97513440
+Bead Sort,333,65,67.94196590
+Bead Sort,333,66,67.84734330
+Bead Sort,333,67,66.28467730
+Bead Sort,333,68,66.60648680
+Bead Sort,333,69,63.99991230
+Bead Sort,333,70,71.77394990
+Bead Sort,333,71,63.27846040
+Bead Sort,333,72,64.05027070
+Bead Sort,333,73,63.98233260
+Bead Sort,333,74,63.37322360
+Bead Sort,333,75,63.43761880
+Bead Sort,333,76,66.31166210
+Bead Sort,333,77,64.88034340
+Bead Sort,333,78,65.16335080
+Bead Sort,333,79,63.10197330
+Bead Sort,333,80,62.55120320
+Bead Sort,333,81,63.92988370
+Bead Sort,333,82,65.91693900
+Bead Sort,333,83,65.16558600
+Bead Sort,333,84,72.40470600
+Bead Sort,333,85,67.05875430
+Bead Sort,333,86,64.34427480
+Bead Sort,333,87,64.82938960
+Bead Sort,333,88,64.34546790
+Bead Sort,333,89,63.07154260
+Bead Sort,333,90,64.30843650
+Bead Sort,333,91,64.90182060
+Bead Sort,333,92,63.30671540
+Bead Sort,333,93,66.52519150
+Bead Sort,333,94,63.32543840
+Bead Sort,333,95,63.32198550
+Bead Sort,333,96,66.05766170
+Bead Sort,333,97,65.29330140
+Bead Sort,333,98,74.99798070
+Bead Sort,333,99,64.33084610
+Bead Sort,333,100,65.87796070
+Bead Sort,333,101,64.78619610
+Bead Sort,333,102,62.47357180
+Bead Sort,333,103,64.39608470
+Bead Sort,333,104,65.72766970
+Bead Sort,333,105,67.19181250
+Bead Sort,333,106,65.92027070
+Bead Sort,333,107,65.49276530
+Bead Sort,333,108,64.57565470
+Bead Sort,333,109,62.76621990
+Bead Sort,333,110,64.28567280
+Bead Sort,333,111,65.67799840
+Bead Sort,333,112,70.75791880
+Bead Sort,333,113,64.87252590
+Bead Sort,333,114,64.43573820
+Bead Sort,333,115,62.10160400
+Bead Sort,333,116,66.40629630
+Bead Sort,333,117,66.12693880
+Bead Sort,333,118,64.34699940
+Bead Sort,333,119,66.11023090
+Bead Sort,333,120,64.89087830
+Bead Sort,333,121,64.22372930
+Bead Sort,333,122,63.70083420
+Bead Sort,333,123,68.29316210
+Bead Sort,333,124,70.37068850
+Bead Sort,333,125,66.81793170
+Bead Sort,333,126,71.73129010
+Bead Sort,333,127,64.50769900
+Bead Sort,333,128,64.11496800
+Bead Sort,333,129,66.97478630
+Bead Sort,333,130,66.36067310
+Bead Sort,333,131,64.45080090
+Bead Sort,333,132,63.56612590
+Bead Sort,333,133,64.69741580
+Bead Sort,333,134,69.33518520
+Bead Sort,333,135,67.21822150
+Bead Sort,333,136,65.87808320
+Bead Sort,333,137,63.16620130
+Bead Sort,333,138,64.39113470
+Bead Sort,333,139,65.67912310
+Bead Sort,333,140,63.46978610
+Bead Sort,333,141,64.16397630
+Bead Sort,333,142,76.86841150
+Bead Sort,333,143,64.34383530
+Bead Sort,333,144,64.96406770
+Bead Sort,333,145,73.43243110
+Bead Sort,333,146,64.37225570
+Bead Sort,333,147,66.33744630
+Bead Sort,333,148,64.94882540
+Bead Sort,333,149,61.98830940
+Bead Sort,333,150,64.94473980
+Bead Sort,333,151,66.09953730
+Bead Sort,333,152,66.41921440
+Bead Sort,333,153,66.62432530
+Bead Sort,333,154,67.25263580
+Bead Sort,333,155,65.45103650
+Bead Sort,333,156,64.86901410
+Bead Sort,333,157,64.17307040
+Bead Sort,333,158,64.89124890
+Bead Sort,333,159,63.90187440
+Bead Sort,333,160,64.71362650
+Bead Sort,333,161,65.90366990
+Bead Sort,333,162,63.20109180
+Bead Sort,333,163,64.78892640
+Bead Sort,333,164,70.26418930
+Bead Sort,333,165,60.87481280
+Bead Sort,333,166,65.43230040
+Bead Sort,333,167,61.51766020
+Bead Sort,333,168,61.62826750
+Bead Sort,333,169,65.99483460
+Bead Sort,333,170,64.73799510
+Bead Sort,333,171,64.85943870
+Bead Sort,333,172,64.45590680
+Bead Sort,333,173,64.61446020
+Bead Sort,333,174,66.23744080
+Bead Sort,333,175,64.97520840
+Bead Sort,333,176,64.10603920
+Bead Sort,333,177,64.90537670
+Bead Sort,333,178,65.65342050
+Bead Sort,333,179,67.25786010
+Bead Sort,333,180,66.34841840
+Bead Sort,333,181,71.75483890
+Bead Sort,333,182,64.82629320
+Bead Sort,333,183,66.17239210
+Bead Sort,333,184,66.26935850
+Bead Sort,333,185,64.26309510
+Bead Sort,333,186,63.58417530
+Bead Sort,333,187,66.30170820
+Bead Sort,333,188,65.57139770
+Bead Sort,333,189,69.34422920
+Bead Sort,333,190,65.89332030
+Bead Sort,333,191,69.13364370
+Bead Sort,333,192,65.94590010
+Bead Sort,333,193,67.66370000
+Bead Sort,333,194,63.22923620
+Bead Sort,333,195,72.95679980
+Bead Sort,333,196,64.47555040
+Bead Sort,333,197,63.12442200
+Bead Sort,333,198,65.15696610
+Bead Sort,333,199,67.09027920
+Bead Sort,333,200,65.15638980
+Bead Sort,333,201,64.64189650
+Bead Sort,333,202,62.62622110
+Bead Sort,333,203,67.05083560
+Bead Sort,333,204,66.42451150
+Bead Sort,333,205,63.88846280
+Bead Sort,333,206,68.79789750
+Bead Sort,333,207,68.20236780
+Bead Sort,333,208,66.70306810
+Bead Sort,333,209,73.56959280
+Bead Sort,333,210,64.37067680
+Bead Sort,333,211,66.69976230
+Bead Sort,333,212,64.89329340
+Bead Sort,333,213,65.24630770
+Bead Sort,333,214,67.30766870
+Bead Sort,333,215,68.89940190
+Bead Sort,333,216,64.10196180
+Bead Sort,333,217,65.01768320
+Bead Sort,333,218,65.24565850
+Bead Sort,333,219,64.18036530
+Bead Sort,333,220,62.79343490
+Bead Sort,333,221,64.16735720
+Bead Sort,333,222,64.50429380
+Bead Sort,333,223,75.50196780
+Bead Sort,333,224,63.86453850
+Bead Sort,333,225,65.87341030
+Bead Sort,333,226,64.04157690
+Bead Sort,333,227,65.62299860
+Bead Sort,333,228,64.55264530
+Bead Sort,333,229,62.92481520
+Bead Sort,333,230,66.38121660
+Bead Sort,333,231,64.07979290
+Bead Sort,333,232,65.43656210
+Bead Sort,333,233,65.67244240
+Bead Sort,333,234,66.84894160
+Bead Sort,333,235,67.85196370
+Bead Sort,333,236,65.51162270
+Bead Sort,333,237,74.32357020
+Bead Sort,333,238,68.61890840
+Bead Sort,333,239,64.69487510
+Bead Sort,333,240,62.26176720
+Bead Sort,333,241,65.57779610
+Bead Sort,333,242,64.95579120
+Bead Sort,333,243,64.19748170
+Bead Sort,333,244,63.67212750
+Bead Sort,333,245,62.79246570
+Bead Sort,333,246,68.22859800
+Bead Sort,333,247,65.82664460
+Bead Sort,333,248,66.28677510
+Bead Sort,333,249,65.71452540
+Bead Sort,333,250,66.41799000
+Bead Sort,333,251,73.05775230
+Bead Sort,333,252,64.60722490
+Bead Sort,333,253,66.57180250
+Bead Sort,333,254,65.50049410
+Bead Sort,333,255,68.84362080
+Bead Sort,333,256,63.95778220
+Bead Sort,333,257,65.45196780
+Bead Sort,333,258,65.64714130
+Bead Sort,333,259,65.87176940
+Bead Sort,333,260,65.10502000
+Bead Sort,333,261,65.33146960
+Bead Sort,333,262,69.34861770
+Bead Sort,333,263,68.00980180
+Bead Sort,333,264,66.46226390
+Bead Sort,333,265,65.55578820
+Bead Sort,333,266,65.43051550
+Bead Sort,333,267,64.39635010
+Bead Sort,333,268,65.12800320
+Bead Sort,333,269,73.07119970
+Bead Sort,333,270,64.39430530
+Bead Sort,333,271,63.92216360
+Bead Sort,333,272,65.13502290
+Bead Sort,333,273,66.73041790
+Bead Sort,333,274,66.52855140
+Bead Sort,333,275,63.91425490
+Bead Sort,333,276,63.92310840
+Bead Sort,333,277,62.00734660
+Bead Sort,333,278,64.13030020
+Bead Sort,333,279,64.01955080
+Bead Sort,333,280,63.55509230
+Bead Sort,333,281,65.14406370
+Bead Sort,333,282,64.77139310
+Bead Sort,333,283,63.38980670
+Bead Sort,333,284,67.24969840
+Bead Sort,333,285,64.85647670
+Bead Sort,333,286,64.74716550
+Bead Sort,333,287,73.87244320
+Bead Sort,333,288,62.12624490
+Bead Sort,333,289,65.85049650
+Bead Sort,333,290,68.22617630
+Bead Sort,333,291,66.93773520
+Bead Sort,333,292,68.23403580
+Bead Sort,333,293,65.87053820
+Bead Sort,333,294,67.82873360
+Bead Sort,333,295,66.75527860
+Bead Sort,333,296,67.05872320
+Bead Sort,333,297,64.93205420
+Bead Sort,333,298,64.86097780
+Bead Sort,333,299,64.98915780
+Bead Sort,333,300,65.48586870
+Bead Sort,333,301,63.84407520
+Bead Sort,333,302,66.92217230
+Bead Sort,333,303,71.37135230
+Bead Sort,333,304,66.68068340
+Bead Sort,333,305,65.80854680
+Bead Sort,333,306,64.49444090
+Bead Sort,333,307,64.25063260
+Bead Sort,333,308,63.46847230
+Bead Sort,333,309,64.78537400
+Bead Sort,333,310,64.92358240
+Bead Sort,333,311,63.10418820
+Bead Sort,333,312,66.25873020
+Bead Sort,333,313,66.05835510
+Bead Sort,333,314,67.29489780
+Bead Sort,333,315,64.54477360
+Bead Sort,333,316,64.81673690
+Bead Sort,333,317,67.26782480
+Bead Sort,333,318,64.76990170
+Bead Sort,333,319,68.27497400
+Bead Sort,333,320,70.22989530
+Bead Sort,333,321,64.48986830
+Bead Sort,333,322,62.86035460
+Bead Sort,333,323,67.15671540
+Bead Sort,333,324,62.65473320
+Bead Sort,333,325,65.16930130
+Bead Sort,333,326,65.60475070
+Bead Sort,333,327,66.38932620
+Bead Sort,333,328,64.58311260
+Bead Sort,333,329,66.49627180
+Bead Sort,333,330,64.12403430
+Bead Sort,333,331,66.37834200
+Bead Sort,333,332,62.74425190
+Bead Sort,333,333,68.56394800
+Bead Sort,333,334,73.82327110
+Bead Sort,333,335,65.94490030
+Bead Sort,333,336,65.71674370
+Bead Sort,333,337,64.96223930
+Bead Sort,333,338,65.62645190
+Bead Sort,333,339,65.14217310
+Bead Sort,333,340,64.67705570
+Bead Sort,333,341,67.63630760
+Bead Sort,333,342,64.53020150
+Bead Sort,333,343,63.39606750
+Bead Sort,333,344,66.54836060
+Bead Sort,333,345,65.82861740
+Bead Sort,333,346,64.52093080
+Bead Sort,333,347,66.61188640
+Bead Sort,333,348,67.39012260
+Bead Sort,333,349,64.63868940
+Bead Sort,333,350,63.52262300
+Bead Sort,333,351,66.03200870
+Bead Sort,333,352,64.43903830
+Bead Sort,333,353,63.13481950
+Bead Sort,333,354,67.05769280
+Bead Sort,333,355,67.62897870
+Bead Sort,333,356,66.48299260
+Bead Sort,333,357,64.54095340
+Bead Sort,333,358,63.89816660
+Bead Sort,333,359,62.58259490
+Bead Sort,333,360,65.46229670
+Bead Sort,333,361,67.75383320
+Bead Sort,333,362,71.90229310
+Bead Sort,333,363,66.14637600
+Bead Sort,333,364,65.87041060
+Bead Sort,333,365,64.51670800
+Bead Sort,333,366,66.50995930
+Bead Sort,333,367,65.05709450
+Bead Sort,333,368,64.45690270
+Bead Sort,333,369,61.98649890
+Bead Sort,333,370,66.54384940
+Bead Sort,333,371,65.70721630
+Bead Sort,333,372,66.67457510
+Bead Sort,333,373,66.89117530
+Bead Sort,333,374,70.19735800
+Bead Sort,333,375,67.50527460
+Bead Sort,333,376,68.57471690
+Bead Sort,333,377,65.89679670
+Bead Sort,333,378,66.93723490
+Bead Sort,333,379,65.21349950
+Bead Sort,333,380,62.62205050
+Bead Sort,333,381,65.96765250
+Bead Sort,333,382,65.99657930
+Bead Sort,333,383,64.55201790
+Bead Sort,333,384,66.89838220
+Bead Sort,333,385,66.55292070
+Bead Sort,333,386,65.04287050
+Bead Sort,333,387,64.71388330
+Bead Sort,333,388,64.93764690
+Bead Sort,333,389,64.30276320
+Bead Sort,333,390,71.26258440
+Bead Sort,333,391,67.89494390
+Bead Sort,333,392,65.06454360
+Bead Sort,333,393,67.23554130
+Bead Sort,333,394,66.46857150
+Bead Sort,333,395,65.69800870
+Bead Sort,333,396,65.19620620
+Bead Sort,333,397,63.82537410
+Bead Sort,333,398,64.94548950
+Bead Sort,333,399,66.71800700
+Bead Sort,333,400,68.00693050
+Bead Sort,333,401,64.18911460
+Bead Sort,333,402,65.63198860
+Bead Sort,333,403,68.53802170
+Bead Sort,333,404,75.33810570
+Bead Sort,333,405,62.14696380
+Bead Sort,333,406,64.85685770
+Bead Sort,333,407,63.64714020
+Bead Sort,333,408,63.34556720
+Bead Sort,333,409,65.06001490
+Bead Sort,333,410,64.87050100
+Bead Sort,333,411,64.37581170
+Bead Sort,333,412,64.55431040
+Bead Sort,333,413,66.50402640
+Bead Sort,333,414,65.32322050
+Bead Sort,333,415,68.45087720
+Bead Sort,333,416,64.42393770
+Bead Sort,333,417,64.79304050
+Bead Sort,333,418,65.51797620
+Bead Sort,333,419,64.32664620
+Bead Sort,333,420,65.19638590
+Bead Sort,333,421,67.38853000
+Bead Sort,333,422,71.03328970
+Bead Sort,333,423,66.22184690
+Bead Sort,333,424,63.60169700
+Bead Sort,333,425,64.93080240
+Bead Sort,333,426,66.58579050
+Bead Sort,333,427,65.64896050
+Bead Sort,333,428,67.21822260
+Bead Sort,333,429,66.78024900
+Bead Sort,333,430,66.23976280
+Bead Sort,333,431,71.45952500
+Bead Sort,333,432,66.11239940
+Bead Sort,333,433,65.49234890
+Bead Sort,333,434,64.02023660
+Bead Sort,333,435,67.39340020
+Bead Sort,333,436,63.51526060
+Bead Sort,333,437,65.10834290
+Bead Sort,333,438,65.90174240
+Bead Sort,333,439,71.84901610
+Bead Sort,333,440,65.47272420
+Bead Sort,333,441,64.99359450
+Bead Sort,333,442,65.43384760
+Bead Sort,333,443,64.42405230
+Bead Sort,333,444,67.70476030
+Bead Sort,333,445,70.21478250
+Bead Sort,333,446,64.17796860
+Bead Sort,333,447,65.05906930
+Bead Sort,333,448,65.48676840
+Bead Sort,333,449,65.49055420
+Bead Sort,333,450,66.77548550
+Bead Sort,333,451,64.41540580
+Bead Sort,333,452,66.13715710
+Bead Sort,333,453,65.92396510
+Bead Sort,333,454,70.06708990
+Bead Sort,333,455,68.44878660
+Bead Sort,333,456,67.20705010
+Bead Sort,333,457,69.10101400
+Bead Sort,333,458,63.29384020
+Bead Sort,333,459,67.77545170
+Bead Sort,333,460,63.69793240
+Bead Sort,333,461,65.74063400
+Bead Sort,333,462,62.36722000
+Bead Sort,333,463,64.41182800
+Bead Sort,333,464,63.42209450
+Bead Sort,333,465,63.46766560
+Bead Sort,333,466,64.02120680
+Bead Sort,333,467,65.10387550
+Bead Sort,333,468,64.32537940
+Bead Sort,333,469,73.50816130
+Bead Sort,333,470,65.68157990
+Bead Sort,333,471,64.74616970
+Bead Sort,333,472,67.38667050
+Bead Sort,333,473,66.53580600
+Bead Sort,333,474,67.10762440
+Bead Sort,333,475,63.36184890
+Bead Sort,333,476,64.93116880
+Bead Sort,333,477,66.49622200
+Bead Sort,333,478,65.42064700
+Bead Sort,333,479,64.42504170
+Bead Sort,333,480,65.76416940
+Bead Sort,333,481,64.83121770
+Bead Sort,333,482,66.30132160
+Bead Sort,333,483,67.04781970
+Bead Sort,333,484,68.37641180
+Bead Sort,333,485,72.84292970
+Bead Sort,333,486,65.65874210
+Bead Sort,333,487,66.32961270
+Bead Sort,333,488,63.57553590
+Bead Sort,333,489,65.96773310
+Bead Sort,333,490,65.80499730
+Bead Sort,333,491,66.15801440
+Bead Sort,333,492,66.56713810
+Bead Sort,333,493,63.49730410
+Bead Sort,333,494,65.78285360
+Bead Sort,333,495,66.11784100
+Bead Sort,333,496,66.93767010
+Bead Sort,333,497,66.24264240
+Bead Sort,333,498,70.89127280
+Bead Sort,333,499,66.62403840
+Bead Sort,333,500,76.25525040
+Bitonic Sort Parallel,333,1,0.00518820
+Bitonic Sort Parallel,333,2,0.00515290
+Bitonic Sort Parallel,333,3,0.00497570
+Bitonic Sort Parallel,333,4,0.00498690
+Bitonic Sort Parallel,333,5,0.00529240
+Bitonic Sort Parallel,333,6,0.00487420
+Bitonic Sort Parallel,333,7,0.00490420
+Bitonic Sort Parallel,333,8,0.00493170
+Bitonic Sort Parallel,333,9,0.00491180
+Bitonic Sort Parallel,333,10,0.00498270
+Bitonic Sort Parallel,333,11,0.00499170
+Bitonic Sort Parallel,333,12,0.00512400
+Bitonic Sort Parallel,333,13,0.00570810
+Bitonic Sort Parallel,333,14,0.00490150
+Bitonic Sort Parallel,333,15,0.00700060
+Bitonic Sort Parallel,333,16,0.00484440
+Bitonic Sort Parallel,333,17,0.00658890
+Bitonic Sort Parallel,333,18,0.00550570
+Bitonic Sort Parallel,333,19,0.00555980
+Bitonic Sort Parallel,333,20,0.00486040
+Bitonic Sort Parallel,333,21,0.00490750
+Bitonic Sort Parallel,333,22,0.00491180
+Bitonic Sort Parallel,333,23,0.00485120
+Bitonic Sort Parallel,333,24,0.00513840
+Bitonic Sort Parallel,333,25,0.00487620
+Bitonic Sort Parallel,333,26,0.00490810
+Bitonic Sort Parallel,333,27,0.00493400
+Bitonic Sort Parallel,333,28,0.00495500
+Bitonic Sort Parallel,333,29,0.00491160
+Bitonic Sort Parallel,333,30,0.00491950
+Bitonic Sort Parallel,333,31,0.00498360
+Bitonic Sort Parallel,333,32,0.00492080
+Bitonic Sort Parallel,333,33,0.00490350
+Bitonic Sort Parallel,333,34,0.00501790
+Bitonic Sort Parallel,333,35,0.00403590
+Bitonic Sort Parallel,333,36,0.00494950
+Bitonic Sort Parallel,333,37,0.00489500
+Bitonic Sort Parallel,333,38,0.00484330
+Bitonic Sort Parallel,333,39,0.00488720
+Bitonic Sort Parallel,333,40,0.00492640
+Bitonic Sort Parallel,333,41,0.00484380
+Bitonic Sort Parallel,333,42,0.00486100
+Bitonic Sort Parallel,333,43,0.00545510
+Bitonic Sort Parallel,333,44,0.00487720
+Bitonic Sort Parallel,333,45,0.00500310
+Bitonic Sort Parallel,333,46,0.00486760
+Bitonic Sort Parallel,333,47,0.00490050
+Bitonic Sort Parallel,333,48,0.00547440
+Bitonic Sort Parallel,333,49,0.00490960
+Bitonic Sort Parallel,333,50,0.00486470
+Bitonic Sort Parallel,333,51,0.00572350
+Bitonic Sort Parallel,333,52,0.00489420
+Bitonic Sort Parallel,333,53,0.00487720
+Bitonic Sort Parallel,333,54,0.00489970
+Bitonic Sort Parallel,333,55,0.00492590
+Bitonic Sort Parallel,333,56,0.00490500
+Bitonic Sort Parallel,333,57,0.00500960
+Bitonic Sort Parallel,333,58,0.00499350
+Bitonic Sort Parallel,333,59,0.00491230
+Bitonic Sort Parallel,333,60,0.00473380
+Bitonic Sort Parallel,333,61,0.00511460
+Bitonic Sort Parallel,333,62,0.00508190
+Bitonic Sort Parallel,333,63,0.00495560
+Bitonic Sort Parallel,333,64,0.00491010
+Bitonic Sort Parallel,333,65,0.00461780
+Bitonic Sort Parallel,333,66,0.00511300
+Bitonic Sort Parallel,333,67,0.00508850
+Bitonic Sort Parallel,333,68,0.00713380
+Bitonic Sort Parallel,333,69,0.00493460
+Bitonic Sort Parallel,333,70,0.00488310
+Bitonic Sort Parallel,333,71,0.00513460
+Bitonic Sort Parallel,333,72,0.00499860
+Bitonic Sort Parallel,333,73,0.00492130
+Bitonic Sort Parallel,333,74,0.00495880
+Bitonic Sort Parallel,333,75,0.00487550
+Bitonic Sort Parallel,333,76,0.00498350
+Bitonic Sort Parallel,333,77,0.00501350
+Bitonic Sort Parallel,333,78,0.00543520
+Bitonic Sort Parallel,333,79,0.00545960
+Bitonic Sort Parallel,333,80,0.00537730
+Bitonic Sort Parallel,333,81,0.00568740
+Bitonic Sort Parallel,333,82,0.00821190
+Bitonic Sort Parallel,333,83,0.00571020
+Bitonic Sort Parallel,333,84,0.00585730
+Bitonic Sort Parallel,333,85,0.00525200
+Bitonic Sort Parallel,333,86,0.00491660
+Bitonic Sort Parallel,333,87,0.00485660
+Bitonic Sort Parallel,333,88,0.00493980
+Bitonic Sort Parallel,333,89,0.00495060
+Bitonic Sort Parallel,333,90,0.00491960
+Bitonic Sort Parallel,333,91,0.00492860
+Bitonic Sort Parallel,333,92,0.00495230
+Bitonic Sort Parallel,333,93,0.00500660
+Bitonic Sort Parallel,333,94,0.00485010
+Bitonic Sort Parallel,333,95,0.00484250
+Bitonic Sort Parallel,333,96,0.00493770
+Bitonic Sort Parallel,333,97,0.00461790
+Bitonic Sort Parallel,333,98,0.00519240
+Bitonic Sort Parallel,333,99,0.00495880
+Bitonic Sort Parallel,333,100,0.00497050
+Bitonic Sort Parallel,333,101,0.00485920
+Bitonic Sort Parallel,333,102,0.00532110
+Bitonic Sort Parallel,333,103,0.00497010
+Bitonic Sort Parallel,333,104,0.00531990
+Bitonic Sort Parallel,333,105,0.00541790
+Bitonic Sort Parallel,333,106,0.00499360
+Bitonic Sort Parallel,333,107,0.00495200
+Bitonic Sort Parallel,333,108,0.00491760
+Bitonic Sort Parallel,333,109,0.00488220
+Bitonic Sort Parallel,333,110,0.00490360
+Bitonic Sort Parallel,333,111,0.00487840
+Bitonic Sort Parallel,333,112,0.00488310
+Bitonic Sort Parallel,333,113,0.00491800
+Bitonic Sort Parallel,333,114,0.00492380
+Bitonic Sort Parallel,333,115,0.00490200
+Bitonic Sort Parallel,333,116,0.00489110
+Bitonic Sort Parallel,333,117,0.00484920
+Bitonic Sort Parallel,333,118,0.00486140
+Bitonic Sort Parallel,333,119,0.00527520
+Bitonic Sort Parallel,333,120,0.00512990
+Bitonic Sort Parallel,333,121,0.00762080
+Bitonic Sort Parallel,333,122,0.00515820
+Bitonic Sort Parallel,333,123,0.00476680
+Bitonic Sort Parallel,333,124,0.00492980
+Bitonic Sort Parallel,333,125,0.00488150
+Bitonic Sort Parallel,333,126,0.00428410
+Bitonic Sort Parallel,333,127,0.00524980
+Bitonic Sort Parallel,333,128,0.00489770
+Bitonic Sort Parallel,333,129,0.00492120
+Bitonic Sort Parallel,333,130,0.00510620
+Bitonic Sort Parallel,333,131,0.00515420
+Bitonic Sort Parallel,333,132,0.00498380
+Bitonic Sort Parallel,333,133,0.00471450
+Bitonic Sort Parallel,333,134,0.00491050
+Bitonic Sort Parallel,333,135,0.00513810
+Bitonic Sort Parallel,333,136,0.00472030
+Bitonic Sort Parallel,333,137,0.00477660
+Bitonic Sort Parallel,333,138,0.00421840
+Bitonic Sort Parallel,333,139,0.00505620
+Bitonic Sort Parallel,333,140,0.00495240
+Bitonic Sort Parallel,333,141,0.00472960
+Bitonic Sort Parallel,333,142,0.00501760
+Bitonic Sort Parallel,333,143,0.00487100
+Bitonic Sort Parallel,333,144,0.00487190
+Bitonic Sort Parallel,333,145,0.00483320
+Bitonic Sort Parallel,333,146,0.00487400
+Bitonic Sort Parallel,333,147,0.00489710
+Bitonic Sort Parallel,333,148,0.00485150
+Bitonic Sort Parallel,333,149,0.00484260
+Bitonic Sort Parallel,333,150,0.00484090
+Bitonic Sort Parallel,333,151,0.00488800
+Bitonic Sort Parallel,333,152,0.00893090
+Bitonic Sort Parallel,333,153,0.00577200
+Bitonic Sort Parallel,333,154,0.00528500
+Bitonic Sort Parallel,333,155,0.00635410
+Bitonic Sort Parallel,333,156,0.00501510
+Bitonic Sort Parallel,333,157,0.00490620
+Bitonic Sort Parallel,333,158,0.00459660
+Bitonic Sort Parallel,333,159,0.00507250
+Bitonic Sort Parallel,333,160,0.00508120
+Bitonic Sort Parallel,333,161,0.00505970
+Bitonic Sort Parallel,333,162,0.00509480
+Bitonic Sort Parallel,333,163,0.00492750
+Bitonic Sort Parallel,333,164,0.00511300
+Bitonic Sort Parallel,333,165,0.00489340
+Bitonic Sort Parallel,333,166,0.00490390
+Bitonic Sort Parallel,333,167,0.00517100
+Bitonic Sort Parallel,333,168,0.00495460
+Bitonic Sort Parallel,333,169,0.00490130
+Bitonic Sort Parallel,333,170,0.00518460
+Bitonic Sort Parallel,333,171,0.00499570
+Bitonic Sort Parallel,333,172,0.00500860
+Bitonic Sort Parallel,333,173,0.00497930
+Bitonic Sort Parallel,333,174,0.00497880
+Bitonic Sort Parallel,333,175,0.00500110
+Bitonic Sort Parallel,333,176,0.00498910
+Bitonic Sort Parallel,333,177,0.00499200
+Bitonic Sort Parallel,333,178,0.00499290
+Bitonic Sort Parallel,333,179,0.00498690
+Bitonic Sort Parallel,333,180,0.00497290
+Bitonic Sort Parallel,333,181,0.00493440
+Bitonic Sort Parallel,333,182,0.00498150
+Bitonic Sort Parallel,333,183,0.00500160
+Bitonic Sort Parallel,333,184,0.00575250
+Bitonic Sort Parallel,333,185,0.00497260
+Bitonic Sort Parallel,333,186,0.00747290
+Bitonic Sort Parallel,333,187,0.00500570
+Bitonic Sort Parallel,333,188,0.00490140
+Bitonic Sort Parallel,333,189,0.00533020
+Bitonic Sort Parallel,333,190,0.00589230
+Bitonic Sort Parallel,333,191,0.00497290
+Bitonic Sort Parallel,333,192,0.00495520
+Bitonic Sort Parallel,333,193,0.00492870
+Bitonic Sort Parallel,333,194,0.00493080
+Bitonic Sort Parallel,333,195,0.00506750
+Bitonic Sort Parallel,333,196,0.00538340
+Bitonic Sort Parallel,333,197,0.00489830
+Bitonic Sort Parallel,333,198,0.00488150
+Bitonic Sort Parallel,333,199,0.00469210
+Bitonic Sort Parallel,333,200,0.00491980
+Bitonic Sort Parallel,333,201,0.00487200
+Bitonic Sort Parallel,333,202,0.00473450
+Bitonic Sort Parallel,333,203,0.00466730
+Bitonic Sort Parallel,333,204,0.00497340
+Bitonic Sort Parallel,333,205,0.00490590
+Bitonic Sort Parallel,333,206,0.00487730
+Bitonic Sort Parallel,333,207,0.00492240
+Bitonic Sort Parallel,333,208,0.00437490
+Bitonic Sort Parallel,333,209,0.00505020
+Bitonic Sort Parallel,333,210,0.00596270
+Bitonic Sort Parallel,333,211,0.00728160
+Bitonic Sort Parallel,333,212,0.00492870
+Bitonic Sort Parallel,333,213,0.00506660
+Bitonic Sort Parallel,333,214,0.00510670
+Bitonic Sort Parallel,333,215,0.00512570
+Bitonic Sort Parallel,333,216,0.00504760
+Bitonic Sort Parallel,333,217,0.00508550
+Bitonic Sort Parallel,333,218,0.00734290
+Bitonic Sort Parallel,333,219,0.00547070
+Bitonic Sort Parallel,333,220,0.00593030
+Bitonic Sort Parallel,333,221,0.00485280
+Bitonic Sort Parallel,333,222,0.00487490
+Bitonic Sort Parallel,333,223,0.00496230
+Bitonic Sort Parallel,333,224,0.00489200
+Bitonic Sort Parallel,333,225,0.00486590
+Bitonic Sort Parallel,333,226,0.00522650
+Bitonic Sort Parallel,333,227,0.00487730
+Bitonic Sort Parallel,333,228,0.00487030
+Bitonic Sort Parallel,333,229,0.00487520
+Bitonic Sort Parallel,333,230,0.00600660
+Bitonic Sort Parallel,333,231,0.00494480
+Bitonic Sort Parallel,333,232,0.00492810
+Bitonic Sort Parallel,333,233,0.00483900
+Bitonic Sort Parallel,333,234,0.00491330
+Bitonic Sort Parallel,333,235,0.00501760
+Bitonic Sort Parallel,333,236,0.00496440
+Bitonic Sort Parallel,333,237,0.00469620
+Bitonic Sort Parallel,333,238,0.00490160
+Bitonic Sort Parallel,333,239,0.00487340
+Bitonic Sort Parallel,333,240,0.00511540
+Bitonic Sort Parallel,333,241,0.00490460
+Bitonic Sort Parallel,333,242,0.00499600
+Bitonic Sort Parallel,333,243,0.00486030
+Bitonic Sort Parallel,333,244,0.00492450
+Bitonic Sort Parallel,333,245,0.00485290
+Bitonic Sort Parallel,333,246,0.00489280
+Bitonic Sort Parallel,333,247,0.00486590
+Bitonic Sort Parallel,333,248,0.00505300
+Bitonic Sort Parallel,333,249,0.00575680
+Bitonic Sort Parallel,333,250,0.00503500
+Bitonic Sort Parallel,333,251,0.00510250
+Bitonic Sort Parallel,333,252,0.00536610
+Bitonic Sort Parallel,333,253,0.00512940
+Bitonic Sort Parallel,333,254,0.00498480
+Bitonic Sort Parallel,333,255,0.00492900
+Bitonic Sort Parallel,333,256,0.00500370
+Bitonic Sort Parallel,333,257,0.00507030
+Bitonic Sort Parallel,333,258,0.00599780
+Bitonic Sort Parallel,333,259,0.00499690
+Bitonic Sort Parallel,333,260,0.00582190
+Bitonic Sort Parallel,333,261,0.00494270
+Bitonic Sort Parallel,333,262,0.00504410
+Bitonic Sort Parallel,333,263,0.00496460
+Bitonic Sort Parallel,333,264,0.00502590
+Bitonic Sort Parallel,333,265,0.00494700
+Bitonic Sort Parallel,333,266,0.00561790
+Bitonic Sort Parallel,333,267,0.00506350
+Bitonic Sort Parallel,333,268,0.00487200
+Bitonic Sort Parallel,333,269,0.00495010
+Bitonic Sort Parallel,333,270,0.00484800
+Bitonic Sort Parallel,333,271,0.00493910
+Bitonic Sort Parallel,333,272,0.00486670
+Bitonic Sort Parallel,333,273,0.00491440
+Bitonic Sort Parallel,333,274,0.00484810
+Bitonic Sort Parallel,333,275,0.00492140
+Bitonic Sort Parallel,333,276,0.00488000
+Bitonic Sort Parallel,333,277,0.00492080
+Bitonic Sort Parallel,333,278,0.00465490
+Bitonic Sort Parallel,333,279,0.00492540
+Bitonic Sort Parallel,333,280,0.00471150
+Bitonic Sort Parallel,333,281,0.00494640
+Bitonic Sort Parallel,333,282,0.00493100
+Bitonic Sort Parallel,333,283,0.00490840
+Bitonic Sort Parallel,333,284,0.00544510
+Bitonic Sort Parallel,333,285,0.00491990
+Bitonic Sort Parallel,333,286,0.00597380
+Bitonic Sort Parallel,333,287,0.00495140
+Bitonic Sort Parallel,333,288,0.00743120
+Bitonic Sort Parallel,333,289,0.00492640
+Bitonic Sort Parallel,333,290,0.00492500
+Bitonic Sort Parallel,333,291,0.00490800
+Bitonic Sort Parallel,333,292,0.00496990
+Bitonic Sort Parallel,333,293,0.00510560
+Bitonic Sort Parallel,333,294,0.00493300
+Bitonic Sort Parallel,333,295,0.00476750
+Bitonic Sort Parallel,333,296,0.00502840
+Bitonic Sort Parallel,333,297,0.00568470
+Bitonic Sort Parallel,333,298,0.00486760
+Bitonic Sort Parallel,333,299,0.00465870
+Bitonic Sort Parallel,333,300,0.00488130
+Bitonic Sort Parallel,333,301,0.00511980
+Bitonic Sort Parallel,333,302,0.00473430
+Bitonic Sort Parallel,333,303,0.00578320
+Bitonic Sort Parallel,333,304,0.00475370
+Bitonic Sort Parallel,333,305,0.00484000
+Bitonic Sort Parallel,333,306,0.00482210
+Bitonic Sort Parallel,333,307,0.00482130
+Bitonic Sort Parallel,333,308,0.00486790
+Bitonic Sort Parallel,333,309,0.00482230
+Bitonic Sort Parallel,333,310,0.00485930
+Bitonic Sort Parallel,333,311,0.00481070
+Bitonic Sort Parallel,333,312,0.00492390
+Bitonic Sort Parallel,333,313,0.00482270
+Bitonic Sort Parallel,333,314,0.00530600
+Bitonic Sort Parallel,333,315,0.00485260
+Bitonic Sort Parallel,333,316,0.01224500
+Bitonic Sort Parallel,333,317,0.00483570
+Bitonic Sort Parallel,333,318,0.00486010
+Bitonic Sort Parallel,333,319,0.00678500
+Bitonic Sort Parallel,333,320,0.00487860
+Bitonic Sort Parallel,333,321,0.00485760
+Bitonic Sort Parallel,333,322,0.00484290
+Bitonic Sort Parallel,333,323,0.00558240
+Bitonic Sort Parallel,333,324,0.00497470
+Bitonic Sort Parallel,333,325,0.00698200
+Bitonic Sort Parallel,333,326,0.00488370
+Bitonic Sort Parallel,333,327,0.00604010
+Bitonic Sort Parallel,333,328,0.00500030
+Bitonic Sort Parallel,333,329,0.00707480
+Bitonic Sort Parallel,333,330,0.00545330
+Bitonic Sort Parallel,333,331,0.00616890
+Bitonic Sort Parallel,333,332,0.00520910
+Bitonic Sort Parallel,333,333,0.00573730
+Bitonic Sort Parallel,333,334,0.00460620
+Bitonic Sort Parallel,333,335,0.00530850
+Bitonic Sort Parallel,333,336,0.00456500
+Bitonic Sort Parallel,333,337,0.00491900
+Bitonic Sort Parallel,333,338,0.00470770
+Bitonic Sort Parallel,333,339,0.00500340
+Bitonic Sort Parallel,333,340,0.00536060
+Bitonic Sort Parallel,333,341,0.00490470
+Bitonic Sort Parallel,333,342,0.00485940
+Bitonic Sort Parallel,333,343,0.00488630
+Bitonic Sort Parallel,333,344,0.00482690
+Bitonic Sort Parallel,333,345,0.00492200
+Bitonic Sort Parallel,333,346,0.00519330
+Bitonic Sort Parallel,333,347,0.00470710
+Bitonic Sort Parallel,333,348,0.00466540
+Bitonic Sort Parallel,333,349,0.00457300
+Bitonic Sort Parallel,333,350,0.00521990
+Bitonic Sort Parallel,333,351,0.00508760
+Bitonic Sort Parallel,333,352,0.00509290
+Bitonic Sort Parallel,333,353,0.00516080
+Bitonic Sort Parallel,333,354,0.00473630
+Bitonic Sort Parallel,333,355,0.00488950
+Bitonic Sort Parallel,333,356,0.00492120
+Bitonic Sort Parallel,333,357,0.00487990
+Bitonic Sort Parallel,333,358,0.00488210
+Bitonic Sort Parallel,333,359,0.00484570
+Bitonic Sort Parallel,333,360,0.00488800
+Bitonic Sort Parallel,333,361,0.00459510
+Bitonic Sort Parallel,333,362,0.00488520
+Bitonic Sort Parallel,333,363,0.00489130
+Bitonic Sort Parallel,333,364,0.00491730
+Bitonic Sort Parallel,333,365,0.00485750
+Bitonic Sort Parallel,333,366,0.00484670
+Bitonic Sort Parallel,333,367,0.00489620
+Bitonic Sort Parallel,333,368,0.00485530
+Bitonic Sort Parallel,333,369,0.00485650
+Bitonic Sort Parallel,333,370,0.00484330
+Bitonic Sort Parallel,333,371,0.00487090
+Bitonic Sort Parallel,333,372,0.00481670
+Bitonic Sort Parallel,333,373,0.00482920
+Bitonic Sort Parallel,333,374,0.00481600
+Bitonic Sort Parallel,333,375,0.00497460
+Bitonic Sort Parallel,333,376,0.00480710
+Bitonic Sort Parallel,333,377,0.00496480
+Bitonic Sort Parallel,333,378,0.00482230
+Bitonic Sort Parallel,333,379,0.00502360
+Bitonic Sort Parallel,333,380,0.01198250
+Bitonic Sort Parallel,333,381,0.01102870
+Bitonic Sort Parallel,333,382,0.00742730
+Bitonic Sort Parallel,333,383,0.00512640
+Bitonic Sort Parallel,333,384,0.00511360
+Bitonic Sort Parallel,333,385,0.00508580
+Bitonic Sort Parallel,333,386,0.00500930
+Bitonic Sort Parallel,333,387,0.00505560
+Bitonic Sort Parallel,333,388,0.00497670
+Bitonic Sort Parallel,333,389,0.00492140
+Bitonic Sort Parallel,333,390,0.00595480
+Bitonic Sort Parallel,333,391,0.00484530
+Bitonic Sort Parallel,333,392,0.00481950
+Bitonic Sort Parallel,333,393,0.00489100
+Bitonic Sort Parallel,333,394,0.00487390
+Bitonic Sort Parallel,333,395,0.00488080
+Bitonic Sort Parallel,333,396,0.00512680
+Bitonic Sort Parallel,333,397,0.00486240
+Bitonic Sort Parallel,333,398,0.00659380
+Bitonic Sort Parallel,333,399,0.00507040
+Bitonic Sort Parallel,333,400,0.00544980
+Bitonic Sort Parallel,333,401,0.00678570
+Bitonic Sort Parallel,333,402,0.00511600
+Bitonic Sort Parallel,333,403,0.00539770
+Bitonic Sort Parallel,333,404,0.00502030
+Bitonic Sort Parallel,333,405,0.00501260
+Bitonic Sort Parallel,333,406,0.00496860
+Bitonic Sort Parallel,333,407,0.00496650
+Bitonic Sort Parallel,333,408,0.00502150
+Bitonic Sort Parallel,333,409,0.00484190
+Bitonic Sort Parallel,333,410,0.00515070
+Bitonic Sort Parallel,333,411,0.00497040
+Bitonic Sort Parallel,333,412,0.00519180
+Bitonic Sort Parallel,333,413,0.00497180
+Bitonic Sort Parallel,333,414,0.00493790
+Bitonic Sort Parallel,333,415,0.00536970
+Bitonic Sort Parallel,333,416,0.00484940
+Bitonic Sort Parallel,333,417,0.00530780
+Bitonic Sort Parallel,333,418,0.00481950
+Bitonic Sort Parallel,333,419,0.00490470
+Bitonic Sort Parallel,333,420,0.00484830
+Bitonic Sort Parallel,333,421,0.00495460
+Bitonic Sort Parallel,333,422,0.00486130
+Bitonic Sort Parallel,333,423,0.00503430
+Bitonic Sort Parallel,333,424,0.00591470
+Bitonic Sort Parallel,333,425,0.00491160
+Bitonic Sort Parallel,333,426,0.00506300
+Bitonic Sort Parallel,333,427,0.00420750
+Bitonic Sort Parallel,333,428,0.00475600
+Bitonic Sort Parallel,333,429,0.00516110
+Bitonic Sort Parallel,333,430,0.00516930
+Bitonic Sort Parallel,333,431,0.00521250
+Bitonic Sort Parallel,333,432,0.00498720
+Bitonic Sort Parallel,333,433,0.00487380
+Bitonic Sort Parallel,333,434,0.00493700
+Bitonic Sort Parallel,333,435,0.00485120
+Bitonic Sort Parallel,333,436,0.00514020
+Bitonic Sort Parallel,333,437,0.00458910
+Bitonic Sort Parallel,333,438,0.00510620
+Bitonic Sort Parallel,333,439,0.00487560
+Bitonic Sort Parallel,333,440,0.00488630
+Bitonic Sort Parallel,333,441,0.00461550
+Bitonic Sort Parallel,333,442,0.00487460
+Bitonic Sort Parallel,333,443,0.00489810
+Bitonic Sort Parallel,333,444,0.00487380
+Bitonic Sort Parallel,333,445,0.00490230
+Bitonic Sort Parallel,333,446,0.00487510
+Bitonic Sort Parallel,333,447,0.00492650
+Bitonic Sort Parallel,333,448,0.00482690
+Bitonic Sort Parallel,333,449,0.00494960
+Bitonic Sort Parallel,333,450,0.00483700
+Bitonic Sort Parallel,333,451,0.00489830
+Bitonic Sort Parallel,333,452,0.00485320
+Bitonic Sort Parallel,333,453,0.00491670
+Bitonic Sort Parallel,333,454,0.00486750
+Bitonic Sort Parallel,333,455,0.00500290
+Bitonic Sort Parallel,333,456,0.00485190
+Bitonic Sort Parallel,333,457,0.00499940
+Bitonic Sort Parallel,333,458,0.00484610
+Bitonic Sort Parallel,333,459,0.00498400
+Bitonic Sort Parallel,333,460,0.00484710
+Bitonic Sort Parallel,333,461,0.00492580
+Bitonic Sort Parallel,333,462,0.00483900
+Bitonic Sort Parallel,333,463,0.00567380
+Bitonic Sort Parallel,333,464,0.00573650
+Bitonic Sort Parallel,333,465,0.00536980
+Bitonic Sort Parallel,333,466,0.00734970
+Bitonic Sort Parallel,333,467,0.00495800
+Bitonic Sort Parallel,333,468,0.00689370
+Bitonic Sort Parallel,333,469,0.00560470
+Bitonic Sort Parallel,333,470,0.00580920
+Bitonic Sort Parallel,333,471,0.00577450
+Bitonic Sort Parallel,333,472,0.00554790
+Bitonic Sort Parallel,333,473,0.00561480
+Bitonic Sort Parallel,333,474,0.00484010
+Bitonic Sort Parallel,333,475,0.00479690
+Bitonic Sort Parallel,333,476,0.00510040
+Bitonic Sort Parallel,333,477,0.00492400
+Bitonic Sort Parallel,333,478,0.00466120
+Bitonic Sort Parallel,333,479,0.00500960
+Bitonic Sort Parallel,333,480,0.00603930
+Bitonic Sort Parallel,333,481,0.00505010
+Bitonic Sort Parallel,333,482,0.00502420
+Bitonic Sort Parallel,333,483,0.00494490
+Bitonic Sort Parallel,333,484,0.00485970
+Bitonic Sort Parallel,333,485,0.00488590
+Bitonic Sort Parallel,333,486,0.00497090
+Bitonic Sort Parallel,333,487,0.00485680
+Bitonic Sort Parallel,333,488,0.00501380
+Bitonic Sort Parallel,333,489,0.00529950
+Bitonic Sort Parallel,333,490,0.00482750
+Bitonic Sort Parallel,333,491,0.00491000
+Bitonic Sort Parallel,333,492,0.00531470
+Bitonic Sort Parallel,333,493,0.00489510
+Bitonic Sort Parallel,333,494,0.00536620
+Bitonic Sort Parallel,333,495,0.00487670
+Bitonic Sort Parallel,333,496,0.00489990
+Bitonic Sort Parallel,333,497,0.00496190
+Bitonic Sort Parallel,333,498,0.00492130
+Bitonic Sort Parallel,333,499,0.00515150
+Bitonic Sort Parallel,333,500,0.00718630
+Block Sort,333,1,0.00090030
+Block Sort,333,2,0.00087100
+Block Sort,333,3,0.00089790
+Block Sort,333,4,0.00086840
+Block Sort,333,5,0.00087020
+Block Sort,333,6,0.00086660
+Block Sort,333,7,0.00086440
+Block Sort,333,8,0.00100260
+Block Sort,333,9,0.00086590
+Block Sort,333,10,0.00088310
+Block Sort,333,11,0.00088420
+Block Sort,333,12,0.00094740
+Block Sort,333,13,0.00085870
+Block Sort,333,14,0.00089080
+Block Sort,333,15,0.00085820
+Block Sort,333,16,0.00084480
+Block Sort,333,17,0.00086510
+Block Sort,333,18,0.00087950
+Block Sort,333,19,0.00086840
+Block Sort,333,20,0.00087640
+Block Sort,333,21,0.00086190
+Block Sort,333,22,0.00086080
+Block Sort,333,23,0.00086010
+Block Sort,333,24,0.00086130
+Block Sort,333,25,0.00086320
+Block Sort,333,26,0.00085780
+Block Sort,333,27,0.00086450
+Block Sort,333,28,0.00086000
+Block Sort,333,29,0.00084580
+Block Sort,333,30,0.00086700
+Block Sort,333,31,0.00085590
+Block Sort,333,32,0.00085760
+Block Sort,333,33,0.00086600
+Block Sort,333,34,0.00082570
+Block Sort,333,35,0.00086480
+Block Sort,333,36,0.00081920
+Block Sort,333,37,0.00086590
+Block Sort,333,38,0.00099820
+Block Sort,333,39,0.00085890
+Block Sort,333,40,0.00093460
+Block Sort,333,41,0.00084390
+Block Sort,333,42,0.00092080
+Block Sort,333,43,0.00098220
+Block Sort,333,44,0.00095260
+Block Sort,333,45,0.00098500
+Block Sort,333,46,0.00089410
+Block Sort,333,47,0.00095060
+Block Sort,333,48,0.00084620
+Block Sort,333,49,0.00094010
+Block Sort,333,50,0.00085480
+Block Sort,333,51,0.00093710
+Block Sort,333,52,0.00085510
+Block Sort,333,53,0.00100550
+Block Sort,333,54,0.00087320
+Block Sort,333,55,0.00084930
+Block Sort,333,56,0.00087920
+Block Sort,333,57,0.00085940
+Block Sort,333,58,0.00086070
+Block Sort,333,59,0.00085620
+Block Sort,333,60,0.00085820
+Block Sort,333,61,0.00084880
+Block Sort,333,62,0.00088350
+Block Sort,333,63,0.00087610
+Block Sort,333,64,0.00084530
+Block Sort,333,65,0.00085450
+Block Sort,333,66,0.00088040
+Block Sort,333,67,0.00084580
+Block Sort,333,68,0.00119270
+Block Sort,333,69,0.00086270
+Block Sort,333,70,0.00118270
+Block Sort,333,71,0.00084020
+Block Sort,333,72,0.00084390
+Block Sort,333,73,0.00112730
+Block Sort,333,74,0.00084510
+Block Sort,333,75,0.00118360
+Block Sort,333,76,0.00084320
+Block Sort,333,77,0.00084860
+Block Sort,333,78,0.00104170
+Block Sort,333,79,0.00086170
+Block Sort,333,80,0.00100780
+Block Sort,333,81,0.00083260
+Block Sort,333,82,0.00094130
+Block Sort,333,83,0.00083630
+Block Sort,333,84,0.00093970
+Block Sort,333,85,0.00084640
+Block Sort,333,86,0.00090430
+Block Sort,333,87,0.00083040
+Block Sort,333,88,0.00086640
+Block Sort,333,89,0.00138520
+Block Sort,333,90,0.00090750
+Block Sort,333,91,0.00120920
+Block Sort,333,92,0.00085230
+Block Sort,333,93,0.00103320
+Block Sort,333,94,0.00083750
+Block Sort,333,95,0.00084020
+Block Sort,333,96,0.00104180
+Block Sort,333,97,0.00082990
+Block Sort,333,98,0.00131560
+Block Sort,333,99,0.00083330
+Block Sort,333,100,0.00106970
+Block Sort,333,101,0.00083060
+Block Sort,333,102,0.00083100
+Block Sort,333,103,0.00099640
+Block Sort,333,104,0.00084780
+Block Sort,333,105,0.00104510
+Block Sort,333,106,0.00084190
+Block Sort,333,107,0.00084420
+Block Sort,333,108,0.00083050
+Block Sort,333,109,0.00084310
+Block Sort,333,110,0.00082400
+Block Sort,333,111,0.00083200
+Block Sort,333,112,0.00084060
+Block Sort,333,113,0.00085500
+Block Sort,333,114,0.00082200
+Block Sort,333,115,0.00082490
+Block Sort,333,116,0.00082760
+Block Sort,333,117,0.00086340
+Block Sort,333,118,0.00081430
+Block Sort,333,119,0.00086600
+Block Sort,333,120,0.00082650
+Block Sort,333,121,0.00087400
+Block Sort,333,122,0.00081930
+Block Sort,333,123,0.00082140
+Block Sort,333,124,0.00086230
+Block Sort,333,125,0.00081930
+Block Sort,333,126,0.00086820
+Block Sort,333,127,0.00084670
+Block Sort,333,128,0.00082690
+Block Sort,333,129,0.00082960
+Block Sort,333,130,0.00088490
+Block Sort,333,131,0.00083740
+Block Sort,333,132,0.00082230
+Block Sort,333,133,0.00083780
+Block Sort,333,134,0.00086960
+Block Sort,333,135,0.00084960
+Block Sort,333,136,0.00083590
+Block Sort,333,137,0.00083910
+Block Sort,333,138,0.00086030
+Block Sort,333,139,0.00085200
+Block Sort,333,140,0.00088040
+Block Sort,333,141,0.00159610
+Block Sort,333,142,0.00091920
+Block Sort,333,143,0.00089080
+Block Sort,333,144,0.00086070
+Block Sort,333,145,0.00088540
+Block Sort,333,146,0.00145620
+Block Sort,333,147,0.00091120
+Block Sort,333,148,0.00164830
+Block Sort,333,149,0.00090580
+Block Sort,333,150,0.00095300
+Block Sort,333,151,0.00093100
+Block Sort,333,152,0.00093270
+Block Sort,333,153,0.00092640
+Block Sort,333,154,0.00103290
+Block Sort,333,155,0.00093030
+Block Sort,333,156,0.00136990
+Block Sort,333,157,0.00095900
+Block Sort,333,158,0.00128030
+Block Sort,333,159,0.00095120
+Block Sort,333,160,0.00109460
+Block Sort,333,161,0.00094170
+Block Sort,333,162,0.00083310
+Block Sort,333,163,0.00141240
+Block Sort,333,164,0.00080370
+Block Sort,333,165,0.00081520
+Block Sort,333,166,0.00097380
+Block Sort,333,167,0.00080880
+Block Sort,333,168,0.00095600
+Block Sort,333,169,0.00082640
+Block Sort,333,170,0.00094830
+Block Sort,333,171,0.00081370
+Block Sort,333,172,0.00134940
+Block Sort,333,173,0.00082200
+Block Sort,333,174,0.00080740
+Block Sort,333,175,0.00102480
+Block Sort,333,176,0.00081530
+Block Sort,333,177,0.00088850
+Block Sort,333,178,0.00083000
+Block Sort,333,179,0.00088760
+Block Sort,333,180,0.00084140
+Block Sort,333,181,0.00089300
+Block Sort,333,182,0.00082810
+Block Sort,333,183,0.00086220
+Block Sort,333,184,0.00081390
+Block Sort,333,185,0.00094920
+Block Sort,333,186,0.00086830
+Block Sort,333,187,0.00086400
+Block Sort,333,188,0.00083950
+Block Sort,333,189,0.00088540
+Block Sort,333,190,0.00083010
+Block Sort,333,191,0.00082650
+Block Sort,333,192,0.00086110
+Block Sort,333,193,0.00079020
+Block Sort,333,194,0.00086390
+Block Sort,333,195,0.00084770
+Block Sort,333,196,0.00085250
+Block Sort,333,197,0.00083550
+Block Sort,333,198,0.00099180
+Block Sort,333,199,0.00083550
+Block Sort,333,200,0.00088450
+Block Sort,333,201,0.00089740
+Block Sort,333,202,0.00090270
+Block Sort,333,203,0.00084330
+Block Sort,333,204,0.00093630
+Block Sort,333,205,0.00085720
+Block Sort,333,206,0.00091490
+Block Sort,333,207,0.00084670
+Block Sort,333,208,0.00093640
+Block Sort,333,209,0.00090230
+Block Sort,333,210,0.00116550
+Block Sort,333,211,0.00088840
+Block Sort,333,212,0.00088770
+Block Sort,333,213,0.00104180
+Block Sort,333,214,0.00089390
+Block Sort,333,215,0.00197350
+Block Sort,333,216,0.00091800
+Block Sort,333,217,0.00088180
+Block Sort,333,218,0.00109810
+Block Sort,333,219,0.00085310
+Block Sort,333,220,0.00113190
+Block Sort,333,221,0.00082760
+Block Sort,333,222,0.00083870
+Block Sort,333,223,0.00088770
+Block Sort,333,224,0.00084320
+Block Sort,333,225,0.00103630
+Block Sort,333,226,0.00085140
+Block Sort,333,227,0.00117740
+Block Sort,333,228,0.00085150
+Block Sort,333,229,0.00096370
+Block Sort,333,230,0.00082760
+Block Sort,333,231,0.00088220
+Block Sort,333,232,0.00098150
+Block Sort,333,233,0.00103520
+Block Sort,333,234,0.00103980
+Block Sort,333,235,0.00091500
+Block Sort,333,236,0.00112260
+Block Sort,333,237,0.00084900
+Block Sort,333,238,0.00101510
+Block Sort,333,239,0.00085880
+Block Sort,333,240,0.00098530
+Block Sort,333,241,0.00134330
+Block Sort,333,242,0.00096000
+Block Sort,333,243,0.00106230
+Block Sort,333,244,0.00095520
+Block Sort,333,245,0.00100720
+Block Sort,333,246,0.00091430
+Block Sort,333,247,0.00103710
+Block Sort,333,248,0.00087510
+Block Sort,333,249,0.00084010
+Block Sort,333,250,0.00093970
+Block Sort,333,251,0.00086360
+Block Sort,333,252,0.00099800
+Block Sort,333,253,0.00085060
+Block Sort,333,254,0.00093080
+Block Sort,333,255,0.00086680
+Block Sort,333,256,0.00110990
+Block Sort,333,257,0.00085230
+Block Sort,333,258,0.00082360
+Block Sort,333,259,0.00091700
+Block Sort,333,260,0.00080940
+Block Sort,333,261,0.00081850
+Block Sort,333,262,0.00083380
+Block Sort,333,263,0.00102100
+Block Sort,333,264,0.00081150
+Block Sort,333,265,0.00083160
+Block Sort,333,266,0.00108550
+Block Sort,333,267,0.00082350
+Block Sort,333,268,0.00084770
+Block Sort,333,269,0.00082150
+Block Sort,333,270,0.00083880
+Block Sort,333,271,0.00081060
+Block Sort,333,272,0.00084210
+Block Sort,333,273,0.00082620
+Block Sort,333,274,0.00099300
+Block Sort,333,275,0.00078950
+Block Sort,333,276,0.00085790
+Block Sort,333,277,0.00081910
+Block Sort,333,278,0.00082980
+Block Sort,333,279,0.00083250
+Block Sort,333,280,0.00081640
+Block Sort,333,281,0.00086010
+Block Sort,333,282,0.00095270
+Block Sort,333,283,0.00089690
+Block Sort,333,284,0.00083050
+Block Sort,333,285,0.00095860
+Block Sort,333,286,0.00083470
+Block Sort,333,287,0.00093320
+Block Sort,333,288,0.00082540
+Block Sort,333,289,0.00095880
+Block Sort,333,290,0.00080800
+Block Sort,333,291,0.00095320
+Block Sort,333,292,0.00081710
+Block Sort,333,293,0.00095540
+Block Sort,333,294,0.00081890
+Block Sort,333,295,0.00093760
+Block Sort,333,296,0.00083160
+Block Sort,333,297,0.00081780
+Block Sort,333,298,0.00096310
+Block Sort,333,299,0.00081180
+Block Sort,333,300,0.00096000
+Block Sort,333,301,0.00079280
+Block Sort,333,302,0.00094100
+Block Sort,333,303,0.00079620
+Block Sort,333,304,0.00095020
+Block Sort,333,305,0.00082070
+Block Sort,333,306,0.00092250
+Block Sort,333,307,0.00081310
+Block Sort,333,308,0.00098080
+Block Sort,333,309,0.00080270
+Block Sort,333,310,0.00082970
+Block Sort,333,311,0.00084770
+Block Sort,333,312,0.00081970
+Block Sort,333,313,0.00084470
+Block Sort,333,314,0.00081590
+Block Sort,333,315,0.00083320
+Block Sort,333,316,0.00081990
+Block Sort,333,317,0.00084400
+Block Sort,333,318,0.00082110
+Block Sort,333,319,0.00081610
+Block Sort,333,320,0.00084520
+Block Sort,333,321,0.00083100
+Block Sort,333,322,0.00085350
+Block Sort,333,323,0.00085190
+Block Sort,333,324,0.00083740
+Block Sort,333,325,0.00087080
+Block Sort,333,326,0.00085040
+Block Sort,333,327,0.00087980
+Block Sort,333,328,0.00085140
+Block Sort,333,329,0.00083250
+Block Sort,333,330,0.00086040
+Block Sort,333,331,0.00086010
+Block Sort,333,332,0.00084980
+Block Sort,333,333,0.00086470
+Block Sort,333,334,0.00082820
+Block Sort,333,335,0.00109290
+Block Sort,333,336,0.00084730
+Block Sort,333,337,0.00091390
+Block Sort,333,338,0.00084690
+Block Sort,333,339,0.00091480
+Block Sort,333,340,0.00083890
+Block Sort,333,341,0.00085860
+Block Sort,333,342,0.00084210
+Block Sort,333,343,0.00096820
+Block Sort,333,344,0.00085040
+Block Sort,333,345,0.00094380
+Block Sort,333,346,0.00085170
+Block Sort,333,347,0.00084300
+Block Sort,333,348,0.00094880
+Block Sort,333,349,0.00085940
+Block Sort,333,350,0.00089380
+Block Sort,333,351,0.00085690
+Block Sort,333,352,0.00084990
+Block Sort,333,353,0.00085140
+Block Sort,333,354,0.00092060
+Block Sort,333,355,0.00086830
+Block Sort,333,356,0.00097440
+Block Sort,333,357,0.00085600
+Block Sort,333,358,0.00093070
+Block Sort,333,359,0.00087580
+Block Sort,333,360,0.00111670
+Block Sort,333,361,0.00083920
+Block Sort,333,362,0.00087350
+Block Sort,333,363,0.00083450
+Block Sort,333,364,0.00080770
+Block Sort,333,365,0.00116190
+Block Sort,333,366,0.00083240
+Block Sort,333,367,0.00108170
+Block Sort,333,368,0.00083880
+Block Sort,333,369,0.00082820
+Block Sort,333,370,0.00111440
+Block Sort,333,371,0.00082800
+Block Sort,333,372,0.00092000
+Block Sort,333,373,0.00082840
+Block Sort,333,374,0.00187130
+Block Sort,333,375,0.00085790
+Block Sort,333,376,0.00085030
+Block Sort,333,377,0.00115620
+Block Sort,333,378,0.00083330
+Block Sort,333,379,0.00083210
+Block Sort,333,380,0.00085190
+Block Sort,333,381,0.00084930
+Block Sort,333,382,0.00087950
+Block Sort,333,383,0.00086670
+Block Sort,333,384,0.00194490
+Block Sort,333,385,0.00085800
+Block Sort,333,386,0.00084070
+Block Sort,333,387,0.00186220
+Block Sort,333,388,0.00086270
+Block Sort,333,389,0.00085140
+Block Sort,333,390,0.00106590
+Block Sort,333,391,0.00085070
+Block Sort,333,392,0.00085620
+Block Sort,333,393,0.00127510
+Block Sort,333,394,0.00084080
+Block Sort,333,395,0.00187110
+Block Sort,333,396,0.00084550
+Block Sort,333,397,0.00083560
+Block Sort,333,398,0.00091820
+Block Sort,333,399,0.00085780
+Block Sort,333,400,0.00091140
+Block Sort,333,401,0.00084960
+Block Sort,333,402,0.00112530
+Block Sort,333,403,0.00084860
+Block Sort,333,404,0.00084390
+Block Sort,333,405,0.00087510
+Block Sort,333,406,0.00099410
+Block Sort,333,407,0.00087690
+Block Sort,333,408,0.00095990
+Block Sort,333,409,0.00086880
+Block Sort,333,410,0.00102240
+Block Sort,333,411,0.00085400
+Block Sort,333,412,0.00085760
+Block Sort,333,413,0.00096010
+Block Sort,333,414,0.00113990
+Block Sort,333,415,0.00103030
+Block Sort,333,416,0.00096470
+Block Sort,333,417,0.00106860
+Block Sort,333,418,0.00095020
+Block Sort,333,419,0.00104970
+Block Sort,333,420,0.00095200
+Block Sort,333,421,0.00107350
+Block Sort,333,422,0.00102810
+Block Sort,333,423,0.00101790
+Block Sort,333,424,0.00094760
+Block Sort,333,425,0.00153130
+Block Sort,333,426,0.00094100
+Block Sort,333,427,0.00101780
+Block Sort,333,428,0.00229410
+Block Sort,333,429,0.00169980
+Block Sort,333,430,0.00119020
+Block Sort,333,431,0.00151450
+Block Sort,333,432,0.00166810
+Block Sort,333,433,0.00153230
+Block Sort,333,434,0.00175820
+Block Sort,333,435,0.00153780
+Block Sort,333,436,0.00092070
+Block Sort,333,437,0.00098310
+Block Sort,333,438,0.00142520
+Block Sort,333,439,0.00094740
+Block Sort,333,440,0.00094140
+Block Sort,333,441,0.00148720
+Block Sort,333,442,0.00095790
+Block Sort,333,443,0.00095010
+Block Sort,333,444,0.00082860
+Block Sort,333,445,0.00082470
+Block Sort,333,446,0.00107290
+Block Sort,333,447,0.00082990
+Block Sort,333,448,0.00097550
+Block Sort,333,449,0.00084560
+Block Sort,333,450,0.00095660
+Block Sort,333,451,0.00086420
+Block Sort,333,452,0.00151490
+Block Sort,333,453,0.00212400
+Block Sort,333,454,0.00101220
+Block Sort,333,455,0.00130090
+Block Sort,333,456,0.00085070
+Block Sort,333,457,0.00102890
+Block Sort,333,458,0.00124250
+Block Sort,333,459,0.00121280
+Block Sort,333,460,0.00167200
+Block Sort,333,461,0.00099000
+Block Sort,333,462,0.00101470
+Block Sort,333,463,0.00177530
+Block Sort,333,464,0.00094830
+Block Sort,333,465,0.00109550
+Block Sort,333,466,0.00102600
+Block Sort,333,467,0.00085840
+Block Sort,333,468,0.00095080
+Block Sort,333,469,0.00088830
+Block Sort,333,470,0.00092230
+Block Sort,333,471,0.00086300
+Block Sort,333,472,0.00093180
+Block Sort,333,473,0.00089000
+Block Sort,333,474,0.00114830
+Block Sort,333,475,0.00085800
+Block Sort,333,476,0.00086680
+Block Sort,333,477,0.00102930
+Block Sort,333,478,0.00086210
+Block Sort,333,479,0.00089760
+Block Sort,333,480,0.00086790
+Block Sort,333,481,0.00108080
+Block Sort,333,482,0.00089760
+Block Sort,333,483,0.00092860
+Block Sort,333,484,0.00089720
+Block Sort,333,485,0.00099900
+Block Sort,333,486,0.00089510
+Block Sort,333,487,0.00094440
+Block Sort,333,488,0.00088140
+Block Sort,333,489,0.00088800
+Block Sort,333,490,0.00120070
+Block Sort,333,491,0.00088220
+Block Sort,333,492,0.00105520
+Block Sort,333,493,0.00091010
+Block Sort,333,494,0.00110670
+Block Sort,333,495,0.00090520
+Block Sort,333,496,0.00109390
+Block Sort,333,497,0.00087070
+Block Sort,333,498,0.00090690
+Block Sort,333,499,0.00085530
+Block Sort,333,500,0.00099770
+Bubble Sort,333,1,0.00594620
+Bubble Sort,333,2,0.00648270
+Bubble Sort,333,3,0.00633960
+Bubble Sort,333,4,0.00678020
+Bubble Sort,333,5,0.00599700
+Bubble Sort,333,6,0.00656880
+Bubble Sort,333,7,0.00639070
+Bubble Sort,333,8,0.00693210
+Bubble Sort,333,9,0.00683050
+Bubble Sort,333,10,0.00608620
+Bubble Sort,333,11,0.00610480
+Bubble Sort,333,12,0.00889210
+Bubble Sort,333,13,0.00683680
+Bubble Sort,333,14,0.01055130
+Bubble Sort,333,15,0.00673160
+Bubble Sort,333,16,0.00658400
+Bubble Sort,333,17,0.01015150
+Bubble Sort,333,18,0.00588960
+Bubble Sort,333,19,0.00574430
+Bubble Sort,333,20,0.00958170
+Bubble Sort,333,21,0.00610320
+Bubble Sort,333,22,0.00585480
+Bubble Sort,333,23,0.00651200
+Bubble Sort,333,24,0.00641370
+Bubble Sort,333,25,0.00605330
+Bubble Sort,333,26,0.01334260
+Bubble Sort,333,27,0.00582610
+Bubble Sort,333,28,0.00590630
+Bubble Sort,333,29,0.00584090
+Bubble Sort,333,30,0.01072990
+Bubble Sort,333,31,0.00609840
+Bubble Sort,333,32,0.01240800
+Bubble Sort,333,33,0.00623090
+Bubble Sort,333,34,0.00611010
+Bubble Sort,333,35,0.00614360
+Bubble Sort,333,36,0.00607530
+Bubble Sort,333,37,0.00589840
+Bubble Sort,333,38,0.00594870
+Bubble Sort,333,39,0.00584510
+Bubble Sort,333,40,0.00900070
+Bubble Sort,333,41,0.00598690
+Bubble Sort,333,42,0.00781880
+Bubble Sort,333,43,0.00612060
+Bubble Sort,333,44,0.00611620
+Bubble Sort,333,45,0.00585990
+Bubble Sort,333,46,0.00646880
+Bubble Sort,333,47,0.00604970
+Bubble Sort,333,48,0.00609280
+Bubble Sort,333,49,0.00663410
+Bubble Sort,333,50,0.00640490
+Bubble Sort,333,51,0.00660840
+Bubble Sort,333,52,0.00608640
+Bubble Sort,333,53,0.00636780
+Bubble Sort,333,54,0.00690020
+Bubble Sort,333,55,0.00621160
+Bubble Sort,333,56,0.00623840
+Bubble Sort,333,57,0.00611330
+Bubble Sort,333,58,0.00599610
+Bubble Sort,333,59,0.00669340
+Bubble Sort,333,60,0.00600340
+Bubble Sort,333,61,0.00643910
+Bubble Sort,333,62,0.00639230
+Bubble Sort,333,63,0.00604100
+Bubble Sort,333,64,0.00621330
+Bubble Sort,333,65,0.00596730
+Bubble Sort,333,66,0.00592800
+Bubble Sort,333,67,0.00605810
+Bubble Sort,333,68,0.00602450
+Bubble Sort,333,69,0.00591650
+Bubble Sort,333,70,0.00603340
+Bubble Sort,333,71,0.00596450
+Bubble Sort,333,72,0.00603570
+Bubble Sort,333,73,0.00613170
+Bubble Sort,333,74,0.00608110
+Bubble Sort,333,75,0.00607970
+Bubble Sort,333,76,0.00664080
+Bubble Sort,333,77,0.00519060
+Bubble Sort,333,78,0.00597110
+Bubble Sort,333,79,0.00606940
+Bubble Sort,333,80,0.00602070
+Bubble Sort,333,81,0.00625080
+Bubble Sort,333,82,0.00601920
+Bubble Sort,333,83,0.00609990
+Bubble Sort,333,84,0.00593640
+Bubble Sort,333,85,0.00613040
+Bubble Sort,333,86,0.00597010
+Bubble Sort,333,87,0.00617590
+Bubble Sort,333,88,0.00588760
+Bubble Sort,333,89,0.00607960
+Bubble Sort,333,90,0.00587770
+Bubble Sort,333,91,0.00624430
+Bubble Sort,333,92,0.00586750
+Bubble Sort,333,93,0.00976500
+Bubble Sort,333,94,0.00606930
+Bubble Sort,333,95,0.00678980
+Bubble Sort,333,96,0.00595710
+Bubble Sort,333,97,0.00826810
+Bubble Sort,333,98,0.00650930
+Bubble Sort,333,99,0.00734740
+Bubble Sort,333,100,0.00613640
+Bubble Sort,333,101,0.00648500
+Bubble Sort,333,102,0.00564900
+Bubble Sort,333,103,0.00618770
+Bubble Sort,333,104,0.00582240
+Bubble Sort,333,105,0.00609880
+Bubble Sort,333,106,0.00616110
+Bubble Sort,333,107,0.00656780
+Bubble Sort,333,108,0.00615350
+Bubble Sort,333,109,0.00592180
+Bubble Sort,333,110,0.00599920
+Bubble Sort,333,111,0.00669470
+Bubble Sort,333,112,0.00593800
+Bubble Sort,333,113,0.00596790
+Bubble Sort,333,114,0.00597460
+Bubble Sort,333,115,0.00589920
+Bubble Sort,333,116,0.00573940
+Bubble Sort,333,117,0.00600790
+Bubble Sort,333,118,0.00614310
+Bubble Sort,333,119,0.00629820
+Bubble Sort,333,120,0.00611260
+Bubble Sort,333,121,0.00610970
+Bubble Sort,333,122,0.00648880
+Bubble Sort,333,123,0.00573880
+Bubble Sort,333,124,0.00594330
+Bubble Sort,333,125,0.00616770
+Bubble Sort,333,126,0.00588240
+Bubble Sort,333,127,0.00615370
+Bubble Sort,333,128,0.00593370
+Bubble Sort,333,129,0.00603020
+Bubble Sort,333,130,0.00624500
+Bubble Sort,333,131,0.00642030
+Bubble Sort,333,132,0.00582800
+Bubble Sort,333,133,0.00606710
+Bubble Sort,333,134,0.00616420
+Bubble Sort,333,135,0.00604860
+Bubble Sort,333,136,0.00606920
+Bubble Sort,333,137,0.00598710
+Bubble Sort,333,138,0.00589750
+Bubble Sort,333,139,0.00621260
+Bubble Sort,333,140,0.00612470
+Bubble Sort,333,141,0.00591890
+Bubble Sort,333,142,0.00586610
+Bubble Sort,333,143,0.00615550
+Bubble Sort,333,144,0.00590370
+Bubble Sort,333,145,0.00577010
+Bubble Sort,333,146,0.00624510
+Bubble Sort,333,147,0.00588280
+Bubble Sort,333,148,0.00624520
+Bubble Sort,333,149,0.00827960
+Bubble Sort,333,150,0.00608710
+Bubble Sort,333,151,0.00593820
+Bubble Sort,333,152,0.00619410
+Bubble Sort,333,153,0.00735730
+Bubble Sort,333,154,0.00607170
+Bubble Sort,333,155,0.00744520
+Bubble Sort,333,156,0.00600590
+Bubble Sort,333,157,0.00607080
+Bubble Sort,333,158,0.00697870
+Bubble Sort,333,159,0.00610840
+Bubble Sort,333,160,0.00589230
+Bubble Sort,333,161,0.00597040
+Bubble Sort,333,162,0.00617980
+Bubble Sort,333,163,0.00609770
+Bubble Sort,333,164,0.00629560
+Bubble Sort,333,165,0.00561510
+Bubble Sort,333,166,0.00615200
+Bubble Sort,333,167,0.00609520
+Bubble Sort,333,168,0.00604770
+Bubble Sort,333,169,0.00596790
+Bubble Sort,333,170,0.00606200
+Bubble Sort,333,171,0.00618340
+Bubble Sort,333,172,0.00607900
+Bubble Sort,333,173,0.00625210
+Bubble Sort,333,174,0.00624930
+Bubble Sort,333,175,0.00613410
+Bubble Sort,333,176,0.00643430
+Bubble Sort,333,177,0.00608030
+Bubble Sort,333,178,0.00613810
+Bubble Sort,333,179,0.00681620
+Bubble Sort,333,180,0.00612610
+Bubble Sort,333,181,0.00621390
+Bubble Sort,333,182,0.00595370
+Bubble Sort,333,183,0.00629190
+Bubble Sort,333,184,0.00592250
+Bubble Sort,333,185,0.00617480
+Bubble Sort,333,186,0.00590500
+Bubble Sort,333,187,0.00624680
+Bubble Sort,333,188,0.00608620
+Bubble Sort,333,189,0.00590540
+Bubble Sort,333,190,0.00634430
+Bubble Sort,333,191,0.00614600
+Bubble Sort,333,192,0.00644540
+Bubble Sort,333,193,0.00616210
+Bubble Sort,333,194,0.00605520
+Bubble Sort,333,195,0.00685450
+Bubble Sort,333,196,0.00622920
+Bubble Sort,333,197,0.00657480
+Bubble Sort,333,198,0.00601100
+Bubble Sort,333,199,0.00625630
+Bubble Sort,333,200,0.00592430
+Bubble Sort,333,201,0.00629310
+Bubble Sort,333,202,0.00586840
+Bubble Sort,333,203,0.00599300
+Bubble Sort,333,204,0.00636300
+Bubble Sort,333,205,0.00700660
+Bubble Sort,333,206,0.00623650
+Bubble Sort,333,207,0.00608420
+Bubble Sort,333,208,0.00612650
+Bubble Sort,333,209,0.00606260
+Bubble Sort,333,210,0.00748980
+Bubble Sort,333,211,0.00649980
+Bubble Sort,333,212,0.00762330
+Bubble Sort,333,213,0.00606370
+Bubble Sort,333,214,0.00669270
+Bubble Sort,333,215,0.00721400
+Bubble Sort,333,216,0.00623480
+Bubble Sort,333,217,0.00605380
+Bubble Sort,333,218,0.00601480
+Bubble Sort,333,219,0.00628230
+Bubble Sort,333,220,0.00595410
+Bubble Sort,333,221,0.00610360
+Bubble Sort,333,222,0.00588960
+Bubble Sort,333,223,0.00601440
+Bubble Sort,333,224,0.00618720
+Bubble Sort,333,225,0.00635310
+Bubble Sort,333,226,0.00604910
+Bubble Sort,333,227,0.00606740
+Bubble Sort,333,228,0.00571330
+Bubble Sort,333,229,0.00616900
+Bubble Sort,333,230,0.00592960
+Bubble Sort,333,231,0.00620660
+Bubble Sort,333,232,0.00752240
+Bubble Sort,333,233,0.00617310
+Bubble Sort,333,234,0.00629420
+Bubble Sort,333,235,0.00621110
+Bubble Sort,333,236,0.00617770
+Bubble Sort,333,237,0.00599180
+Bubble Sort,333,238,0.00630560
+Bubble Sort,333,239,0.00598340
+Bubble Sort,333,240,0.00586250
+Bubble Sort,333,241,0.00611270
+Bubble Sort,333,242,0.00595510
+Bubble Sort,333,243,0.00597880
+Bubble Sort,333,244,0.00600810
+Bubble Sort,333,245,0.00621260
+Bubble Sort,333,246,0.00608370
+Bubble Sort,333,247,0.00605720
+Bubble Sort,333,248,0.00582720
+Bubble Sort,333,249,0.00623580
+Bubble Sort,333,250,0.00759840
+Bubble Sort,333,251,0.00608480
+Bubble Sort,333,252,0.00605690
+Bubble Sort,333,253,0.00613040
+Bubble Sort,333,254,0.00602330
+Bubble Sort,333,255,0.00615870
+Bubble Sort,333,256,0.00625510
+Bubble Sort,333,257,0.00602930
+Bubble Sort,333,258,0.00627870
+Bubble Sort,333,259,0.00629620
+Bubble Sort,333,260,0.00690250
+Bubble Sort,333,261,0.00610650
+Bubble Sort,333,262,0.00799150
+Bubble Sort,333,263,0.00604430
+Bubble Sort,333,264,0.00594870
+Bubble Sort,333,265,0.00837810
+Bubble Sort,333,266,0.00590160
+Bubble Sort,333,267,0.00631780
+Bubble Sort,333,268,0.00603270
+Bubble Sort,333,269,0.00592200
+Bubble Sort,333,270,0.00618800
+Bubble Sort,333,271,0.00603910
+Bubble Sort,333,272,0.00643270
+Bubble Sort,333,273,0.00592960
+Bubble Sort,333,274,0.00609690
+Bubble Sort,333,275,0.00593240
+Bubble Sort,333,276,0.00615260
+Bubble Sort,333,277,0.00623690
+Bubble Sort,333,278,0.00599520
+Bubble Sort,333,279,0.00611730
+Bubble Sort,333,280,0.00622530
+Bubble Sort,333,281,0.00610520
+Bubble Sort,333,282,0.00597130
+Bubble Sort,333,283,0.00609040
+Bubble Sort,333,284,0.00593050
+Bubble Sort,333,285,0.00594770
+Bubble Sort,333,286,0.00599490
+Bubble Sort,333,287,0.00621220
+Bubble Sort,333,288,0.00600870
+Bubble Sort,333,289,0.00578890
+Bubble Sort,333,290,0.00619850
+Bubble Sort,333,291,0.00621330
+Bubble Sort,333,292,0.00613160
+Bubble Sort,333,293,0.00581890
+Bubble Sort,333,294,0.00580840
+Bubble Sort,333,295,0.00588440
+Bubble Sort,333,296,0.00652580
+Bubble Sort,333,297,0.00624230
+Bubble Sort,333,298,0.00591250
+Bubble Sort,333,299,0.00628870
+Bubble Sort,333,300,0.00632140
+Bubble Sort,333,301,0.00654580
+Bubble Sort,333,302,0.00578110
+Bubble Sort,333,303,0.00615080
+Bubble Sort,333,304,0.00572320
+Bubble Sort,333,305,0.00722790
+Bubble Sort,333,306,0.00653610
+Bubble Sort,333,307,0.00648820
+Bubble Sort,333,308,0.00624350
+Bubble Sort,333,309,0.00621100
+Bubble Sort,333,310,0.00665580
+Bubble Sort,333,311,0.00616580
+Bubble Sort,333,312,0.00597740
+Bubble Sort,333,313,0.00592960
+Bubble Sort,333,314,0.00637190
+Bubble Sort,333,315,0.00592990
+Bubble Sort,333,316,0.00610000
+Bubble Sort,333,317,0.00599580
+Bubble Sort,333,318,0.00605710
+Bubble Sort,333,319,0.00693810
+Bubble Sort,333,320,0.00596170
+Bubble Sort,333,321,0.00591120
+Bubble Sort,333,322,0.00603460
+Bubble Sort,333,323,0.00631180
+Bubble Sort,333,324,0.00588690
+Bubble Sort,333,325,0.00947920
+Bubble Sort,333,326,0.00598730
+Bubble Sort,333,327,0.00599700
+Bubble Sort,333,328,0.00643540
+Bubble Sort,333,329,0.00609760
+Bubble Sort,333,330,0.00616890
+Bubble Sort,333,331,0.00603820
+Bubble Sort,333,332,0.00572820
+Bubble Sort,333,333,0.00618590
+Bubble Sort,333,334,0.00622010
+Bubble Sort,333,335,0.00589150
+Bubble Sort,333,336,0.00599720
+Bubble Sort,333,337,0.00600780
+Bubble Sort,333,338,0.00586770
+Bubble Sort,333,339,0.00609380
+Bubble Sort,333,340,0.00592480
+Bubble Sort,333,341,0.00621690
+Bubble Sort,333,342,0.00604860
+Bubble Sort,333,343,0.00643680
+Bubble Sort,333,344,0.00616350
+Bubble Sort,333,345,0.00605260
+Bubble Sort,333,346,0.00584150
+Bubble Sort,333,347,0.00591230
+Bubble Sort,333,348,0.00636240
+Bubble Sort,333,349,0.00607330
+Bubble Sort,333,350,0.00612890
+Bubble Sort,333,351,0.00586560
+Bubble Sort,333,352,0.00610740
+Bubble Sort,333,353,0.00613470
+Bubble Sort,333,354,0.00592810
+Bubble Sort,333,355,0.00611280
+Bubble Sort,333,356,0.00601960
+Bubble Sort,333,357,0.00629890
+Bubble Sort,333,358,0.00653610
+Bubble Sort,333,359,0.00615050
+Bubble Sort,333,360,0.00601250
+Bubble Sort,333,361,0.00594650
+Bubble Sort,333,362,0.00706700
+Bubble Sort,333,363,0.00619880
+Bubble Sort,333,364,0.00701900
+Bubble Sort,333,365,0.00711690
+Bubble Sort,333,366,0.00659230
+Bubble Sort,333,367,0.00699180
+Bubble Sort,333,368,0.00624900
+Bubble Sort,333,369,0.00730040
+Bubble Sort,333,370,0.00637460
+Bubble Sort,333,371,0.00623730
+Bubble Sort,333,372,0.00628170
+Bubble Sort,333,373,0.00604720
+Bubble Sort,333,374,0.00733870
+Bubble Sort,333,375,0.00629640
+Bubble Sort,333,376,0.00749270
+Bubble Sort,333,377,0.00591150
+Bubble Sort,333,378,0.00972850
+Bubble Sort,333,379,0.00595000
+Bubble Sort,333,380,0.00624790
+Bubble Sort,333,381,0.00668120
+Bubble Sort,333,382,0.00619190
+Bubble Sort,333,383,0.00633660
+Bubble Sort,333,384,0.00600170
+Bubble Sort,333,385,0.00568510
+Bubble Sort,333,386,0.00553520
+Bubble Sort,333,387,0.00584510
+Bubble Sort,333,388,0.00639380
+Bubble Sort,333,389,0.00638870
+Bubble Sort,333,390,0.00602980
+Bubble Sort,333,391,0.00622250
+Bubble Sort,333,392,0.00612230
+Bubble Sort,333,393,0.00665130
+Bubble Sort,333,394,0.00817700
+Bubble Sort,333,395,0.00640490
+Bubble Sort,333,396,0.00674580
+Bubble Sort,333,397,0.00615430
+Bubble Sort,333,398,0.00597370
+Bubble Sort,333,399,0.00644630
+Bubble Sort,333,400,0.00621470
+Bubble Sort,333,401,0.00615460
+Bubble Sort,333,402,0.00614560
+Bubble Sort,333,403,0.00603070
+Bubble Sort,333,404,0.00574260
+Bubble Sort,333,405,0.00601110
+Bubble Sort,333,406,0.00550260
+Bubble Sort,333,407,0.00623710
+Bubble Sort,333,408,0.00566150
+Bubble Sort,333,409,0.00611590
+Bubble Sort,333,410,0.00647180
+Bubble Sort,333,411,0.00601060
+Bubble Sort,333,412,0.00630670
+Bubble Sort,333,413,0.00604310
+Bubble Sort,333,414,0.00578370
+Bubble Sort,333,415,0.00598500
+Bubble Sort,333,416,0.00616840
+Bubble Sort,333,417,0.00585090
+Bubble Sort,333,418,0.00718480
+Bubble Sort,333,419,0.00599150
+Bubble Sort,333,420,0.00672450
+Bubble Sort,333,421,0.00610650
+Bubble Sort,333,422,0.00598870
+Bubble Sort,333,423,0.00612130
+Bubble Sort,333,424,0.00604430
+Bubble Sort,333,425,0.00581200
+Bubble Sort,333,426,0.00614510
+Bubble Sort,333,427,0.00580920
+Bubble Sort,333,428,0.00604670
+Bubble Sort,333,429,0.00598860
+Bubble Sort,333,430,0.00628090
+Bubble Sort,333,431,0.00596990
+Bubble Sort,333,432,0.00601860
+Bubble Sort,333,433,0.00610580
+Bubble Sort,333,434,0.00603730
+Bubble Sort,333,435,0.00602940
+Bubble Sort,333,436,0.00588080
+Bubble Sort,333,437,0.00613630
+Bubble Sort,333,438,0.00838110
+Bubble Sort,333,439,0.00617980
+Bubble Sort,333,440,0.00612400
+Bubble Sort,333,441,0.00597230
+Bubble Sort,333,442,0.00609020
+Bubble Sort,333,443,0.00640720
+Bubble Sort,333,444,0.00604740
+Bubble Sort,333,445,0.00756470
+Bubble Sort,333,446,0.00597950
+Bubble Sort,333,447,0.00610420
+Bubble Sort,333,448,0.00609460
+Bubble Sort,333,449,0.00607800
+Bubble Sort,333,450,0.00578450
+Bubble Sort,333,451,0.00805310
+Bubble Sort,333,452,0.00609360
+Bubble Sort,333,453,0.00746880
+Bubble Sort,333,454,0.00599180
+Bubble Sort,333,455,0.00593050
+Bubble Sort,333,456,0.00625650
+Bubble Sort,333,457,0.00607780
+Bubble Sort,333,458,0.00622290
+Bubble Sort,333,459,0.00612000
+Bubble Sort,333,460,0.00694140
+Bubble Sort,333,461,0.00608200
+Bubble Sort,333,462,0.00691870
+Bubble Sort,333,463,0.00615130
+Bubble Sort,333,464,0.00681720
+Bubble Sort,333,465,0.00589990
+Bubble Sort,333,466,0.00673530
+Bubble Sort,333,467,0.00588930
+Bubble Sort,333,468,0.00608080
+Bubble Sort,333,469,0.00598160
+Bubble Sort,333,470,0.00618800
+Bubble Sort,333,471,0.00758730
+Bubble Sort,333,472,0.00616200
+Bubble Sort,333,473,0.00611020
+Bubble Sort,333,474,0.00613570
+Bubble Sort,333,475,0.00804100
+Bubble Sort,333,476,0.00597370
+Bubble Sort,333,477,0.00621180
+Bubble Sort,333,478,0.00694270
+Bubble Sort,333,479,0.00592540
+Bubble Sort,333,480,0.00624340
+Bubble Sort,333,481,0.00757800
+Bubble Sort,333,482,0.00628690
+Bubble Sort,333,483,0.00719600
+Bubble Sort,333,484,0.00601870
+Bubble Sort,333,485,0.01104750
+Bubble Sort,333,486,0.00606110
+Bubble Sort,333,487,0.00735470
+Bubble Sort,333,488,0.00619310
+Bubble Sort,333,489,0.00640630
+Bubble Sort,333,490,0.00613600
+Bubble Sort,333,491,0.00614730
+Bubble Sort,333,492,0.00668100
+Bubble Sort,333,493,0.00591720
+Bubble Sort,333,494,0.00774760
+Bubble Sort,333,495,0.00619120
+Bubble Sort,333,496,0.00598960
+Bubble Sort,333,497,0.00604450
+Bubble Sort,333,498,0.00652310
+Bubble Sort,333,499,0.00602970
+Bubble Sort,333,500,0.00926800
+Bucket Sort,333,1,0.00035590
+Bucket Sort,333,2,0.00025130
+Bucket Sort,333,3,0.00026950
+Bucket Sort,333,4,0.00028340
+Bucket Sort,333,5,0.00044780
+Bucket Sort,333,6,0.00025270
+Bucket Sort,333,7,0.00026930
+Bucket Sort,333,8,0.00025870
+Bucket Sort,333,9,0.00027520
+Bucket Sort,333,10,0.00025750
+Bucket Sort,333,11,0.00025890
+Bucket Sort,333,12,0.00026450
+Bucket Sort,333,13,0.00025530
+Bucket Sort,333,14,0.00026260
+Bucket Sort,333,15,0.00025850
+Bucket Sort,333,16,0.00035600
+Bucket Sort,333,17,0.00025530
+Bucket Sort,333,18,0.00026140
+Bucket Sort,333,19,0.00034330
+Bucket Sort,333,20,0.00025670
+Bucket Sort,333,21,0.00024840
+Bucket Sort,333,22,0.00025740
+Bucket Sort,333,23,0.00026010
+Bucket Sort,333,24,0.00025220
+Bucket Sort,333,25,0.00030830
+Bucket Sort,333,26,0.00033360
+Bucket Sort,333,27,0.00025380
+Bucket Sort,333,28,0.00031390
+Bucket Sort,333,29,0.00025570
+Bucket Sort,333,30,0.00031620
+Bucket Sort,333,31,0.00024720
+Bucket Sort,333,32,0.00024860
+Bucket Sort,333,33,0.00038080
+Bucket Sort,333,34,0.00024710
+Bucket Sort,333,35,0.00025310
+Bucket Sort,333,36,0.00046690
+Bucket Sort,333,37,0.00025620
+Bucket Sort,333,38,0.00029510
+Bucket Sort,333,39,0.00025020
+Bucket Sort,333,40,0.00025050
+Bucket Sort,333,41,0.00026670
+Bucket Sort,333,42,0.00025670
+Bucket Sort,333,43,0.00025700
+Bucket Sort,333,44,0.00025170
+Bucket Sort,333,45,0.00025140
+Bucket Sort,333,46,0.00025310
+Bucket Sort,333,47,0.00026500
+Bucket Sort,333,48,0.00025010
+Bucket Sort,333,49,0.00025200
+Bucket Sort,333,50,0.00025160
+Bucket Sort,333,51,0.00026090
+Bucket Sort,333,52,0.00024390
+Bucket Sort,333,53,0.00025080
+Bucket Sort,333,54,0.00024900
+Bucket Sort,333,55,0.00025520
+Bucket Sort,333,56,0.00024270
+Bucket Sort,333,57,0.00026830
+Bucket Sort,333,58,0.00024860
+Bucket Sort,333,59,0.00025800
+Bucket Sort,333,60,0.00024440
+Bucket Sort,333,61,0.00025990
+Bucket Sort,333,62,0.00024800
+Bucket Sort,333,63,0.00025920
+Bucket Sort,333,64,0.00024350
+Bucket Sort,333,65,0.00025970
+Bucket Sort,333,66,0.00025050
+Bucket Sort,333,67,0.00025620
+Bucket Sort,333,68,0.00024850
+Bucket Sort,333,69,0.00025510
+Bucket Sort,333,70,0.00024520
+Bucket Sort,333,71,0.00024620
+Bucket Sort,333,72,0.00029930
+Bucket Sort,333,73,0.00024470
+Bucket Sort,333,74,0.00028910
+Bucket Sort,333,75,0.00024300
+Bucket Sort,333,76,0.00024220
+Bucket Sort,333,77,0.00030770
+Bucket Sort,333,78,0.00024100
+Bucket Sort,333,79,0.00028700
+Bucket Sort,333,80,0.00024560
+Bucket Sort,333,81,0.00024150
+Bucket Sort,333,82,0.00046240
+Bucket Sort,333,83,0.00024340
+Bucket Sort,333,84,0.00024710
+Bucket Sort,333,85,0.00028800
+Bucket Sort,333,86,0.00024200
+Bucket Sort,333,87,0.00027320
+Bucket Sort,333,88,0.00027790
+Bucket Sort,333,89,0.00025830
+Bucket Sort,333,90,0.00024770
+Bucket Sort,333,91,0.00026850
+Bucket Sort,333,92,0.00024680
+Bucket Sort,333,93,0.00028700
+Bucket Sort,333,94,0.00024830
+Bucket Sort,333,95,0.00028090
+Bucket Sort,333,96,0.00024420
+Bucket Sort,333,97,0.00028200
+Bucket Sort,333,98,0.00024390
+Bucket Sort,333,99,0.00024690
+Bucket Sort,333,100,0.00028040
+Bucket Sort,333,101,0.00024230
+Bucket Sort,333,102,0.00027600
+Bucket Sort,333,103,0.00024440
+Bucket Sort,333,104,0.00029790
+Bucket Sort,333,105,0.00024310
+Bucket Sort,333,106,0.00026620
+Bucket Sort,333,107,0.00024380
+Bucket Sort,333,108,0.00028360
+Bucket Sort,333,109,0.00024550
+Bucket Sort,333,110,0.00026250
+Bucket Sort,333,111,0.00024260
+Bucket Sort,333,112,0.00024400
+Bucket Sort,333,113,0.00028210
+Bucket Sort,333,114,0.00024120
+Bucket Sort,333,115,0.00029020
+Bucket Sort,333,116,0.00028540
+Bucket Sort,333,117,0.00026680
+Bucket Sort,333,118,0.00025360
+Bucket Sort,333,119,0.00025530
+Bucket Sort,333,120,0.00030060
+Bucket Sort,333,121,0.00026940
+Bucket Sort,333,122,0.00024880
+Bucket Sort,333,123,0.00028900
+Bucket Sort,333,124,0.00031410
+Bucket Sort,333,125,0.00029740
+Bucket Sort,333,126,0.00029820
+Bucket Sort,333,127,0.00025570
+Bucket Sort,333,128,0.00024460
+Bucket Sort,333,129,0.00027880
+Bucket Sort,333,130,0.00024630
+Bucket Sort,333,131,0.00027890
+Bucket Sort,333,132,0.00024560
+Bucket Sort,333,133,0.00026940
+Bucket Sort,333,134,0.00025180
+Bucket Sort,333,135,0.00026330
+Bucket Sort,333,136,0.00026110
+Bucket Sort,333,137,0.00028690
+Bucket Sort,333,138,0.00029020
+Bucket Sort,333,139,0.00028460
+Bucket Sort,333,140,0.00028170
+Bucket Sort,333,141,0.00026480
+Bucket Sort,333,142,0.00025920
+Bucket Sort,333,143,0.00026190
+Bucket Sort,333,144,0.00025740
+Bucket Sort,333,145,0.00029810
+Bucket Sort,333,146,0.00027870
+Bucket Sort,333,147,0.00025920
+Bucket Sort,333,148,0.00025720
+Bucket Sort,333,149,0.00028390
+Bucket Sort,333,150,0.00029020
+Bucket Sort,333,151,0.00026480
+Bucket Sort,333,152,0.00028010
+Bucket Sort,333,153,0.00028350
+Bucket Sort,333,154,0.00028220
+Bucket Sort,333,155,0.00029090
+Bucket Sort,333,156,0.00028260
+Bucket Sort,333,157,0.00027850
+Bucket Sort,333,158,0.00026850
+Bucket Sort,333,159,0.00027800
+Bucket Sort,333,160,0.00029650
+Bucket Sort,333,161,0.00028210
+Bucket Sort,333,162,0.00027090
+Bucket Sort,333,163,0.00027230
+Bucket Sort,333,164,0.00027380
+Bucket Sort,333,165,0.00026370
+Bucket Sort,333,166,0.00028190
+Bucket Sort,333,167,0.00026760
+Bucket Sort,333,168,0.00028100
+Bucket Sort,333,169,0.00026640
+Bucket Sort,333,170,0.00028210
+Bucket Sort,333,171,0.00027230
+Bucket Sort,333,172,0.00030120
+Bucket Sort,333,173,0.00027020
+Bucket Sort,333,174,0.00027550
+Bucket Sort,333,175,0.00025910
+Bucket Sort,333,176,0.00026370
+Bucket Sort,333,177,0.00028340
+Bucket Sort,333,178,0.00026510
+Bucket Sort,333,179,0.00079030
+Bucket Sort,333,180,0.00027890
+Bucket Sort,333,181,0.00027050
+Bucket Sort,333,182,0.00027950
+Bucket Sort,333,183,0.00025560
+Bucket Sort,333,184,0.00025140
+Bucket Sort,333,185,0.00034790
+Bucket Sort,333,186,0.00025180
+Bucket Sort,333,187,0.00058890
+Bucket Sort,333,188,0.00025040
+Bucket Sort,333,189,0.00025930
+Bucket Sort,333,190,0.00026010
+Bucket Sort,333,191,0.00025240
+Bucket Sort,333,192,0.00025500
+Bucket Sort,333,193,0.00143550
+Bucket Sort,333,194,0.00025460
+Bucket Sort,333,195,0.00025330
+Bucket Sort,333,196,0.00024830
+Bucket Sort,333,197,0.00024870
+Bucket Sort,333,198,0.00024790
+Bucket Sort,333,199,0.00089610
+Bucket Sort,333,200,0.00024590
+Bucket Sort,333,201,0.00025200
+Bucket Sort,333,202,0.00026210
+Bucket Sort,333,203,0.00027970
+Bucket Sort,333,204,0.00025670
+Bucket Sort,333,205,0.00027120
+Bucket Sort,333,206,0.00066440
+Bucket Sort,333,207,0.00025210
+Bucket Sort,333,208,0.00024700
+Bucket Sort,333,209,0.00026100
+Bucket Sort,333,210,0.00024640
+Bucket Sort,333,211,0.00024860
+Bucket Sort,333,212,0.00055310
+Bucket Sort,333,213,0.00024540
+Bucket Sort,333,214,0.00048770
+Bucket Sort,333,215,0.00028380
+Bucket Sort,333,216,0.00026450
+Bucket Sort,333,217,0.00024840
+Bucket Sort,333,218,0.00028080
+Bucket Sort,333,219,0.00025500
+Bucket Sort,333,220,0.00028890
+Bucket Sort,333,221,0.00025660
+Bucket Sort,333,222,0.00027860
+Bucket Sort,333,223,0.00025360
+Bucket Sort,333,224,0.00028190
+Bucket Sort,333,225,0.00026490
+Bucket Sort,333,226,0.00035920
+Bucket Sort,333,227,0.00025040
+Bucket Sort,333,228,0.00025620
+Bucket Sort,333,229,0.00025280
+Bucket Sort,333,230,0.00025020
+Bucket Sort,333,231,0.00021350
+Bucket Sort,333,232,0.00021080
+Bucket Sort,333,233,0.00029270
+Bucket Sort,333,234,0.00021380
+Bucket Sort,333,235,0.00029240
+Bucket Sort,333,236,0.00021030
+Bucket Sort,333,237,0.00020950
+Bucket Sort,333,238,0.00028150
+Bucket Sort,333,239,0.00022850
+Bucket Sort,333,240,0.00027830
+Bucket Sort,333,241,0.00021380
+Bucket Sort,333,242,0.00030340
+Bucket Sort,333,243,0.00021290
+Bucket Sort,333,244,0.00020880
+Bucket Sort,333,245,0.00029510
+Bucket Sort,333,246,0.00020610
+Bucket Sort,333,247,0.00033900
+Bucket Sort,333,248,0.00021190
+Bucket Sort,333,249,0.00020930
+Bucket Sort,333,250,0.00028070
+Bucket Sort,333,251,0.00021510
+Bucket Sort,333,252,0.00028080
+Bucket Sort,333,253,0.00020510
+Bucket Sort,333,254,0.00021760
+Bucket Sort,333,255,0.00027180
+Bucket Sort,333,256,0.00027340
+Bucket Sort,333,257,0.00026490
+Bucket Sort,333,258,0.00027270
+Bucket Sort,333,259,0.00026340
+Bucket Sort,333,260,0.00026590
+Bucket Sort,333,261,0.00026110
+Bucket Sort,333,262,0.00026050
+Bucket Sort,333,263,0.00026530
+Bucket Sort,333,264,0.00027100
+Bucket Sort,333,265,0.00026790
+Bucket Sort,333,266,0.00026270
+Bucket Sort,333,267,0.00026220
+Bucket Sort,333,268,0.00027240
+Bucket Sort,333,269,0.00026860
+Bucket Sort,333,270,0.00026890
+Bucket Sort,333,271,0.00026160
+Bucket Sort,333,272,0.00026600
+Bucket Sort,333,273,0.00026570
+Bucket Sort,333,274,0.00026170
+Bucket Sort,333,275,0.00026390
+Bucket Sort,333,276,0.00026440
+Bucket Sort,333,277,0.00026350
+Bucket Sort,333,278,0.00026090
+Bucket Sort,333,279,0.00026820
+Bucket Sort,333,280,0.00026130
+Bucket Sort,333,281,0.00026480
+Bucket Sort,333,282,0.00026990
+Bucket Sort,333,283,0.00027300
+Bucket Sort,333,284,0.00027300
+Bucket Sort,333,285,0.00027070
+Bucket Sort,333,286,0.00026400
+Bucket Sort,333,287,0.00026640
+Bucket Sort,333,288,0.00027600
+Bucket Sort,333,289,0.00026000
+Bucket Sort,333,290,0.00027650
+Bucket Sort,333,291,0.00027260
+Bucket Sort,333,292,0.00026830
+Bucket Sort,333,293,0.00026360
+Bucket Sort,333,294,0.00026990
+Bucket Sort,333,295,0.00026780
+Bucket Sort,333,296,0.00026380
+Bucket Sort,333,297,0.00027650
+Bucket Sort,333,298,0.00026390
+Bucket Sort,333,299,0.00026700
+Bucket Sort,333,300,0.00026240
+Bucket Sort,333,301,0.00025850
+Bucket Sort,333,302,0.00026310
+Bucket Sort,333,303,0.00025400
+Bucket Sort,333,304,0.00037460
+Bucket Sort,333,305,0.00027480
+Bucket Sort,333,306,0.00026110
+Bucket Sort,333,307,0.00081620
+Bucket Sort,333,308,0.00025580
+Bucket Sort,333,309,0.00026920
+Bucket Sort,333,310,0.00074280
+Bucket Sort,333,311,0.00027760
+Bucket Sort,333,312,0.00026430
+Bucket Sort,333,313,0.00260310
+Bucket Sort,333,314,0.00026700
+Bucket Sort,333,315,0.00034800
+Bucket Sort,333,316,0.00081120
+Bucket Sort,333,317,0.00026390
+Bucket Sort,333,318,0.00062230
+Bucket Sort,333,319,0.00036650
+Bucket Sort,333,320,0.00031310
+Bucket Sort,333,321,0.00068050
+Bucket Sort,333,322,0.00028400
+Bucket Sort,333,323,0.00027290
+Bucket Sort,333,324,0.00026600
+Bucket Sort,333,325,0.00049340
+Bucket Sort,333,326,0.00027040
+Bucket Sort,333,327,0.00028380
+Bucket Sort,333,328,0.00023190
+Bucket Sort,333,329,0.00028210
+Bucket Sort,333,330,0.00038100
+Bucket Sort,333,331,0.00082140
+Bucket Sort,333,332,0.00028380
+Bucket Sort,333,333,0.00028820
+Bucket Sort,333,334,0.00028450
+Bucket Sort,333,335,0.00027490
+Bucket Sort,333,336,0.00023790
+Bucket Sort,333,337,0.00022570
+Bucket Sort,333,338,0.00021760
+Bucket Sort,333,339,0.00021110
+Bucket Sort,333,340,0.00021010
+Bucket Sort,333,341,0.00083230
+Bucket Sort,333,342,0.00026660
+Bucket Sort,333,343,0.00028290
+Bucket Sort,333,344,0.00028210
+Bucket Sort,333,345,0.00021780
+Bucket Sort,333,346,0.00027860
+Bucket Sort,333,347,0.00026860
+Bucket Sort,333,348,0.00027530
+Bucket Sort,333,349,0.00234800
+Bucket Sort,333,350,0.00026940
+Bucket Sort,333,351,0.00028360
+Bucket Sort,333,352,0.00027540
+Bucket Sort,333,353,0.00027380
+Bucket Sort,333,354,0.00021900
+Bucket Sort,333,355,0.00029030
+Bucket Sort,333,356,0.00027430
+Bucket Sort,333,357,0.00032780
+Bucket Sort,333,358,0.00028460
+Bucket Sort,333,359,0.00027470
+Bucket Sort,333,360,0.00025740
+Bucket Sort,333,361,0.00038220
+Bucket Sort,333,362,0.00027160
+Bucket Sort,333,363,0.00029460
+Bucket Sort,333,364,0.00028370
+Bucket Sort,333,365,0.00026860
+Bucket Sort,333,366,0.00028530
+Bucket Sort,333,367,0.00121840
+Bucket Sort,333,368,0.00027430
+Bucket Sort,333,369,0.00027780
+Bucket Sort,333,370,0.00027380
+Bucket Sort,333,371,0.00077230
+Bucket Sort,333,372,0.00027760
+Bucket Sort,333,373,0.00027380
+Bucket Sort,333,374,0.00073440
+Bucket Sort,333,375,0.00027950
+Bucket Sort,333,376,0.00028340
+Bucket Sort,333,377,0.00027270
+Bucket Sort,333,378,0.00027840
+Bucket Sort,333,379,0.00026930
+Bucket Sort,333,380,0.00027970
+Bucket Sort,333,381,0.00026450
+Bucket Sort,333,382,0.00027650
+Bucket Sort,333,383,0.00076080
+Bucket Sort,333,384,0.00027890
+Bucket Sort,333,385,0.00027940
+Bucket Sort,333,386,0.00027580
+Bucket Sort,333,387,0.00063220
+Bucket Sort,333,388,0.00027810
+Bucket Sort,333,389,0.00027340
+Bucket Sort,333,390,0.00071390
+Bucket Sort,333,391,0.00028290
+Bucket Sort,333,392,0.00026690
+Bucket Sort,333,393,0.00027910
+Bucket Sort,333,394,0.00025060
+Bucket Sort,333,395,0.00049640
+Bucket Sort,333,396,0.00027610
+Bucket Sort,333,397,0.00086030
+Bucket Sort,333,398,0.00042880
+Bucket Sort,333,399,0.00027830
+Bucket Sort,333,400,0.00037750
+Bucket Sort,333,401,0.00028700
+Bucket Sort,333,402,0.00025720
+Bucket Sort,333,403,0.00028840
+Bucket Sort,333,404,0.00025310
+Bucket Sort,333,405,0.00023530
+Bucket Sort,333,406,0.00040100
+Bucket Sort,333,407,0.00025330
+Bucket Sort,333,408,0.00028880
+Bucket Sort,333,409,0.00024990
+Bucket Sort,333,410,0.00028540
+Bucket Sort,333,411,0.00025760
+Bucket Sort,333,412,0.00028290
+Bucket Sort,333,413,0.00024880
+Bucket Sort,333,414,0.00028560
+Bucket Sort,333,415,0.00023540
+Bucket Sort,333,416,0.00025560
+Bucket Sort,333,417,0.00029460
+Bucket Sort,333,418,0.00025810
+Bucket Sort,333,419,0.00028640
+Bucket Sort,333,420,0.00025110
+Bucket Sort,333,421,0.00028150
+Bucket Sort,333,422,0.00024280
+Bucket Sort,333,423,0.00029280
+Bucket Sort,333,424,0.00169590
+Bucket Sort,333,425,0.00028090
+Bucket Sort,333,426,0.00027470
+Bucket Sort,333,427,0.00026550
+Bucket Sort,333,428,0.00025920
+Bucket Sort,333,429,0.00026780
+Bucket Sort,333,430,0.00026880
+Bucket Sort,333,431,0.00030350
+Bucket Sort,333,432,0.00033690
+Bucket Sort,333,433,0.00027460
+Bucket Sort,333,434,0.00027910
+Bucket Sort,333,435,0.00029150
+Bucket Sort,333,436,0.00026260
+Bucket Sort,333,437,0.00030190
+Bucket Sort,333,438,0.00028530
+Bucket Sort,333,439,0.00028890
+Bucket Sort,333,440,0.00033810
+Bucket Sort,333,441,0.00027240
+Bucket Sort,333,442,0.00029710
+Bucket Sort,333,443,0.00047710
+Bucket Sort,333,444,0.00028680
+Bucket Sort,333,445,0.00026540
+Bucket Sort,333,446,0.00078460
+Bucket Sort,333,447,0.00028470
+Bucket Sort,333,448,0.00029230
+Bucket Sort,333,449,0.00027070
+Bucket Sort,333,450,0.00076980
+Bucket Sort,333,451,0.00026560
+Bucket Sort,333,452,0.00028060
+Bucket Sort,333,453,0.00028870
+Bucket Sort,333,454,0.00028420
+Bucket Sort,333,455,0.00028500
+Bucket Sort,333,456,0.00028410
+Bucket Sort,333,457,0.00028320
+Bucket Sort,333,458,0.00048250
+Bucket Sort,333,459,0.00028900
+Bucket Sort,333,460,0.00028830
+Bucket Sort,333,461,0.00028530
+Bucket Sort,333,462,0.00027590
+Bucket Sort,333,463,0.00027180
+Bucket Sort,333,464,0.00026880
+Bucket Sort,333,465,0.00031970
+Bucket Sort,333,466,0.00027350
+Bucket Sort,333,467,0.00031060
+Bucket Sort,333,468,0.00027680
+Bucket Sort,333,469,0.00038730
+Bucket Sort,333,470,0.00027440
+Bucket Sort,333,471,0.00026090
+Bucket Sort,333,472,0.00028190
+Bucket Sort,333,473,0.00028920
+Bucket Sort,333,474,0.00028480
+Bucket Sort,333,475,0.00033480
+Bucket Sort,333,476,0.00026760
+Bucket Sort,333,477,0.00025950
+Bucket Sort,333,478,0.00028950
+Bucket Sort,333,479,0.00026680
+Bucket Sort,333,480,0.00026850
+Bucket Sort,333,481,0.00027100
+Bucket Sort,333,482,0.00026650
+Bucket Sort,333,483,0.00025690
+Bucket Sort,333,484,0.00026510
+Bucket Sort,333,485,0.00024910
+Bucket Sort,333,486,0.00025840
+Bucket Sort,333,487,0.00025570
+Bucket Sort,333,488,0.00039540
+Bucket Sort,333,489,0.00035560
+Bucket Sort,333,490,0.00036640
+Bucket Sort,333,491,0.00070330
+Bucket Sort,333,492,0.00025250
+Bucket Sort,333,493,0.00049080
+Bucket Sort,333,494,0.00026860
+Bucket Sort,333,495,0.00025270
+Bucket Sort,333,496,0.00024720
+Bucket Sort,333,497,0.00036910
+Bucket Sort,333,498,0.00025300
+Bucket Sort,333,499,0.00031900
+Bucket Sort,333,500,0.00025110
+Burst Sort,333,1,0.00026600
+Burst Sort,333,2,0.00037640
+Burst Sort,333,3,0.00024830
+Burst Sort,333,4,0.00024430
+Burst Sort,333,5,0.00049530
+Burst Sort,333,6,0.00024580
+Burst Sort,333,7,0.00024830
+Burst Sort,333,8,0.00050780
+Burst Sort,333,9,0.00024150
+Burst Sort,333,10,0.00025390
+Burst Sort,333,11,0.00029550
+Burst Sort,333,12,0.00025170
+Burst Sort,333,13,0.00024340
+Burst Sort,333,14,0.00024730
+Burst Sort,333,15,0.00026760
+Burst Sort,333,16,0.00053220
+Burst Sort,333,17,0.00025520
+Burst Sort,333,18,0.00025740
+Burst Sort,333,19,0.00032390
+Burst Sort,333,20,0.00026340
+Burst Sort,333,21,0.00025140
+Burst Sort,333,22,0.00024730
+Burst Sort,333,23,0.00037020
+Burst Sort,333,24,0.00024040
+Burst Sort,333,25,0.00025300
+Burst Sort,333,26,0.00023950
+Burst Sort,333,27,0.00025160
+Burst Sort,333,28,0.00024050
+Burst Sort,333,29,0.00024420
+Burst Sort,333,30,0.00023890
+Burst Sort,333,31,0.00028490
+Burst Sort,333,32,0.00026740
+Burst Sort,333,33,0.00026000
+Burst Sort,333,34,0.00027530
+Burst Sort,333,35,0.00025730
+Burst Sort,333,36,0.00027830
+Burst Sort,333,37,0.00024730
+Burst Sort,333,38,0.00027880
+Burst Sort,333,39,0.00024500
+Burst Sort,333,40,0.00026410
+Burst Sort,333,41,0.00051480
+Burst Sort,333,42,0.00025970
+Burst Sort,333,43,0.00026430
+Burst Sort,333,44,0.00044290
+Burst Sort,333,45,0.00025740
+Burst Sort,333,46,0.00038340
+Burst Sort,333,47,0.00026630
+Burst Sort,333,48,0.00025830
+Burst Sort,333,49,0.00025860
+Burst Sort,333,50,0.00026180
+Burst Sort,333,51,0.00027200
+Burst Sort,333,52,0.00033130
+Burst Sort,333,53,0.00026700
+Burst Sort,333,54,0.00024200
+Burst Sort,333,55,0.00026530
+Burst Sort,333,56,0.00024470
+Burst Sort,333,57,0.00026740
+Burst Sort,333,58,0.00032630
+Burst Sort,333,59,0.00025820
+Burst Sort,333,60,0.00024150
+Burst Sort,333,61,0.00029410
+Burst Sort,333,62,0.00026710
+Burst Sort,333,63,0.00027310
+Burst Sort,333,64,0.00027330
+Burst Sort,333,65,0.00027350
+Burst Sort,333,66,0.00026070
+Burst Sort,333,67,0.00050080
+Burst Sort,333,68,0.00024960
+Burst Sort,333,69,0.00025870
+Burst Sort,333,70,0.00027240
+Burst Sort,333,71,0.00025200
+Burst Sort,333,72,0.00024460
+Burst Sort,333,73,0.00045850
+Burst Sort,333,74,0.00026640
+Burst Sort,333,75,0.00025810
+Burst Sort,333,76,0.00024180
+Burst Sort,333,77,0.00029070
+Burst Sort,333,78,0.00024640
+Burst Sort,333,79,0.00023930
+Burst Sort,333,80,0.00026520
+Burst Sort,333,81,0.00024260
+Burst Sort,333,82,0.00024670
+Burst Sort,333,83,0.00024500
+Burst Sort,333,84,0.00031780
+Burst Sort,333,85,0.00025200
+Burst Sort,333,86,0.00061460
+Burst Sort,333,87,0.00024050
+Burst Sort,333,88,0.00024550
+Burst Sort,333,89,0.00031650
+Burst Sort,333,90,0.00026440
+Burst Sort,333,91,0.00025620
+Burst Sort,333,92,0.00026010
+Burst Sort,333,93,0.00027010
+Burst Sort,333,94,0.00026950
+Burst Sort,333,95,0.00026620
+Burst Sort,333,96,0.00025480
+Burst Sort,333,97,0.00025210
+Burst Sort,333,98,0.00024650
+Burst Sort,333,99,0.00025820
+Burst Sort,333,100,0.00025390
+Burst Sort,333,101,0.00023560
+Burst Sort,333,102,0.00025180
+Burst Sort,333,103,0.00025430
+Burst Sort,333,104,0.00026880
+Burst Sort,333,105,0.00025070
+Burst Sort,333,106,0.00025320
+Burst Sort,333,107,0.00027920
+Burst Sort,333,108,0.00027600
+Burst Sort,333,109,0.00023670
+Burst Sort,333,110,0.00026080
+Burst Sort,333,111,0.00024060
+Burst Sort,333,112,0.00025460
+Burst Sort,333,113,0.00023350
+Burst Sort,333,114,0.00025640
+Burst Sort,333,115,0.00025690
+Burst Sort,333,116,0.00026140
+Burst Sort,333,117,0.00024920
+Burst Sort,333,118,0.00026770
+Burst Sort,333,119,0.00024600
+Burst Sort,333,120,0.00024970
+Burst Sort,333,121,0.00026330
+Burst Sort,333,122,0.00026350
+Burst Sort,333,123,0.00024920
+Burst Sort,333,124,0.00026240
+Burst Sort,333,125,0.00024610
+Burst Sort,333,126,0.00025160
+Burst Sort,333,127,0.00026780
+Burst Sort,333,128,0.00024720
+Burst Sort,333,129,0.00024690
+Burst Sort,333,130,0.00026010
+Burst Sort,333,131,0.00025270
+Burst Sort,333,132,0.00025660
+Burst Sort,333,133,0.00024190
+Burst Sort,333,134,0.00026240
+Burst Sort,333,135,0.00024700
+Burst Sort,333,136,0.00025070
+Burst Sort,333,137,0.00024090
+Burst Sort,333,138,0.00025610
+Burst Sort,333,139,0.00025860
+Burst Sort,333,140,0.00025500
+Burst Sort,333,141,0.00025240
+Burst Sort,333,142,0.00025710
+Burst Sort,333,143,0.00025870
+Burst Sort,333,144,0.00026200
+Burst Sort,333,145,0.00027570
+Burst Sort,333,146,0.00024820
+Burst Sort,333,147,0.00026600
+Burst Sort,333,148,0.00030100
+Burst Sort,333,149,0.00026640
+Burst Sort,333,150,0.00030310
+Burst Sort,333,151,0.00026120
+Burst Sort,333,152,0.00027290
+Burst Sort,333,153,0.00036780
+Burst Sort,333,154,0.00026740
+Burst Sort,333,155,0.00026080
+Burst Sort,333,156,0.00027170
+Burst Sort,333,157,0.00028060
+Burst Sort,333,158,0.00026790
+Burst Sort,333,159,0.00026670
+Burst Sort,333,160,0.00027500
+Burst Sort,333,161,0.00026870
+Burst Sort,333,162,0.00025920
+Burst Sort,333,163,0.00027330
+Burst Sort,333,164,0.00026680
+Burst Sort,333,165,0.00025840
+Burst Sort,333,166,0.00026160
+Burst Sort,333,167,0.00027420
+Burst Sort,333,168,0.00026170
+Burst Sort,333,169,0.00026900
+Burst Sort,333,170,0.00026370
+Burst Sort,333,171,0.00026600
+Burst Sort,333,172,0.00026460
+Burst Sort,333,173,0.00026010
+Burst Sort,333,174,0.00024410
+Burst Sort,333,175,0.00025640
+Burst Sort,333,176,0.00026170
+Burst Sort,333,177,0.00026260
+Burst Sort,333,178,0.00025820
+Burst Sort,333,179,0.00026900
+Burst Sort,333,180,0.00026270
+Burst Sort,333,181,0.00026200
+Burst Sort,333,182,0.00026940
+Burst Sort,333,183,0.00026350
+Burst Sort,333,184,0.00026080
+Burst Sort,333,185,0.00044850
+Burst Sort,333,186,0.00026280
+Burst Sort,333,187,0.00025970
+Burst Sort,333,188,0.00026160
+Burst Sort,333,189,0.00026860
+Burst Sort,333,190,0.00026680
+Burst Sort,333,191,0.00026560
+Burst Sort,333,192,0.00026230
+Burst Sort,333,193,0.00027640
+Burst Sort,333,194,0.00026330
+Burst Sort,333,195,0.00025080
+Burst Sort,333,196,0.00025690
+Burst Sort,333,197,0.00026210
+Burst Sort,333,198,0.00026730
+Burst Sort,333,199,0.00026440
+Burst Sort,333,200,0.00026630
+Burst Sort,333,201,0.00026140
+Burst Sort,333,202,0.00025790
+Burst Sort,333,203,0.00025920
+Burst Sort,333,204,0.00026570
+Burst Sort,333,205,0.00023810
+Burst Sort,333,206,0.00026000
+Burst Sort,333,207,0.00023680
+Burst Sort,333,208,0.00025860
+Burst Sort,333,209,0.00023730
+Burst Sort,333,210,0.00025560
+Burst Sort,333,211,0.00026810
+Burst Sort,333,212,0.00026270
+Burst Sort,333,213,0.00024900
+Burst Sort,333,214,0.00026570
+Burst Sort,333,215,0.00023910
+Burst Sort,333,216,0.00025640
+Burst Sort,333,217,0.00024460
+Burst Sort,333,218,0.00025720
+Burst Sort,333,219,0.00024840
+Burst Sort,333,220,0.00025460
+Burst Sort,333,221,0.00025130
+Burst Sort,333,222,0.00025740
+Burst Sort,333,223,0.00026480
+Burst Sort,333,224,0.00027040
+Burst Sort,333,225,0.00026170
+Burst Sort,333,226,0.00025900
+Burst Sort,333,227,0.00024660
+Burst Sort,333,228,0.00027370
+Burst Sort,333,229,0.00024100
+Burst Sort,333,230,0.00024910
+Burst Sort,333,231,0.00024070
+Burst Sort,333,232,0.00026870
+Burst Sort,333,233,0.00023890
+Burst Sort,333,234,0.00025190
+Burst Sort,333,235,0.00026480
+Burst Sort,333,236,0.00025870
+Burst Sort,333,237,0.00025900
+Burst Sort,333,238,0.00026010
+Burst Sort,333,239,0.00025990
+Burst Sort,333,240,0.00024680
+Burst Sort,333,241,0.00024500
+Burst Sort,333,242,0.00025130
+Burst Sort,333,243,0.00025130
+Burst Sort,333,244,0.00025090
+Burst Sort,333,245,0.00026790
+Burst Sort,333,246,0.00025340
+Burst Sort,333,247,0.00027150
+Burst Sort,333,248,0.00026470
+Burst Sort,333,249,0.00027180
+Burst Sort,333,250,0.00026200
+Burst Sort,333,251,0.00026200
+Burst Sort,333,252,0.00027670
+Burst Sort,333,253,0.00026260
+Burst Sort,333,254,0.00027110
+Burst Sort,333,255,0.00026230
+Burst Sort,333,256,0.00026450
+Burst Sort,333,257,0.00027160
+Burst Sort,333,258,0.00027350
+Burst Sort,333,259,0.00024520
+Burst Sort,333,260,0.00026810
+Burst Sort,333,261,0.00053640
+Burst Sort,333,262,0.00026050
+Burst Sort,333,263,0.00025270
+Burst Sort,333,264,0.00027370
+Burst Sort,333,265,0.00026370
+Burst Sort,333,266,0.00029320
+Burst Sort,333,267,0.00026230
+Burst Sort,333,268,0.00034820
+Burst Sort,333,269,0.00026570
+Burst Sort,333,270,0.00028200
+Burst Sort,333,271,0.00025700
+Burst Sort,333,272,0.00041830
+Burst Sort,333,273,0.00028690
+Burst Sort,333,274,0.00023230
+Burst Sort,333,275,0.00032680
+Burst Sort,333,276,0.00025050
+Burst Sort,333,277,0.00025380
+Burst Sort,333,278,0.00026330
+Burst Sort,333,279,0.00024820
+Burst Sort,333,280,0.00024490
+Burst Sort,333,281,0.00025400
+Burst Sort,333,282,0.00024900
+Burst Sort,333,283,0.00024490
+Burst Sort,333,284,0.00026280
+Burst Sort,333,285,0.00024810
+Burst Sort,333,286,0.00025580
+Burst Sort,333,287,0.00024200
+Burst Sort,333,288,0.00024570
+Burst Sort,333,289,0.00025840
+Burst Sort,333,290,0.00026940
+Burst Sort,333,291,0.00024910
+Burst Sort,333,292,0.00025240
+Burst Sort,333,293,0.00024710
+Burst Sort,333,294,0.00025010
+Burst Sort,333,295,0.00029490
+Burst Sort,333,296,0.00025750
+Burst Sort,333,297,0.00041700
+Burst Sort,333,298,0.00024380
+Burst Sort,333,299,0.00025210
+Burst Sort,333,300,0.00038720
+Burst Sort,333,301,0.00033560
+Burst Sort,333,302,0.00060580
+Burst Sort,333,303,0.00066760
+Burst Sort,333,304,0.00047810
+Burst Sort,333,305,0.00045570
+Burst Sort,333,306,0.00039640
+Burst Sort,333,307,0.00025340
+Burst Sort,333,308,0.00051990
+Burst Sort,333,309,0.00024860
+Burst Sort,333,310,0.00025960
+Burst Sort,333,311,0.00032750
+Burst Sort,333,312,0.00025790
+Burst Sort,333,313,0.00091090
+Burst Sort,333,314,0.00024760
+Burst Sort,333,315,0.00025620
+Burst Sort,333,316,0.00026650
+Burst Sort,333,317,0.00027760
+Burst Sort,333,318,0.00024330
+Burst Sort,333,319,0.00024000
+Burst Sort,333,320,0.00026490
+Burst Sort,333,321,0.00023930
+Burst Sort,333,322,0.00024470
+Burst Sort,333,323,0.00023980
+Burst Sort,333,324,0.00024130
+Burst Sort,333,325,0.00023590
+Burst Sort,333,326,0.00024820
+Burst Sort,333,327,0.00023410
+Burst Sort,333,328,0.00025980
+Burst Sort,333,329,0.00023210
+Burst Sort,333,330,0.00024770
+Burst Sort,333,331,0.00023220
+Burst Sort,333,332,0.00024140
+Burst Sort,333,333,0.00023330
+Burst Sort,333,334,0.00024430
+Burst Sort,333,335,0.00026180
+Burst Sort,333,336,0.00024050
+Burst Sort,333,337,0.00023650
+Burst Sort,333,338,0.00024470
+Burst Sort,333,339,0.00023760
+Burst Sort,333,340,0.00023940
+Burst Sort,333,341,0.00023330
+Burst Sort,333,342,0.00025210
+Burst Sort,333,343,0.00023510
+Burst Sort,333,344,0.00024970
+Burst Sort,333,345,0.00023530
+Burst Sort,333,346,0.00027090
+Burst Sort,333,347,0.00023740
+Burst Sort,333,348,0.00026600
+Burst Sort,333,349,0.00026380
+Burst Sort,333,350,0.00026050
+Burst Sort,333,351,0.00025860
+Burst Sort,333,352,0.00026320
+Burst Sort,333,353,0.00026960
+Burst Sort,333,354,0.00025800
+Burst Sort,333,355,0.00025710
+Burst Sort,333,356,0.00027380
+Burst Sort,333,357,0.00026140
+Burst Sort,333,358,0.00027440
+Burst Sort,333,359,0.00027720
+Burst Sort,333,360,0.00026280
+Burst Sort,333,361,0.00026690
+Burst Sort,333,362,0.00026610
+Burst Sort,333,363,0.00056410
+Burst Sort,333,364,0.00023740
+Burst Sort,333,365,0.00028190
+Burst Sort,333,366,0.00026210
+Burst Sort,333,367,0.00024600
+Burst Sort,333,368,0.00024950
+Burst Sort,333,369,0.00024710
+Burst Sort,333,370,0.00046470
+Burst Sort,333,371,0.00025850
+Burst Sort,333,372,0.00027480
+Burst Sort,333,373,0.00034480
+Burst Sort,333,374,0.00027820
+Burst Sort,333,375,0.00055940
+Burst Sort,333,376,0.00026650
+Burst Sort,333,377,0.00050690
+Burst Sort,333,378,0.00026660
+Burst Sort,333,379,0.00026920
+Burst Sort,333,380,0.00026010
+Burst Sort,333,381,0.00024330
+Burst Sort,333,382,0.00026340
+Burst Sort,333,383,0.00024280
+Burst Sort,333,384,0.00029000
+Burst Sort,333,385,0.00026110
+Burst Sort,333,386,0.00026860
+Burst Sort,333,387,0.00025300
+Burst Sort,333,388,0.00026900
+Burst Sort,333,389,0.00026800
+Burst Sort,333,390,0.00024900
+Burst Sort,333,391,0.00026720
+Burst Sort,333,392,0.00042390
+Burst Sort,333,393,0.00031450
+Burst Sort,333,394,0.00024840
+Burst Sort,333,395,0.00026360
+Burst Sort,333,396,0.00024730
+Burst Sort,333,397,0.00027140
+Burst Sort,333,398,0.00030390
+Burst Sort,333,399,0.00025360
+Burst Sort,333,400,0.00024180
+Burst Sort,333,401,0.00024910
+Burst Sort,333,402,0.00026220
+Burst Sort,333,403,0.00026850
+Burst Sort,333,404,0.00027360
+Burst Sort,333,405,0.00026610
+Burst Sort,333,406,0.00024080
+Burst Sort,333,407,0.00034750
+Burst Sort,333,408,0.00025550
+Burst Sort,333,409,0.00024530
+Burst Sort,333,410,0.00023480
+Burst Sort,333,411,0.00025780
+Burst Sort,333,412,0.00025480
+Burst Sort,333,413,0.00025920
+Burst Sort,333,414,0.00027710
+Burst Sort,333,415,0.00024180
+Burst Sort,333,416,0.00024980
+Burst Sort,333,417,0.00024600
+Burst Sort,333,418,0.00039150
+Burst Sort,333,419,0.00025120
+Burst Sort,333,420,0.00127510
+Burst Sort,333,421,0.00025670
+Burst Sort,333,422,0.00024850
+Burst Sort,333,423,0.00024170
+Burst Sort,333,424,0.00082820
+Burst Sort,333,425,0.00024860
+Burst Sort,333,426,0.00023880
+Burst Sort,333,427,0.00025330
+Burst Sort,333,428,0.00080840
+Burst Sort,333,429,0.00024930
+Burst Sort,333,430,0.00025030
+Burst Sort,333,431,0.00024190
+Burst Sort,333,432,0.00021920
+Burst Sort,333,433,0.00024380
+Burst Sort,333,434,0.00072640
+Burst Sort,333,435,0.00026290
+Burst Sort,333,436,0.00026680
+Burst Sort,333,437,0.00027930
+Burst Sort,333,438,0.00027080
+Burst Sort,333,439,0.00050500
+Burst Sort,333,440,0.00026100
+Burst Sort,333,441,0.00026580
+Burst Sort,333,442,0.00025700
+Burst Sort,333,443,0.00026080
+Burst Sort,333,444,0.00061070
+Burst Sort,333,445,0.00026990
+Burst Sort,333,446,0.00026440
+Burst Sort,333,447,0.00126650
+Burst Sort,333,448,0.00029160
+Burst Sort,333,449,0.00023680
+Burst Sort,333,450,0.00025160
+Burst Sort,333,451,0.00027020
+Burst Sort,333,452,0.00051510
+Burst Sort,333,453,0.00026350
+Burst Sort,333,454,0.00028320
+Burst Sort,333,455,0.00025740
+Burst Sort,333,456,0.00024580
+Burst Sort,333,457,0.00078810
+Burst Sort,333,458,0.00026120
+Burst Sort,333,459,0.00030600
+Burst Sort,333,460,0.00065130
+Burst Sort,333,461,0.00025090
+Burst Sort,333,462,0.00084750
+Burst Sort,333,463,0.00026170
+Burst Sort,333,464,0.00025060
+Burst Sort,333,465,0.00023550
+Burst Sort,333,466,0.00023750
+Burst Sort,333,467,0.00046700
+Burst Sort,333,468,0.00025600
+Burst Sort,333,469,0.00025270
+Burst Sort,333,470,0.00083850
+Burst Sort,333,471,0.00024260
+Burst Sort,333,472,0.00025390
+Burst Sort,333,473,0.00025400
+Burst Sort,333,474,0.00039230
+Burst Sort,333,475,0.00023580
+Burst Sort,333,476,0.00023700
+Burst Sort,333,477,0.00091230
+Burst Sort,333,478,0.00025240
+Burst Sort,333,479,0.00024610
+Burst Sort,333,480,0.00033980
+Burst Sort,333,481,0.00023210
+Burst Sort,333,482,0.00023420
+Burst Sort,333,483,0.00086540
+Burst Sort,333,484,0.00025150
+Burst Sort,333,485,0.00024440
+Burst Sort,333,486,0.00024200
+Burst Sort,333,487,0.00201630
+Burst Sort,333,488,0.00024110
+Burst Sort,333,489,0.00025830
+Burst Sort,333,490,0.00025640
+Burst Sort,333,491,0.00023590
+Burst Sort,333,492,0.00023550
+Burst Sort,333,493,0.00026540
+Burst Sort,333,494,0.00090090
+Burst Sort,333,495,0.00026690
+Burst Sort,333,496,0.00025580
+Burst Sort,333,497,0.00024170
+Burst Sort,333,498,0.00039010
+Burst Sort,333,499,0.00025580
+Burst Sort,333,500,0.00025270
+Cocktail Sort,333,1,0.00883980
+Cocktail Sort,333,2,0.00853380
+Cocktail Sort,333,3,0.00569750
+Cocktail Sort,333,4,0.00877870
+Cocktail Sort,333,5,0.00596140
+Cocktail Sort,333,6,0.00729330
+Cocktail Sort,333,7,0.00573980
+Cocktail Sort,333,8,0.00874940
+Cocktail Sort,333,9,0.00535410
+Cocktail Sort,333,10,0.00990070
+Cocktail Sort,333,11,0.00698870
+Cocktail Sort,333,12,0.00543350
+Cocktail Sort,333,13,0.00567790
+Cocktail Sort,333,14,0.00525990
+Cocktail Sort,333,15,0.00573070
+Cocktail Sort,333,16,0.00700680
+Cocktail Sort,333,17,0.00552030
+Cocktail Sort,333,18,0.00586380
+Cocktail Sort,333,19,0.00602820
+Cocktail Sort,333,20,0.00563460
+Cocktail Sort,333,21,0.00887480
+Cocktail Sort,333,22,0.00551790
+Cocktail Sort,333,23,0.00561110
+Cocktail Sort,333,24,0.00617540
+Cocktail Sort,333,25,0.00698250
+Cocktail Sort,333,26,0.00874280
+Cocktail Sort,333,27,0.00768240
+Cocktail Sort,333,28,0.00560490
+Cocktail Sort,333,29,0.00603240
+Cocktail Sort,333,30,0.00582720
+Cocktail Sort,333,31,0.00689970
+Cocktail Sort,333,32,0.00566490
+Cocktail Sort,333,33,0.00938400
+Cocktail Sort,333,34,0.00611000
+Cocktail Sort,333,35,0.00553700
+Cocktail Sort,333,36,0.00846850
+Cocktail Sort,333,37,0.00592920
+Cocktail Sort,333,38,0.00784620
+Cocktail Sort,333,39,0.00794630
+Cocktail Sort,333,40,0.00565530
+Cocktail Sort,333,41,0.00570210
+Cocktail Sort,333,42,0.00723690
+Cocktail Sort,333,43,0.00713830
+Cocktail Sort,333,44,0.00632040
+Cocktail Sort,333,45,0.00671370
+Cocktail Sort,333,46,0.00665580
+Cocktail Sort,333,47,0.00562820
+Cocktail Sort,333,48,0.00640460
+Cocktail Sort,333,49,0.00667660
+Cocktail Sort,333,50,0.00688670
+Cocktail Sort,333,51,0.00692770
+Cocktail Sort,333,52,0.00574220
+Cocktail Sort,333,53,0.00654890
+Cocktail Sort,333,54,0.00536670
+Cocktail Sort,333,55,0.00846450
+Cocktail Sort,333,56,0.00525850
+Cocktail Sort,333,57,0.00823620
+Cocktail Sort,333,58,0.00639570
+Cocktail Sort,333,59,0.00853330
+Cocktail Sort,333,60,0.00624120
+Cocktail Sort,333,61,0.00766030
+Cocktail Sort,333,62,0.00545810
+Cocktail Sort,333,63,0.00674740
+Cocktail Sort,333,64,0.00541490
+Cocktail Sort,333,65,0.00588930
+Cocktail Sort,333,66,0.00566290
+Cocktail Sort,333,67,0.00578450
+Cocktail Sort,333,68,0.00582360
+Cocktail Sort,333,69,0.00533950
+Cocktail Sort,333,70,0.00643850
+Cocktail Sort,333,71,0.00556910
+Cocktail Sort,333,72,0.00667550
+Cocktail Sort,333,73,0.00586970
+Cocktail Sort,333,74,0.00545940
+Cocktail Sort,333,75,0.00538450
+Cocktail Sort,333,76,0.00562560
+Cocktail Sort,333,77,0.00546110
+Cocktail Sort,333,78,0.00573030
+Cocktail Sort,333,79,0.00542010
+Cocktail Sort,333,80,0.00577350
+Cocktail Sort,333,81,0.00543870
+Cocktail Sort,333,82,0.00835730
+Cocktail Sort,333,83,0.00556660
+Cocktail Sort,333,84,0.00668970
+Cocktail Sort,333,85,0.00734190
+Cocktail Sort,333,86,0.00603520
+Cocktail Sort,333,87,0.00673730
+Cocktail Sort,333,88,0.00694580
+Cocktail Sort,333,89,0.00585760
+Cocktail Sort,333,90,0.00605610
+Cocktail Sort,333,91,0.00596030
+Cocktail Sort,333,92,0.00733600
+Cocktail Sort,333,93,0.00583390
+Cocktail Sort,333,94,0.00740720
+Cocktail Sort,333,95,0.00735820
+Cocktail Sort,333,96,0.00656970
+Cocktail Sort,333,97,0.00572960
+Cocktail Sort,333,98,0.00568150
+Cocktail Sort,333,99,0.00601410
+Cocktail Sort,333,100,0.00558030
+Cocktail Sort,333,101,0.00540210
+Cocktail Sort,333,102,0.00590340
+Cocktail Sort,333,103,0.00737120
+Cocktail Sort,333,104,0.00548870
+Cocktail Sort,333,105,0.00585980
+Cocktail Sort,333,106,0.00502250
+Cocktail Sort,333,107,0.00830880
+Cocktail Sort,333,108,0.00565950
+Cocktail Sort,333,109,0.00545870
+Cocktail Sort,333,110,0.01157780
+Cocktail Sort,333,111,0.00546580
+Cocktail Sort,333,112,0.00548520
+Cocktail Sort,333,113,0.00655410
+Cocktail Sort,333,114,0.00528690
+Cocktail Sort,333,115,0.01074750
+Cocktail Sort,333,116,0.00568530
+Cocktail Sort,333,117,0.00579770
+Cocktail Sort,333,118,0.01306420
+Cocktail Sort,333,119,0.00612660
+Cocktail Sort,333,120,0.00571830
+Cocktail Sort,333,121,0.00873800
+Cocktail Sort,333,122,0.00865340
+Cocktail Sort,333,123,0.00659000
+Cocktail Sort,333,124,0.00688850
+Cocktail Sort,333,125,0.01051120
+Cocktail Sort,333,126,0.00681510
+Cocktail Sort,333,127,0.00573360
+Cocktail Sort,333,128,0.00575010
+Cocktail Sort,333,129,0.00572100
+Cocktail Sort,333,130,0.00560700
+Cocktail Sort,333,131,0.00746310
+Cocktail Sort,333,132,0.00564420
+Cocktail Sort,333,133,0.00551910
+Cocktail Sort,333,134,0.00669470
+Cocktail Sort,333,135,0.00546550
+Cocktail Sort,333,136,0.00791840
+Cocktail Sort,333,137,0.00580640
+Cocktail Sort,333,138,0.00600140
+Cocktail Sort,333,139,0.00499300
+Cocktail Sort,333,140,0.00576550
+Cocktail Sort,333,141,0.00510680
+Cocktail Sort,333,142,0.00546420
+Cocktail Sort,333,143,0.00622200
+Cocktail Sort,333,144,0.00569960
+Cocktail Sort,333,145,0.00617940
+Cocktail Sort,333,146,0.00554350
+Cocktail Sort,333,147,0.00576080
+Cocktail Sort,333,148,0.00562020
+Cocktail Sort,333,149,0.00547430
+Cocktail Sort,333,150,0.00550720
+Cocktail Sort,333,151,0.00640950
+Cocktail Sort,333,152,0.00566250
+Cocktail Sort,333,153,0.00565400
+Cocktail Sort,333,154,0.00571890
+Cocktail Sort,333,155,0.00570940
+Cocktail Sort,333,156,0.00586010
+Cocktail Sort,333,157,0.00549680
+Cocktail Sort,333,158,0.00572780
+Cocktail Sort,333,159,0.00545450
+Cocktail Sort,333,160,0.00534230
+Cocktail Sort,333,161,0.00548460
+Cocktail Sort,333,162,0.00541760
+Cocktail Sort,333,163,0.00532700
+Cocktail Sort,333,164,0.00790010
+Cocktail Sort,333,165,0.00587250
+Cocktail Sort,333,166,0.00547720
+Cocktail Sort,333,167,0.00553600
+Cocktail Sort,333,168,0.00751630
+Cocktail Sort,333,169,0.00553850
+Cocktail Sort,333,170,0.00563510
+Cocktail Sort,333,171,0.00971400
+Cocktail Sort,333,172,0.00604610
+Cocktail Sort,333,173,0.00878160
+Cocktail Sort,333,174,0.00830260
+Cocktail Sort,333,175,0.00631190
+Cocktail Sort,333,176,0.00728480
+Cocktail Sort,333,177,0.00848060
+Cocktail Sort,333,178,0.01038220
+Cocktail Sort,333,179,0.00648430
+Cocktail Sort,333,180,0.00768860
+Cocktail Sort,333,181,0.00570980
+Cocktail Sort,333,182,0.00799010
+Cocktail Sort,333,183,0.00546680
+Cocktail Sort,333,184,0.00566140
+Cocktail Sort,333,185,0.00700480
+Cocktail Sort,333,186,0.00623370
+Cocktail Sort,333,187,0.00557860
+Cocktail Sort,333,188,0.00572040
+Cocktail Sort,333,189,0.00602600
+Cocktail Sort,333,190,0.00540810
+Cocktail Sort,333,191,0.00533480
+Cocktail Sort,333,192,0.00633670
+Cocktail Sort,333,193,0.00587150
+Cocktail Sort,333,194,0.00600730
+Cocktail Sort,333,195,0.00599140
+Cocktail Sort,333,196,0.00540560
+Cocktail Sort,333,197,0.00523150
+Cocktail Sort,333,198,0.00628610
+Cocktail Sort,333,199,0.00546060
+Cocktail Sort,333,200,0.00537520
+Cocktail Sort,333,201,0.00589660
+Cocktail Sort,333,202,0.00548050
+Cocktail Sort,333,203,0.00552130
+Cocktail Sort,333,204,0.00552600
+Cocktail Sort,333,205,0.00583950
+Cocktail Sort,333,206,0.00561200
+Cocktail Sort,333,207,0.00548870
+Cocktail Sort,333,208,0.00560550
+Cocktail Sort,333,209,0.00588880
+Cocktail Sort,333,210,0.00652600
+Cocktail Sort,333,211,0.00526990
+Cocktail Sort,333,212,0.00594820
+Cocktail Sort,333,213,0.00526500
+Cocktail Sort,333,214,0.00564550
+Cocktail Sort,333,215,0.00559590
+Cocktail Sort,333,216,0.00767980
+Cocktail Sort,333,217,0.00544790
+Cocktail Sort,333,218,0.00556860
+Cocktail Sort,333,219,0.00713180
+Cocktail Sort,333,220,0.00546250
+Cocktail Sort,333,221,0.00652400
+Cocktail Sort,333,222,0.00530810
+Cocktail Sort,333,223,0.00560230
+Cocktail Sort,333,224,0.00553510
+Cocktail Sort,333,225,0.00592370
+Cocktail Sort,333,226,0.00551470
+Cocktail Sort,333,227,0.00549690
+Cocktail Sort,333,228,0.00590530
+Cocktail Sort,333,229,0.00589900
+Cocktail Sort,333,230,0.00571680
+Cocktail Sort,333,231,0.00550480
+Cocktail Sort,333,232,0.00560050
+Cocktail Sort,333,233,0.00592710
+Cocktail Sort,333,234,0.00587330
+Cocktail Sort,333,235,0.00640150
+Cocktail Sort,333,236,0.00568510
+Cocktail Sort,333,237,0.00540500
+Cocktail Sort,333,238,0.00794440
+Cocktail Sort,333,239,0.00534370
+Cocktail Sort,333,240,0.00682080
+Cocktail Sort,333,241,0.00546440
+Cocktail Sort,333,242,0.00654910
+Cocktail Sort,333,243,0.00519910
+Cocktail Sort,333,244,0.00533440
+Cocktail Sort,333,245,0.00705940
+Cocktail Sort,333,246,0.00507400
+Cocktail Sort,333,247,0.00544500
+Cocktail Sort,333,248,0.00530060
+Cocktail Sort,333,249,0.00627100
+Cocktail Sort,333,250,0.00551460
+Cocktail Sort,333,251,0.00563330
+Cocktail Sort,333,252,0.00568750
+Cocktail Sort,333,253,0.00556660
+Cocktail Sort,333,254,0.00599420
+Cocktail Sort,333,255,0.00526250
+Cocktail Sort,333,256,0.00603510
+Cocktail Sort,333,257,0.00522970
+Cocktail Sort,333,258,0.00552620
+Cocktail Sort,333,259,0.00563950
+Cocktail Sort,333,260,0.00571410
+Cocktail Sort,333,261,0.00561840
+Cocktail Sort,333,262,0.00493640
+Cocktail Sort,333,263,0.00559300
+Cocktail Sort,333,264,0.00543180
+Cocktail Sort,333,265,0.00549280
+Cocktail Sort,333,266,0.00565700
+Cocktail Sort,333,267,0.00546500
+Cocktail Sort,333,268,0.00557480
+Cocktail Sort,333,269,0.00552680
+Cocktail Sort,333,270,0.00490200
+Cocktail Sort,333,271,0.00567970
+Cocktail Sort,333,272,0.00518290
+Cocktail Sort,333,273,0.00539070
+Cocktail Sort,333,274,0.00509420
+Cocktail Sort,333,275,0.00547540
+Cocktail Sort,333,276,0.00541600
+Cocktail Sort,333,277,0.00562640
+Cocktail Sort,333,278,0.00594870
+Cocktail Sort,333,279,0.00547720
+Cocktail Sort,333,280,0.00592020
+Cocktail Sort,333,281,0.00723210
+Cocktail Sort,333,282,0.00543260
+Cocktail Sort,333,283,0.00623330
+Cocktail Sort,333,284,0.00603040
+Cocktail Sort,333,285,0.00555300
+Cocktail Sort,333,286,0.00657160
+Cocktail Sort,333,287,0.00528950
+Cocktail Sort,333,288,0.00616050
+Cocktail Sort,333,289,0.00568900
+Cocktail Sort,333,290,0.00611180
+Cocktail Sort,333,291,0.00559740
+Cocktail Sort,333,292,0.00579630
+Cocktail Sort,333,293,0.01367710
+Cocktail Sort,333,294,0.00605210
+Cocktail Sort,333,295,0.00771740
+Cocktail Sort,333,296,0.00591330
+Cocktail Sort,333,297,0.00545070
+Cocktail Sort,333,298,0.00574840
+Cocktail Sort,333,299,0.00665680
+Cocktail Sort,333,300,0.00536050
+Cocktail Sort,333,301,0.00689230
+Cocktail Sort,333,302,0.00617930
+Cocktail Sort,333,303,0.00574920
+Cocktail Sort,333,304,0.00592220
+Cocktail Sort,333,305,0.00552950
+Cocktail Sort,333,306,0.00571330
+Cocktail Sort,333,307,0.00579020
+Cocktail Sort,333,308,0.00597610
+Cocktail Sort,333,309,0.00544440
+Cocktail Sort,333,310,0.00557630
+Cocktail Sort,333,311,0.00543580
+Cocktail Sort,333,312,0.00571370
+Cocktail Sort,333,313,0.00566880
+Cocktail Sort,333,314,0.00549820
+Cocktail Sort,333,315,0.00556490
+Cocktail Sort,333,316,0.00557630
+Cocktail Sort,333,317,0.00538250
+Cocktail Sort,333,318,0.00577210
+Cocktail Sort,333,319,0.00613080
+Cocktail Sort,333,320,0.00561620
+Cocktail Sort,333,321,0.00598230
+Cocktail Sort,333,322,0.00540380
+Cocktail Sort,333,323,0.00541610
+Cocktail Sort,333,324,0.00567820
+Cocktail Sort,333,325,0.00535270
+Cocktail Sort,333,326,0.00549740
+Cocktail Sort,333,327,0.00509460
+Cocktail Sort,333,328,0.00558160
+Cocktail Sort,333,329,0.00570210
+Cocktail Sort,333,330,0.00554220
+Cocktail Sort,333,331,0.00566010
+Cocktail Sort,333,332,0.00549780
+Cocktail Sort,333,333,0.00555850
+Cocktail Sort,333,334,0.00564090
+Cocktail Sort,333,335,0.00560420
+Cocktail Sort,333,336,0.00528480
+Cocktail Sort,333,337,0.00572340
+Cocktail Sort,333,338,0.00542060
+Cocktail Sort,333,339,0.00541360
+Cocktail Sort,333,340,0.00554800
+Cocktail Sort,333,341,0.00551560
+Cocktail Sort,333,342,0.00523570
+Cocktail Sort,333,343,0.00526270
+Cocktail Sort,333,344,0.00542630
+Cocktail Sort,333,345,0.00564580
+Cocktail Sort,333,346,0.00567530
+Cocktail Sort,333,347,0.00544820
+Cocktail Sort,333,348,0.00564840
+Cocktail Sort,333,349,0.00543820
+Cocktail Sort,333,350,0.00534320
+Cocktail Sort,333,351,0.00518000
+Cocktail Sort,333,352,0.00547160
+Cocktail Sort,333,353,0.00533520
+Cocktail Sort,333,354,0.00562550
+Cocktail Sort,333,355,0.00532200
+Cocktail Sort,333,356,0.00546580
+Cocktail Sort,333,357,0.00560710
+Cocktail Sort,333,358,0.00562320
+Cocktail Sort,333,359,0.00571350
+Cocktail Sort,333,360,0.00539990
+Cocktail Sort,333,361,0.00600150
+Cocktail Sort,333,362,0.00563360
+Cocktail Sort,333,363,0.00592830
+Cocktail Sort,333,364,0.00610340
+Cocktail Sort,333,365,0.00584570
+Cocktail Sort,333,366,0.00549980
+Cocktail Sort,333,367,0.00538050
+Cocktail Sort,333,368,0.00524940
+Cocktail Sort,333,369,0.00564050
+Cocktail Sort,333,370,0.00667340
+Cocktail Sort,333,371,0.00577390
+Cocktail Sort,333,372,0.00635230
+Cocktail Sort,333,373,0.00564470
+Cocktail Sort,333,374,0.00547510
+Cocktail Sort,333,375,0.00590290
+Cocktail Sort,333,376,0.00538180
+Cocktail Sort,333,377,0.00552080
+Cocktail Sort,333,378,0.00515530
+Cocktail Sort,333,379,0.00530440
+Cocktail Sort,333,380,0.00539020
+Cocktail Sort,333,381,0.00558540
+Cocktail Sort,333,382,0.00536610
+Cocktail Sort,333,383,0.00514360
+Cocktail Sort,333,384,0.00574520
+Cocktail Sort,333,385,0.00534490
+Cocktail Sort,333,386,0.00507640
+Cocktail Sort,333,387,0.00616240
+Cocktail Sort,333,388,0.00523510
+Cocktail Sort,333,389,0.00569180
+Cocktail Sort,333,390,0.00584440
+Cocktail Sort,333,391,0.00526620
+Cocktail Sort,333,392,0.00554080
+Cocktail Sort,333,393,0.00573050
+Cocktail Sort,333,394,0.00516550
+Cocktail Sort,333,395,0.00557600
+Cocktail Sort,333,396,0.00551760
+Cocktail Sort,333,397,0.00551500
+Cocktail Sort,333,398,0.00569310
+Cocktail Sort,333,399,0.00565800
+Cocktail Sort,333,400,0.00505060
+Cocktail Sort,333,401,0.00543880
+Cocktail Sort,333,402,0.00570460
+Cocktail Sort,333,403,0.00545990
+Cocktail Sort,333,404,0.00545910
+Cocktail Sort,333,405,0.00532670
+Cocktail Sort,333,406,0.00560790
+Cocktail Sort,333,407,0.00612210
+Cocktail Sort,333,408,0.00987180
+Cocktail Sort,333,409,0.00556290
+Cocktail Sort,333,410,0.00533270
+Cocktail Sort,333,411,0.00545970
+Cocktail Sort,333,412,0.00529870
+Cocktail Sort,333,413,0.00518150
+Cocktail Sort,333,414,0.00579250
+Cocktail Sort,333,415,0.00581550
+Cocktail Sort,333,416,0.00594620
+Cocktail Sort,333,417,0.00552010
+Cocktail Sort,333,418,0.00567570
+Cocktail Sort,333,419,0.00539940
+Cocktail Sort,333,420,0.00537650
+Cocktail Sort,333,421,0.00524450
+Cocktail Sort,333,422,0.00632730
+Cocktail Sort,333,423,0.00667770
+Cocktail Sort,333,424,0.00560260
+Cocktail Sort,333,425,0.00656440
+Cocktail Sort,333,426,0.00664750
+Cocktail Sort,333,427,0.00620090
+Cocktail Sort,333,428,0.00563160
+Cocktail Sort,333,429,0.00761590
+Cocktail Sort,333,430,0.00565170
+Cocktail Sort,333,431,0.00530190
+Cocktail Sort,333,432,0.00604580
+Cocktail Sort,333,433,0.00614060
+Cocktail Sort,333,434,0.00538460
+Cocktail Sort,333,435,0.00548710
+Cocktail Sort,333,436,0.00604810
+Cocktail Sort,333,437,0.00588070
+Cocktail Sort,333,438,0.00581900
+Cocktail Sort,333,439,0.00568820
+Cocktail Sort,333,440,0.00540210
+Cocktail Sort,333,441,0.00586050
+Cocktail Sort,333,442,0.00540140
+Cocktail Sort,333,443,0.00722450
+Cocktail Sort,333,444,0.00583430
+Cocktail Sort,333,445,0.00617700
+Cocktail Sort,333,446,0.00563560
+Cocktail Sort,333,447,0.00549030
+Cocktail Sort,333,448,0.00579110
+Cocktail Sort,333,449,0.00533170
+Cocktail Sort,333,450,0.00529760
+Cocktail Sort,333,451,0.00570100
+Cocktail Sort,333,452,0.00546860
+Cocktail Sort,333,453,0.00538650
+Cocktail Sort,333,454,0.00470540
+Cocktail Sort,333,455,0.00544130
+Cocktail Sort,333,456,0.00553550
+Cocktail Sort,333,457,0.00508290
+Cocktail Sort,333,458,0.00538100
+Cocktail Sort,333,459,0.00570310
+Cocktail Sort,333,460,0.00557310
+Cocktail Sort,333,461,0.00542630
+Cocktail Sort,333,462,0.00545820
+Cocktail Sort,333,463,0.00534780
+Cocktail Sort,333,464,0.00559750
+Cocktail Sort,333,465,0.00576220
+Cocktail Sort,333,466,0.00569130
+Cocktail Sort,333,467,0.00485440
+Cocktail Sort,333,468,0.00581680
+Cocktail Sort,333,469,0.00586420
+Cocktail Sort,333,470,0.00558880
+Cocktail Sort,333,471,0.00526320
+Cocktail Sort,333,472,0.00550530
+Cocktail Sort,333,473,0.00577550
+Cocktail Sort,333,474,0.00549200
+Cocktail Sort,333,475,0.00513950
+Cocktail Sort,333,476,0.00552890
+Cocktail Sort,333,477,0.00549540
+Cocktail Sort,333,478,0.00569940
+Cocktail Sort,333,479,0.00531830
+Cocktail Sort,333,480,0.00551340
+Cocktail Sort,333,481,0.00509590
+Cocktail Sort,333,482,0.00551160
+Cocktail Sort,333,483,0.00541010
+Cocktail Sort,333,484,0.00550110
+Cocktail Sort,333,485,0.00747670
+Cocktail Sort,333,486,0.00536810
+Cocktail Sort,333,487,0.00577220
+Cocktail Sort,333,488,0.00568530
+Cocktail Sort,333,489,0.00610790
+Cocktail Sort,333,490,0.00539630
+Cocktail Sort,333,491,0.00546450
+Cocktail Sort,333,492,0.00638700
+Cocktail Sort,333,493,0.00675130
+Cocktail Sort,333,494,0.00744110
+Cocktail Sort,333,495,0.00569020
+Cocktail Sort,333,496,0.00544300
+Cocktail Sort,333,497,0.00524710
+Cocktail Sort,333,498,0.00587150
+Cocktail Sort,333,499,0.00566360
+Cocktail Sort,333,500,0.00544640
+Comb Sort,333,1,0.00054870
+Comb Sort,333,2,0.00054180
+Comb Sort,333,3,0.00056990
+Comb Sort,333,4,0.00057590
+Comb Sort,333,5,0.00055330
+Comb Sort,333,6,0.00059290
+Comb Sort,333,7,0.00054670
+Comb Sort,333,8,0.00055530
+Comb Sort,333,9,0.00056040
+Comb Sort,333,10,0.00055290
+Comb Sort,333,11,0.00060290
+Comb Sort,333,12,0.00053160
+Comb Sort,333,13,0.00054380
+Comb Sort,333,14,0.00052350
+Comb Sort,333,15,0.00059440
+Comb Sort,333,16,0.00056150
+Comb Sort,333,17,0.00058440
+Comb Sort,333,18,0.00053880
+Comb Sort,333,19,0.00056070
+Comb Sort,333,20,0.00054930
+Comb Sort,333,21,0.00059200
+Comb Sort,333,22,0.00051630
+Comb Sort,333,23,0.00055480
+Comb Sort,333,24,0.00061120
+Comb Sort,333,25,0.00060820
+Comb Sort,333,26,0.00059100
+Comb Sort,333,27,0.00056670
+Comb Sort,333,28,0.00073560
+Comb Sort,333,29,0.00058280
+Comb Sort,333,30,0.00092040
+Comb Sort,333,31,0.00053820
+Comb Sort,333,32,0.00175930
+Comb Sort,333,33,0.00052560
+Comb Sort,333,34,0.00058830
+Comb Sort,333,35,0.00052090
+Comb Sort,333,36,0.00060680
+Comb Sort,333,37,0.00053660
+Comb Sort,333,38,0.00053680
+Comb Sort,333,39,0.00057040
+Comb Sort,333,40,0.00056750
+Comb Sort,333,41,0.00076690
+Comb Sort,333,42,0.00057950
+Comb Sort,333,43,0.00063010
+Comb Sort,333,44,0.00061410
+Comb Sort,333,45,0.00057130
+Comb Sort,333,46,0.00059430
+Comb Sort,333,47,0.00064590
+Comb Sort,333,48,0.00059950
+Comb Sort,333,49,0.00075680
+Comb Sort,333,50,0.00054510
+Comb Sort,333,51,0.00054220
+Comb Sort,333,52,0.00069080
+Comb Sort,333,53,0.00055250
+Comb Sort,333,54,0.00058420
+Comb Sort,333,55,0.00056620
+Comb Sort,333,56,0.00070100
+Comb Sort,333,57,0.00059510
+Comb Sort,333,58,0.00055500
+Comb Sort,333,59,0.00073320
+Comb Sort,333,60,0.00076200
+Comb Sort,333,61,0.00066100
+Comb Sort,333,62,0.00076080
+Comb Sort,333,63,0.00129830
+Comb Sort,333,64,0.00139560
+Comb Sort,333,65,0.00059240
+Comb Sort,333,66,0.00053450
+Comb Sort,333,67,0.00054510
+Comb Sort,333,68,0.00084080
+Comb Sort,333,69,0.00076550
+Comb Sort,333,70,0.00064930
+Comb Sort,333,71,0.00052790
+Comb Sort,333,72,0.00057980
+Comb Sort,333,73,0.00055360
+Comb Sort,333,74,0.00065360
+Comb Sort,333,75,0.00058310
+Comb Sort,333,76,0.00050640
+Comb Sort,333,77,0.00066060
+Comb Sort,333,78,0.00055190
+Comb Sort,333,79,0.00066890
+Comb Sort,333,80,0.00057640
+Comb Sort,333,81,0.00056860
+Comb Sort,333,82,0.00056760
+Comb Sort,333,83,0.00068690
+Comb Sort,333,84,0.00062840
+Comb Sort,333,85,0.00084170
+Comb Sort,333,86,0.00054400
+Comb Sort,333,87,0.00055910
+Comb Sort,333,88,0.00084340
+Comb Sort,333,89,0.00054960
+Comb Sort,333,90,0.00072650
+Comb Sort,333,91,0.00061670
+Comb Sort,333,92,0.00055410
+Comb Sort,333,93,0.00061840
+Comb Sort,333,94,0.00054720
+Comb Sort,333,95,0.00062820
+Comb Sort,333,96,0.00054000
+Comb Sort,333,97,0.00053110
+Comb Sort,333,98,0.00054550
+Comb Sort,333,99,0.00055120
+Comb Sort,333,100,0.00052730
+Comb Sort,333,101,0.00055960
+Comb Sort,333,102,0.00054200
+Comb Sort,333,103,0.00053770
+Comb Sort,333,104,0.00058560
+Comb Sort,333,105,0.00058460
+Comb Sort,333,106,0.00059480
+Comb Sort,333,107,0.00058090
+Comb Sort,333,108,0.00055710
+Comb Sort,333,109,0.00072030
+Comb Sort,333,110,0.00055320
+Comb Sort,333,111,0.00084590
+Comb Sort,333,112,0.00055960
+Comb Sort,333,113,0.00075640
+Comb Sort,333,114,0.00056980
+Comb Sort,333,115,0.00058530
+Comb Sort,333,116,0.00057860
+Comb Sort,333,117,0.00056850
+Comb Sort,333,118,0.00072980
+Comb Sort,333,119,0.00059420
+Comb Sort,333,120,0.00052490
+Comb Sort,333,121,0.00054120
+Comb Sort,333,122,0.00056180
+Comb Sort,333,123,0.00057300
+Comb Sort,333,124,0.00060730
+Comb Sort,333,125,0.00060330
+Comb Sort,333,126,0.00056480
+Comb Sort,333,127,0.00061270
+Comb Sort,333,128,0.00060370
+Comb Sort,333,129,0.00060390
+Comb Sort,333,130,0.00060100
+Comb Sort,333,131,0.00057790
+Comb Sort,333,132,0.00054470
+Comb Sort,333,133,0.00056950
+Comb Sort,333,134,0.00056780
+Comb Sort,333,135,0.00054550
+Comb Sort,333,136,0.00058600
+Comb Sort,333,137,0.00058200
+Comb Sort,333,138,0.00056870
+Comb Sort,333,139,0.00059890
+Comb Sort,333,140,0.00058610
+Comb Sort,333,141,0.00056870
+Comb Sort,333,142,0.00056810
+Comb Sort,333,143,0.00056890
+Comb Sort,333,144,0.00054920
+Comb Sort,333,145,0.00055500
+Comb Sort,333,146,0.00056630
+Comb Sort,333,147,0.00053790
+Comb Sort,333,148,0.00057450
+Comb Sort,333,149,0.00056590
+Comb Sort,333,150,0.00058550
+Comb Sort,333,151,0.00053770
+Comb Sort,333,152,0.00057620
+Comb Sort,333,153,0.00065030
+Comb Sort,333,154,0.00062530
+Comb Sort,333,155,0.00067150
+Comb Sort,333,156,0.00057190
+Comb Sort,333,157,0.00055370
+Comb Sort,333,158,0.00058650
+Comb Sort,333,159,0.00060310
+Comb Sort,333,160,0.00060550
+Comb Sort,333,161,0.00057720
+Comb Sort,333,162,0.00058560
+Comb Sort,333,163,0.00054550
+Comb Sort,333,164,0.00056570
+Comb Sort,333,165,0.00057690
+Comb Sort,333,166,0.00058250
+Comb Sort,333,167,0.00056510
+Comb Sort,333,168,0.00055540
+Comb Sort,333,169,0.00055400
+Comb Sort,333,170,0.00055870
+Comb Sort,333,171,0.00056730
+Comb Sort,333,172,0.00058940
+Comb Sort,333,173,0.00054930
+Comb Sort,333,174,0.00063060
+Comb Sort,333,175,0.00055260
+Comb Sort,333,176,0.00063670
+Comb Sort,333,177,0.00059910
+Comb Sort,333,178,0.00064750
+Comb Sort,333,179,0.00059680
+Comb Sort,333,180,0.00054230
+Comb Sort,333,181,0.00058630
+Comb Sort,333,182,0.00056300
+Comb Sort,333,183,0.00058270
+Comb Sort,333,184,0.00058220
+Comb Sort,333,185,0.00062750
+Comb Sort,333,186,0.00054790
+Comb Sort,333,187,0.00064580
+Comb Sort,333,188,0.00055690
+Comb Sort,333,189,0.00074740
+Comb Sort,333,190,0.00052930
+Comb Sort,333,191,0.00061760
+Comb Sort,333,192,0.00053680
+Comb Sort,333,193,0.00060160
+Comb Sort,333,194,0.00071260
+Comb Sort,333,195,0.00057730
+Comb Sort,333,196,0.00063800
+Comb Sort,333,197,0.00055780
+Comb Sort,333,198,0.00069980
+Comb Sort,333,199,0.00054250
+Comb Sort,333,200,0.00054290
+Comb Sort,333,201,0.00112300
+Comb Sort,333,202,0.00058690
+Comb Sort,333,203,0.00055790
+Comb Sort,333,204,0.00071020
+Comb Sort,333,205,0.00092380
+Comb Sort,333,206,0.00108110
+Comb Sort,333,207,0.00058260
+Comb Sort,333,208,0.00056880
+Comb Sort,333,209,0.00156770
+Comb Sort,333,210,0.00052290
+Comb Sort,333,211,0.00053920
+Comb Sort,333,212,0.00156550
+Comb Sort,333,213,0.00053500
+Comb Sort,333,214,0.00069790
+Comb Sort,333,215,0.00058890
+Comb Sort,333,216,0.00074330
+Comb Sort,333,217,0.00055270
+Comb Sort,333,218,0.00057020
+Comb Sort,333,219,0.00073920
+Comb Sort,333,220,0.00054040
+Comb Sort,333,221,0.00054100
+Comb Sort,333,222,0.00074080
+Comb Sort,333,223,0.00059850
+Comb Sort,333,224,0.00055360
+Comb Sort,333,225,0.00060150
+Comb Sort,333,226,0.00055490
+Comb Sort,333,227,0.00056660
+Comb Sort,333,228,0.00074870
+Comb Sort,333,229,0.00054200
+Comb Sort,333,230,0.00056030
+Comb Sort,333,231,0.00054230
+Comb Sort,333,232,0.00056550
+Comb Sort,333,233,0.00055370
+Comb Sort,333,234,0.00055600
+Comb Sort,333,235,0.00058880
+Comb Sort,333,236,0.00054640
+Comb Sort,333,237,0.00055310
+Comb Sort,333,238,0.00057650
+Comb Sort,333,239,0.00087330
+Comb Sort,333,240,0.00058110
+Comb Sort,333,241,0.00053490
+Comb Sort,333,242,0.00055070
+Comb Sort,333,243,0.00054320
+Comb Sort,333,244,0.00121380
+Comb Sort,333,245,0.00239990
+Comb Sort,333,246,0.00063360
+Comb Sort,333,247,0.00057420
+Comb Sort,333,248,0.00054710
+Comb Sort,333,249,0.00065420
+Comb Sort,333,250,0.00083580
+Comb Sort,333,251,0.00065390
+Comb Sort,333,252,0.00065230
+Comb Sort,333,253,0.00065200
+Comb Sort,333,254,0.00075740
+Comb Sort,333,255,0.00072130
+Comb Sort,333,256,0.00091540
+Comb Sort,333,257,0.00054490
+Comb Sort,333,258,0.00062580
+Comb Sort,333,259,0.00057330
+Comb Sort,333,260,0.00066160
+Comb Sort,333,261,0.00054690
+Comb Sort,333,262,0.00057080
+Comb Sort,333,263,0.00063970
+Comb Sort,333,264,0.00056760
+Comb Sort,333,265,0.00066160
+Comb Sort,333,266,0.00056070
+Comb Sort,333,267,0.00065680
+Comb Sort,333,268,0.00072380
+Comb Sort,333,269,0.00065540
+Comb Sort,333,270,0.00060970
+Comb Sort,333,271,0.00063810
+Comb Sort,333,272,0.00345230
+Comb Sort,333,273,0.00053340
+Comb Sort,333,274,0.00053040
+Comb Sort,333,275,0.00051190
+Comb Sort,333,276,0.00056210
+Comb Sort,333,277,0.00051760
+Comb Sort,333,278,0.00065620
+Comb Sort,333,279,0.00051490
+Comb Sort,333,280,0.00051270
+Comb Sort,333,281,0.00074590
+Comb Sort,333,282,0.00056230
+Comb Sort,333,283,0.00089180
+Comb Sort,333,284,0.00052320
+Comb Sort,333,285,0.00052520
+Comb Sort,333,286,0.00054400
+Comb Sort,333,287,0.00052910
+Comb Sort,333,288,0.00079140
+Comb Sort,333,289,0.00054820
+Comb Sort,333,290,0.00051960
+Comb Sort,333,291,0.00095500
+Comb Sort,333,292,0.00083710
+Comb Sort,333,293,0.00060840
+Comb Sort,333,294,0.00054940
+Comb Sort,333,295,0.00059230
+Comb Sort,333,296,0.00056150
+Comb Sort,333,297,0.00052640
+Comb Sort,333,298,0.00057390
+Comb Sort,333,299,0.00056100
+Comb Sort,333,300,0.00055270
+Comb Sort,333,301,0.00056170
+Comb Sort,333,302,0.00055280
+Comb Sort,333,303,0.00099570
+Comb Sort,333,304,0.00131580
+Comb Sort,333,305,0.00052880
+Comb Sort,333,306,0.00057570
+Comb Sort,333,307,0.00104350
+Comb Sort,333,308,0.00054800
+Comb Sort,333,309,0.00052540
+Comb Sort,333,310,0.00058070
+Comb Sort,333,311,0.00053540
+Comb Sort,333,312,0.00137100
+Comb Sort,333,313,0.00057640
+Comb Sort,333,314,0.00052890
+Comb Sort,333,315,0.00059900
+Comb Sort,333,316,0.00058960
+Comb Sort,333,317,0.00054220
+Comb Sort,333,318,0.00056020
+Comb Sort,333,319,0.00057970
+Comb Sort,333,320,0.00059340
+Comb Sort,333,321,0.00056230
+Comb Sort,333,322,0.00055320
+Comb Sort,333,323,0.00057110
+Comb Sort,333,324,0.00057520
+Comb Sort,333,325,0.00055770
+Comb Sort,333,326,0.00096970
+Comb Sort,333,327,0.00054510
+Comb Sort,333,328,0.00056580
+Comb Sort,333,329,0.00057630
+Comb Sort,333,330,0.00053130
+Comb Sort,333,331,0.00103070
+Comb Sort,333,332,0.00056420
+Comb Sort,333,333,0.00058080
+Comb Sort,333,334,0.00055010
+Comb Sort,333,335,0.00059740
+Comb Sort,333,336,0.00127330
+Comb Sort,333,337,0.00057390
+Comb Sort,333,338,0.00058040
+Comb Sort,333,339,0.00055790
+Comb Sort,333,340,0.00058010
+Comb Sort,333,341,0.00052110
+Comb Sort,333,342,0.00055040
+Comb Sort,333,343,0.00055110
+Comb Sort,333,344,0.00053000
+Comb Sort,333,345,0.00052250
+Comb Sort,333,346,0.00057430
+Comb Sort,333,347,0.00055140
+Comb Sort,333,348,0.00146830
+Comb Sort,333,349,0.00053070
+Comb Sort,333,350,0.00052320
+Comb Sort,333,351,0.00055330
+Comb Sort,333,352,0.00057680
+Comb Sort,333,353,0.00054200
+Comb Sort,333,354,0.00060440
+Comb Sort,333,355,0.00056690
+Comb Sort,333,356,0.00054910
+Comb Sort,333,357,0.00052640
+Comb Sort,333,358,0.00098640
+Comb Sort,333,359,0.00054290
+Comb Sort,333,360,0.00055740
+Comb Sort,333,361,0.00060040
+Comb Sort,333,362,0.00053380
+Comb Sort,333,363,0.00058490
+Comb Sort,333,364,0.00053750
+Comb Sort,333,365,0.00055730
+Comb Sort,333,366,0.00052170
+Comb Sort,333,367,0.00065060
+Comb Sort,333,368,0.00056170
+Comb Sort,333,369,0.00064470
+Comb Sort,333,370,0.00054100
+Comb Sort,333,371,0.00065500
+Comb Sort,333,372,0.00058850
+Comb Sort,333,373,0.00061790
+Comb Sort,333,374,0.00057770
+Comb Sort,333,375,0.00056500
+Comb Sort,333,376,0.00056710
+Comb Sort,333,377,0.00055200
+Comb Sort,333,378,0.00057030
+Comb Sort,333,379,0.00067770
+Comb Sort,333,380,0.00059610
+Comb Sort,333,381,0.00060430
+Comb Sort,333,382,0.00059740
+Comb Sort,333,383,0.00055460
+Comb Sort,333,384,0.00056580
+Comb Sort,333,385,0.00053880
+Comb Sort,333,386,0.00056900
+Comb Sort,333,387,0.00057010
+Comb Sort,333,388,0.00053290
+Comb Sort,333,389,0.00055080
+Comb Sort,333,390,0.00057020
+Comb Sort,333,391,0.00056330
+Comb Sort,333,392,0.00056110
+Comb Sort,333,393,0.00054340
+Comb Sort,333,394,0.00055180
+Comb Sort,333,395,0.00055430
+Comb Sort,333,396,0.00059810
+Comb Sort,333,397,0.00056440
+Comb Sort,333,398,0.00056610
+Comb Sort,333,399,0.00052980
+Comb Sort,333,400,0.00062960
+Comb Sort,333,401,0.00056800
+Comb Sort,333,402,0.00057290
+Comb Sort,333,403,0.00061280
+Comb Sort,333,404,0.00061020
+Comb Sort,333,405,0.00059180
+Comb Sort,333,406,0.00054280
+Comb Sort,333,407,0.00058560
+Comb Sort,333,408,0.00054810
+Comb Sort,333,409,0.00058830
+Comb Sort,333,410,0.00056950
+Comb Sort,333,411,0.00058190
+Comb Sort,333,412,0.00059020
+Comb Sort,333,413,0.00057280
+Comb Sort,333,414,0.00056460
+Comb Sort,333,415,0.00054450
+Comb Sort,333,416,0.00061050
+Comb Sort,333,417,0.00061660
+Comb Sort,333,418,0.00058530
+Comb Sort,333,419,0.00057720
+Comb Sort,333,420,0.00057440
+Comb Sort,333,421,0.00060390
+Comb Sort,333,422,0.00055530
+Comb Sort,333,423,0.00055130
+Comb Sort,333,424,0.00058090
+Comb Sort,333,425,0.00055520
+Comb Sort,333,426,0.00059950
+Comb Sort,333,427,0.00057100
+Comb Sort,333,428,0.00056350
+Comb Sort,333,429,0.00058250
+Comb Sort,333,430,0.00057280
+Comb Sort,333,431,0.00053570
+Comb Sort,333,432,0.00056690
+Comb Sort,333,433,0.00054040
+Comb Sort,333,434,0.00058000
+Comb Sort,333,435,0.00064780
+Comb Sort,333,436,0.00056410
+Comb Sort,333,437,0.00055290
+Comb Sort,333,438,0.00062060
+Comb Sort,333,439,0.00054820
+Comb Sort,333,440,0.00059830
+Comb Sort,333,441,0.00062110
+Comb Sort,333,442,0.00057930
+Comb Sort,333,443,0.00057570
+Comb Sort,333,444,0.00054260
+Comb Sort,333,445,0.00054090
+Comb Sort,333,446,0.00054840
+Comb Sort,333,447,0.00112390
+Comb Sort,333,448,0.00058140
+Comb Sort,333,449,0.00056870
+Comb Sort,333,450,0.00058630
+Comb Sort,333,451,0.00066390
+Comb Sort,333,452,0.00056830
+Comb Sort,333,453,0.00058850
+Comb Sort,333,454,0.00055940
+Comb Sort,333,455,0.00060010
+Comb Sort,333,456,0.00059720
+Comb Sort,333,457,0.00055740
+Comb Sort,333,458,0.00052190
+Comb Sort,333,459,0.00053440
+Comb Sort,333,460,0.00057130
+Comb Sort,333,461,0.00053230
+Comb Sort,333,462,0.00056220
+Comb Sort,333,463,0.00054470
+Comb Sort,333,464,0.00052250
+Comb Sort,333,465,0.00057180
+Comb Sort,333,466,0.00057270
+Comb Sort,333,467,0.00054710
+Comb Sort,333,468,0.00053360
+Comb Sort,333,469,0.00054900
+Comb Sort,333,470,0.00055310
+Comb Sort,333,471,0.00055750
+Comb Sort,333,472,0.00060200
+Comb Sort,333,473,0.00058140
+Comb Sort,333,474,0.00057980
+Comb Sort,333,475,0.00057400
+Comb Sort,333,476,0.00057200
+Comb Sort,333,477,0.00057640
+Comb Sort,333,478,0.00074130
+Comb Sort,333,479,0.00058410
+Comb Sort,333,480,0.00057440
+Comb Sort,333,481,0.00058030
+Comb Sort,333,482,0.00063830
+Comb Sort,333,483,0.00055390
+Comb Sort,333,484,0.00057710
+Comb Sort,333,485,0.00072540
+Comb Sort,333,486,0.00055600
+Comb Sort,333,487,0.00052670
+Comb Sort,333,488,0.00063590
+Comb Sort,333,489,0.00055100
+Comb Sort,333,490,0.00065750
+Comb Sort,333,491,0.00066840
+Comb Sort,333,492,0.00054900
+Comb Sort,333,493,0.00066910
+Comb Sort,333,494,0.00055990
+Comb Sort,333,495,0.00054600
+Comb Sort,333,496,0.00055260
+Comb Sort,333,497,0.00052760
+Comb Sort,333,498,0.00061230
+Comb Sort,333,499,0.00078960
+Comb Sort,333,500,0.00060290
+Counting Sort,333,1,0.27429700
+Counting Sort,333,2,0.27570040
+Counting Sort,333,3,0.25933930
+Counting Sort,333,4,0.24974840
+Counting Sort,333,5,0.26105510
+Counting Sort,333,6,0.30110680
+Counting Sort,333,7,0.26412420
+Counting Sort,333,8,0.26419300
+Counting Sort,333,9,0.24936130
+Counting Sort,333,10,0.25018420
+Counting Sort,333,11,0.24581900
+Counting Sort,333,12,0.26213370
+Counting Sort,333,13,0.25603370
+Counting Sort,333,14,0.24894830
+Counting Sort,333,15,0.26074040
+Counting Sort,333,16,0.26389940
+Counting Sort,333,17,0.25189530
+Counting Sort,333,18,0.24770190
+Counting Sort,333,19,0.25646210
+Counting Sort,333,20,0.26078290
+Counting Sort,333,21,0.27683660
+Counting Sort,333,22,0.24714770
+Counting Sort,333,23,0.27029360
+Counting Sort,333,24,0.25999590
+Counting Sort,333,25,0.25150670
+Counting Sort,333,26,0.25374510
+Counting Sort,333,27,0.25432460
+Counting Sort,333,28,0.25067050
+Counting Sort,333,29,0.26295260
+Counting Sort,333,30,0.24810430
+Counting Sort,333,31,0.25345800
+Counting Sort,333,32,0.25925050
+Counting Sort,333,33,0.26507330
+Counting Sort,333,34,0.25956780
+Counting Sort,333,35,0.26902560
+Counting Sort,333,36,0.26927470
+Counting Sort,333,37,0.26987820
+Counting Sort,333,38,0.25623280
+Counting Sort,333,39,0.26158270
+Counting Sort,333,40,0.27005930
+Counting Sort,333,41,0.27127820
+Counting Sort,333,42,0.25503660
+Counting Sort,333,43,0.26830490
+Counting Sort,333,44,0.26615500
+Counting Sort,333,45,0.26774710
+Counting Sort,333,46,0.25575100
+Counting Sort,333,47,0.24543470
+Counting Sort,333,48,0.25379330
+Counting Sort,333,49,0.26488410
+Counting Sort,333,50,0.25421790
+Counting Sort,333,51,0.25769460
+Counting Sort,333,52,0.25801370
+Counting Sort,333,53,0.25942010
+Counting Sort,333,54,0.24966790
+Counting Sort,333,55,0.26169720
+Counting Sort,333,56,0.26385240
+Counting Sort,333,57,0.24869550
+Counting Sort,333,58,0.25446330
+Counting Sort,333,59,0.26184080
+Counting Sort,333,60,0.25039770
+Counting Sort,333,61,0.24994000
+Counting Sort,333,62,0.26435050
+Counting Sort,333,63,0.25584710
+Counting Sort,333,64,0.25769790
+Counting Sort,333,65,0.25603580
+Counting Sort,333,66,0.26011900
+Counting Sort,333,67,0.26039330
+Counting Sort,333,68,0.24794020
+Counting Sort,333,69,0.24928470
+Counting Sort,333,70,0.25130530
+Counting Sort,333,71,0.24738110
+Counting Sort,333,72,0.24453010
+Counting Sort,333,73,0.26126590
+Counting Sort,333,74,0.25583020
+Counting Sort,333,75,0.25669730
+Counting Sort,333,76,0.26251500
+Counting Sort,333,77,0.26205430
+Counting Sort,333,78,0.25636690
+Counting Sort,333,79,0.26046910
+Counting Sort,333,80,0.25713980
+Counting Sort,333,81,0.24451170
+Counting Sort,333,82,0.25414760
+Counting Sort,333,83,0.24140420
+Counting Sort,333,84,0.29501000
+Counting Sort,333,85,0.26232280
+Counting Sort,333,86,0.25457570
+Counting Sort,333,87,0.26093840
+Counting Sort,333,88,0.25737090
+Counting Sort,333,89,0.26135230
+Counting Sort,333,90,0.25455360
+Counting Sort,333,91,0.25396020
+Counting Sort,333,92,0.25189880
+Counting Sort,333,93,0.24585290
+Counting Sort,333,94,0.25446500
+Counting Sort,333,95,0.26702810
+Counting Sort,333,96,0.25826250
+Counting Sort,333,97,0.25500190
+Counting Sort,333,98,0.24937140
+Counting Sort,333,99,0.25167580
+Counting Sort,333,100,0.25165890
+Counting Sort,333,101,0.24680550
+Counting Sort,333,102,0.25289020
+Counting Sort,333,103,0.25900990
+Counting Sort,333,104,0.25158530
+Counting Sort,333,105,0.25525980
+Counting Sort,333,106,0.25569650
+Counting Sort,333,107,0.25736630
+Counting Sort,333,108,0.26448690
+Counting Sort,333,109,0.24891920
+Counting Sort,333,110,0.25969090
+Counting Sort,333,111,0.26014000
+Counting Sort,333,112,0.25818210
+Counting Sort,333,113,0.26326220
+Counting Sort,333,114,0.25572740
+Counting Sort,333,115,0.25747750
+Counting Sort,333,116,0.25632830
+Counting Sort,333,117,0.25549280
+Counting Sort,333,118,0.25490970
+Counting Sort,333,119,0.25640080
+Counting Sort,333,120,0.26290210
+Counting Sort,333,121,0.25305590
+Counting Sort,333,122,0.25187410
+Counting Sort,333,123,0.26784430
+Counting Sort,333,124,0.26336800
+Counting Sort,333,125,0.27729070
+Counting Sort,333,126,0.28631900
+Counting Sort,333,127,0.27077650
+Counting Sort,333,128,0.32119820
+Counting Sort,333,129,0.27923080
+Counting Sort,333,130,0.29275420
+Counting Sort,333,131,0.25604830
+Counting Sort,333,132,0.26926410
+Counting Sort,333,133,0.26021480
+Counting Sort,333,134,0.28227010
+Counting Sort,333,135,0.26490300
+Counting Sort,333,136,0.25201080
+Counting Sort,333,137,0.26560500
+Counting Sort,333,138,0.24624920
+Counting Sort,333,139,0.26210730
+Counting Sort,333,140,0.26060140
+Counting Sort,333,141,0.24666570
+Counting Sort,333,142,0.25314420
+Counting Sort,333,143,0.24564100
+Counting Sort,333,144,0.24580590
+Counting Sort,333,145,0.25167330
+Counting Sort,333,146,0.26070430
+Counting Sort,333,147,0.24904220
+Counting Sort,333,148,0.25199040
+Counting Sort,333,149,0.25251110
+Counting Sort,333,150,0.24915080
+Counting Sort,333,151,0.25716870
+Counting Sort,333,152,0.25886590
+Counting Sort,333,153,0.24486140
+Counting Sort,333,154,0.26036350
+Counting Sort,333,155,0.24575890
+Counting Sort,333,156,0.25390110
+Counting Sort,333,157,0.27051180
+Counting Sort,333,158,0.25641570
+Counting Sort,333,159,0.27131870
+Counting Sort,333,160,0.25200900
+Counting Sort,333,161,0.25026060
+Counting Sort,333,162,0.25716450
+Counting Sort,333,163,0.25553170
+Counting Sort,333,164,0.25329240
+Counting Sort,333,165,0.25582640
+Counting Sort,333,166,0.24757700
+Counting Sort,333,167,0.25068540
+Counting Sort,333,168,0.26040560
+Counting Sort,333,169,0.25360010
+Counting Sort,333,170,0.25905540
+Counting Sort,333,171,0.24902680
+Counting Sort,333,172,0.25698520
+Counting Sort,333,173,0.25288370
+Counting Sort,333,174,0.26837980
+Counting Sort,333,175,0.30175100
+Counting Sort,333,176,0.25157760
+Counting Sort,333,177,0.25228950
+Counting Sort,333,178,0.24531300
+Counting Sort,333,179,0.25201830
+Counting Sort,333,180,0.25620240
+Counting Sort,333,181,0.24764090
+Counting Sort,333,182,0.25566420
+Counting Sort,333,183,0.25557160
+Counting Sort,333,184,0.24906850
+Counting Sort,333,185,0.25306040
+Counting Sort,333,186,0.25766540
+Counting Sort,333,187,0.27110340
+Counting Sort,333,188,0.27113360
+Counting Sort,333,189,0.27514770
+Counting Sort,333,190,0.26537930
+Counting Sort,333,191,0.27087150
+Counting Sort,333,192,0.26504930
+Counting Sort,333,193,0.25677650
+Counting Sort,333,194,0.24823160
+Counting Sort,333,195,0.26068930
+Counting Sort,333,196,0.25415040
+Counting Sort,333,197,0.26114850
+Counting Sort,333,198,0.25093480
+Counting Sort,333,199,0.25304890
+Counting Sort,333,200,0.25493500
+Counting Sort,333,201,0.26115770
+Counting Sort,333,202,0.25186100
+Counting Sort,333,203,0.25209210
+Counting Sort,333,204,0.25371360
+Counting Sort,333,205,0.25761620
+Counting Sort,333,206,0.26050690
+Counting Sort,333,207,0.24948320
+Counting Sort,333,208,0.25552690
+Counting Sort,333,209,0.25236040
+Counting Sort,333,210,0.25366780
+Counting Sort,333,211,0.26069490
+Counting Sort,333,212,0.24892880
+Counting Sort,333,213,0.25226000
+Counting Sort,333,214,0.25436380
+Counting Sort,333,215,0.26194220
+Counting Sort,333,216,0.28115000
+Counting Sort,333,217,0.24633090
+Counting Sort,333,218,0.25413300
+Counting Sort,333,219,0.25737120
+Counting Sort,333,220,0.24851520
+Counting Sort,333,221,0.24952260
+Counting Sort,333,222,0.27657090
+Counting Sort,333,223,0.25178610
+Counting Sort,333,224,0.25640280
+Counting Sort,333,225,0.27091760
+Counting Sort,333,226,0.25532950
+Counting Sort,333,227,0.25303100
+Counting Sort,333,228,0.25149840
+Counting Sort,333,229,0.25839530
+Counting Sort,333,230,0.25238660
+Counting Sort,333,231,0.25213230
+Counting Sort,333,232,0.26211410
+Counting Sort,333,233,0.25925010
+Counting Sort,333,234,0.25139850
+Counting Sort,333,235,0.24845520
+Counting Sort,333,236,0.30358280
+Counting Sort,333,237,0.24941400
+Counting Sort,333,238,0.25293810
+Counting Sort,333,239,0.27323260
+Counting Sort,333,240,0.25412760
+Counting Sort,333,241,0.25242460
+Counting Sort,333,242,0.25728420
+Counting Sort,333,243,0.28129720
+Counting Sort,333,244,0.27394610
+Counting Sort,333,245,0.25562220
+Counting Sort,333,246,0.28825070
+Counting Sort,333,247,0.24963550
+Counting Sort,333,248,0.26759900
+Counting Sort,333,249,0.27510770
+Counting Sort,333,250,0.27336530
+Counting Sort,333,251,0.27657910
+Counting Sort,333,252,0.26332630
+Counting Sort,333,253,0.26397570
+Counting Sort,333,254,0.25631140
+Counting Sort,333,255,0.26493520
+Counting Sort,333,256,0.25748330
+Counting Sort,333,257,0.27707730
+Counting Sort,333,258,0.29794330
+Counting Sort,333,259,0.27000630
+Counting Sort,333,260,0.25157340
+Counting Sort,333,261,0.29208600
+Counting Sort,333,262,0.27532830
+Counting Sort,333,263,0.25324120
+Counting Sort,333,264,0.29710000
+Counting Sort,333,265,0.26189000
+Counting Sort,333,266,0.24967550
+Counting Sort,333,267,0.26779030
+Counting Sort,333,268,0.26721140
+Counting Sort,333,269,0.27938880
+Counting Sort,333,270,0.27882980
+Counting Sort,333,271,0.26274930
+Counting Sort,333,272,0.26580070
+Counting Sort,333,273,0.28550790
+Counting Sort,333,274,0.26244240
+Counting Sort,333,275,0.26589060
+Counting Sort,333,276,0.26821510
+Counting Sort,333,277,0.26366290
+Counting Sort,333,278,0.27102000
+Counting Sort,333,279,0.25591400
+Counting Sort,333,280,0.26046140
+Counting Sort,333,281,0.27753280
+Counting Sort,333,282,0.26021080
+Counting Sort,333,283,0.26708360
+Counting Sort,333,284,0.25994940
+Counting Sort,333,285,0.27122560
+Counting Sort,333,286,0.25190680
+Counting Sort,333,287,0.25506020
+Counting Sort,333,288,0.25210590
+Counting Sort,333,289,0.26667360
+Counting Sort,333,290,0.26258630
+Counting Sort,333,291,0.25715680
+Counting Sort,333,292,0.25677990
+Counting Sort,333,293,0.25485730
+Counting Sort,333,294,0.26090080
+Counting Sort,333,295,0.25761500
+Counting Sort,333,296,0.25305270
+Counting Sort,333,297,0.25438710
+Counting Sort,333,298,0.26601110
+Counting Sort,333,299,0.25343250
+Counting Sort,333,300,0.26740570
+Counting Sort,333,301,0.26498930
+Counting Sort,333,302,0.25888940
+Counting Sort,333,303,0.25179880
+Counting Sort,333,304,0.24607310
+Counting Sort,333,305,0.25840160
+Counting Sort,333,306,0.25140800
+Counting Sort,333,307,0.24956140
+Counting Sort,333,308,0.25366540
+Counting Sort,333,309,0.26632890
+Counting Sort,333,310,0.26023210
+Counting Sort,333,311,0.24499930
+Counting Sort,333,312,0.27051580
+Counting Sort,333,313,0.25027310
+Counting Sort,333,314,0.25366550
+Counting Sort,333,315,0.25026080
+Counting Sort,333,316,0.25095410
+Counting Sort,333,317,0.25119960
+Counting Sort,333,318,0.26805990
+Counting Sort,333,319,0.25502180
+Counting Sort,333,320,0.24599000
+Counting Sort,333,321,0.25296400
+Counting Sort,333,322,0.25768120
+Counting Sort,333,323,0.24756540
+Counting Sort,333,324,0.25323050
+Counting Sort,333,325,0.24797640
+Counting Sort,333,326,0.25509970
+Counting Sort,333,327,0.25452570
+Counting Sort,333,328,0.24856460
+Counting Sort,333,329,0.25087660
+Counting Sort,333,330,0.25001600
+Counting Sort,333,331,0.24917040
+Counting Sort,333,332,0.26714960
+Counting Sort,333,333,0.25169040
+Counting Sort,333,334,0.28087720
+Counting Sort,333,335,0.26013290
+Counting Sort,333,336,0.25735870
+Counting Sort,333,337,0.25677810
+Counting Sort,333,338,0.25244830
+Counting Sort,333,339,0.25026010
+Counting Sort,333,340,0.24987300
+Counting Sort,333,341,0.25278310
+Counting Sort,333,342,0.26060140
+Counting Sort,333,343,0.26021760
+Counting Sort,333,344,0.24997070
+Counting Sort,333,345,0.29219810
+Counting Sort,333,346,0.26220920
+Counting Sort,333,347,0.25288770
+Counting Sort,333,348,0.25868210
+Counting Sort,333,349,0.25885990
+Counting Sort,333,350,0.26041700
+Counting Sort,333,351,0.24627830
+Counting Sort,333,352,0.25715020
+Counting Sort,333,353,0.24756700
+Counting Sort,333,354,0.25094010
+Counting Sort,333,355,0.25529270
+Counting Sort,333,356,0.25459440
+Counting Sort,333,357,0.25295660
+Counting Sort,333,358,0.25299230
+Counting Sort,333,359,0.25518060
+Counting Sort,333,360,0.24900840
+Counting Sort,333,361,0.25403030
+Counting Sort,333,362,0.25422810
+Counting Sort,333,363,0.25006160
+Counting Sort,333,364,0.24379730
+Counting Sort,333,365,0.25234320
+Counting Sort,333,366,0.26631710
+Counting Sort,333,367,0.25857900
+Counting Sort,333,368,0.25828130
+Counting Sort,333,369,0.26568720
+Counting Sort,333,370,0.25816950
+Counting Sort,333,371,0.25305110
+Counting Sort,333,372,0.24459700
+Counting Sort,333,373,0.26283490
+Counting Sort,333,374,0.25064670
+Counting Sort,333,375,0.26061340
+Counting Sort,333,376,0.25221630
+Counting Sort,333,377,0.24817840
+Counting Sort,333,378,0.24959520
+Counting Sort,333,379,0.25701250
+Counting Sort,333,380,0.25822250
+Counting Sort,333,381,0.25224830
+Counting Sort,333,382,0.24547800
+Counting Sort,333,383,0.25288820
+Counting Sort,333,384,0.25280690
+Counting Sort,333,385,0.24577890
+Counting Sort,333,386,0.26039350
+Counting Sort,333,387,0.24991630
+Counting Sort,333,388,0.24730850
+Counting Sort,333,389,0.24935690
+Counting Sort,333,390,0.24656250
+Counting Sort,333,391,0.25389210
+Counting Sort,333,392,0.25619930
+Counting Sort,333,393,0.25267260
+Counting Sort,333,394,0.25588540
+Counting Sort,333,395,0.25087580
+Counting Sort,333,396,0.25637160
+Counting Sort,333,397,0.25882840
+Counting Sort,333,398,0.26078160
+Counting Sort,333,399,0.26197690
+Counting Sort,333,400,0.25269020
+Counting Sort,333,401,0.24873340
+Counting Sort,333,402,0.24589460
+Counting Sort,333,403,0.25801710
+Counting Sort,333,404,0.25807510
+Counting Sort,333,405,0.26139540
+Counting Sort,333,406,0.26364240
+Counting Sort,333,407,0.25527500
+Counting Sort,333,408,0.23999820
+Counting Sort,333,409,0.27445450
+Counting Sort,333,410,0.25759460
+Counting Sort,333,411,0.27803680
+Counting Sort,333,412,0.26384640
+Counting Sort,333,413,0.30000080
+Counting Sort,333,414,0.26932160
+Counting Sort,333,415,0.25441210
+Counting Sort,333,416,0.25893230
+Counting Sort,333,417,0.26506040
+Counting Sort,333,418,0.25444850
+Counting Sort,333,419,0.26592380
+Counting Sort,333,420,0.26276900
+Counting Sort,333,421,0.26215660
+Counting Sort,333,422,0.26697000
+Counting Sort,333,423,0.25746920
+Counting Sort,333,424,0.26898130
+Counting Sort,333,425,0.25962740
+Counting Sort,333,426,0.24850130
+Counting Sort,333,427,0.26226690
+Counting Sort,333,428,0.26296860
+Counting Sort,333,429,0.26231970
+Counting Sort,333,430,0.27943020
+Counting Sort,333,431,0.26653510
+Counting Sort,333,432,0.25777540
+Counting Sort,333,433,0.25353160
+Counting Sort,333,434,0.25976290
+Counting Sort,333,435,0.26515620
+Counting Sort,333,436,0.25069350
+Counting Sort,333,437,0.25893890
+Counting Sort,333,438,0.24744610
+Counting Sort,333,439,0.25874700
+Counting Sort,333,440,0.27340710
+Counting Sort,333,441,0.25633490
+Counting Sort,333,442,0.25675580
+Counting Sort,333,443,0.27681120
+Counting Sort,333,444,0.27749720
+Counting Sort,333,445,0.24406380
+Counting Sort,333,446,0.24573000
+Counting Sort,333,447,0.25049380
+Counting Sort,333,448,0.25249230
+Counting Sort,333,449,0.24664790
+Counting Sort,333,450,0.26431110
+Counting Sort,333,451,0.25614200
+Counting Sort,333,452,0.25055910
+Counting Sort,333,453,0.25848990
+Counting Sort,333,454,0.26042570
+Counting Sort,333,455,0.25228980
+Counting Sort,333,456,0.25957750
+Counting Sort,333,457,0.25501850
+Counting Sort,333,458,0.25656980
+Counting Sort,333,459,0.26793410
+Counting Sort,333,460,0.24793820
+Counting Sort,333,461,0.27952520
+Counting Sort,333,462,0.24975480
+Counting Sort,333,463,0.25160350
+Counting Sort,333,464,0.24959280
+Counting Sort,333,465,0.24710780
+Counting Sort,333,466,0.27449100
+Counting Sort,333,467,0.25368500
+Counting Sort,333,468,0.29869830
+Counting Sort,333,469,0.25894170
+Counting Sort,333,470,0.26137320
+Counting Sort,333,471,0.28159080
+Counting Sort,333,472,0.26612760
+Counting Sort,333,473,0.24841160
+Counting Sort,333,474,0.25609570
+Counting Sort,333,475,0.26246760
+Counting Sort,333,476,0.24943660
+Counting Sort,333,477,0.25514500
+Counting Sort,333,478,0.26125060
+Counting Sort,333,479,0.25002800
+Counting Sort,333,480,0.28102720
+Counting Sort,333,481,0.26210480
+Counting Sort,333,482,0.25713640
+Counting Sort,333,483,0.25343570
+Counting Sort,333,484,0.26586980
+Counting Sort,333,485,0.25395640
+Counting Sort,333,486,0.27075380
+Counting Sort,333,487,0.26301570
+Counting Sort,333,488,0.30393600
+Counting Sort,333,489,0.25910250
+Counting Sort,333,490,0.26806670
+Counting Sort,333,491,0.26200010
+Counting Sort,333,492,0.26044210
+Counting Sort,333,493,0.25375260
+Counting Sort,333,494,0.27838030
+Counting Sort,333,495,0.31292440
+Counting Sort,333,496,0.25523340
+Counting Sort,333,497,0.29682980
+Counting Sort,333,498,0.26783730
+Counting Sort,333,499,0.26029230
+Counting Sort,333,500,0.29280590
+Cubesort,333,1,0.00016550
+Cubesort,333,2,0.00014930
+Cubesort,333,3,0.00014790
+Cubesort,333,4,0.00015450
+Cubesort,333,5,0.00016080
+Cubesort,333,6,0.00015420
+Cubesort,333,7,0.00015430
+Cubesort,333,8,0.00015480
+Cubesort,333,9,0.00015090
+Cubesort,333,10,0.00015910
+Cubesort,333,11,0.00015500
+Cubesort,333,12,0.00015160
+Cubesort,333,13,0.00014870
+Cubesort,333,14,0.00015380
+Cubesort,333,15,0.00014830
+Cubesort,333,16,0.00033450
+Cubesort,333,17,0.00014790
+Cubesort,333,18,0.00015050
+Cubesort,333,19,0.00014880
+Cubesort,333,20,0.00014970
+Cubesort,333,21,0.00015560
+Cubesort,333,22,0.00015440
+Cubesort,333,23,0.00015880
+Cubesort,333,24,0.00015450
+Cubesort,333,25,0.00014680
+Cubesort,333,26,0.00014790
+Cubesort,333,27,0.00015020
+Cubesort,333,28,0.00015360
+Cubesort,333,29,0.00015870
+Cubesort,333,30,0.00014750
+Cubesort,333,31,0.00014880
+Cubesort,333,32,0.00014700
+Cubesort,333,33,0.00014680
+Cubesort,333,34,0.00017110
+Cubesort,333,35,0.00014860
+Cubesort,333,36,0.00015020
+Cubesort,333,37,0.00015210
+Cubesort,333,38,0.00014600
+Cubesort,333,39,0.00014410
+Cubesort,333,40,0.00014730
+Cubesort,333,41,0.00014410
+Cubesort,333,42,0.00014770
+Cubesort,333,43,0.00014500
+Cubesort,333,44,0.00015170
+Cubesort,333,45,0.00014840
+Cubesort,333,46,0.00014850
+Cubesort,333,47,0.00015420
+Cubesort,333,48,0.00014670
+Cubesort,333,49,0.00024850
+Cubesort,333,50,0.00014420
+Cubesort,333,51,0.00014330
+Cubesort,333,52,0.00014900
+Cubesort,333,53,0.00014870
+Cubesort,333,54,0.00018400
+Cubesort,333,55,0.00014690
+Cubesort,333,56,0.00015690
+Cubesort,333,57,0.00014640
+Cubesort,333,58,0.00018600
+Cubesort,333,59,0.00015160
+Cubesort,333,60,0.00014740
+Cubesort,333,61,0.00015160
+Cubesort,333,62,0.00015570
+Cubesort,333,63,0.00015070
+Cubesort,333,64,0.00015070
+Cubesort,333,65,0.00014540
+Cubesort,333,66,0.00014200
+Cubesort,333,67,0.00014620
+Cubesort,333,68,0.00015780
+Cubesort,333,69,0.00014750
+Cubesort,333,70,0.00014910
+Cubesort,333,71,0.00015610
+Cubesort,333,72,0.00015480
+Cubesort,333,73,0.00015140
+Cubesort,333,74,0.00015500
+Cubesort,333,75,0.00014710
+Cubesort,333,76,0.00014790
+Cubesort,333,77,0.00014670
+Cubesort,333,78,0.00015150
+Cubesort,333,79,0.00014150
+Cubesort,333,80,0.00015010
+Cubesort,333,81,0.00014460
+Cubesort,333,82,0.00014620
+Cubesort,333,83,0.00014090
+Cubesort,333,84,0.00016710
+Cubesort,333,85,0.00015100
+Cubesort,333,86,0.00014860
+Cubesort,333,87,0.00014230
+Cubesort,333,88,0.00014730
+Cubesort,333,89,0.00014680
+Cubesort,333,90,0.00014310
+Cubesort,333,91,0.00014480
+Cubesort,333,92,0.00014570
+Cubesort,333,93,0.00014550
+Cubesort,333,94,0.00014710
+Cubesort,333,95,0.00014350
+Cubesort,333,96,0.00015130
+Cubesort,333,97,0.00014750
+Cubesort,333,98,0.00014300
+Cubesort,333,99,0.00014080
+Cubesort,333,100,0.00014780
+Cubesort,333,101,0.00014500
+Cubesort,333,102,0.00014720
+Cubesort,333,103,0.00014540
+Cubesort,333,104,0.00014730
+Cubesort,333,105,0.00014220
+Cubesort,333,106,0.00014670
+Cubesort,333,107,0.00014930
+Cubesort,333,108,0.00014330
+Cubesort,333,109,0.00014180
+Cubesort,333,110,0.00014770
+Cubesort,333,111,0.00014810
+Cubesort,333,112,0.00014630
+Cubesort,333,113,0.00014670
+Cubesort,333,114,0.00014330
+Cubesort,333,115,0.00014720
+Cubesort,333,116,0.00014670
+Cubesort,333,117,0.00014790
+Cubesort,333,118,0.00014750
+Cubesort,333,119,0.00014370
+Cubesort,333,120,0.00046990
+Cubesort,333,121,0.00016030
+Cubesort,333,122,0.00014920
+Cubesort,333,123,0.00017590
+Cubesort,333,124,0.00015030
+Cubesort,333,125,0.00015180
+Cubesort,333,126,0.00015240
+Cubesort,333,127,0.00014910
+Cubesort,333,128,0.00014830
+Cubesort,333,129,0.00015250
+Cubesort,333,130,0.00014700
+Cubesort,333,131,0.00014710
+Cubesort,333,132,0.00014900
+Cubesort,333,133,0.00023600
+Cubesort,333,134,0.00016060
+Cubesort,333,135,0.00015580
+Cubesort,333,136,0.00034150
+Cubesort,333,137,0.00015250
+Cubesort,333,138,0.00015820
+Cubesort,333,139,0.00018610
+Cubesort,333,140,0.00015290
+Cubesort,333,141,0.00015250
+Cubesort,333,142,0.00015630
+Cubesort,333,143,0.00015290
+Cubesort,333,144,0.00015860
+Cubesort,333,145,0.00015610
+Cubesort,333,146,0.00015850
+Cubesort,333,147,0.00015790
+Cubesort,333,148,0.00014930
+Cubesort,333,149,0.00016490
+Cubesort,333,150,0.00015600
+Cubesort,333,151,0.00015830
+Cubesort,333,152,0.00016310
+Cubesort,333,153,0.00015760
+Cubesort,333,154,0.00015600
+Cubesort,333,155,0.00015350
+Cubesort,333,156,0.00015500
+Cubesort,333,157,0.00014920
+Cubesort,333,158,0.00014960
+Cubesort,333,159,0.00015420
+Cubesort,333,160,0.00015740
+Cubesort,333,161,0.00014890
+Cubesort,333,162,0.00014900
+Cubesort,333,163,0.00015350
+Cubesort,333,164,0.00016010
+Cubesort,333,165,0.00014860
+Cubesort,333,166,0.00014880
+Cubesort,333,167,0.00015840
+Cubesort,333,168,0.00015630
+Cubesort,333,169,0.00015420
+Cubesort,333,170,0.00016120
+Cubesort,333,171,0.00015110
+Cubesort,333,172,0.00015920
+Cubesort,333,173,0.00014800
+Cubesort,333,174,0.00015470
+Cubesort,333,175,0.00014770
+Cubesort,333,176,0.00015350
+Cubesort,333,177,0.00015590
+Cubesort,333,178,0.00015140
+Cubesort,333,179,0.00015350
+Cubesort,333,180,0.00016000
+Cubesort,333,181,0.00031390
+Cubesort,333,182,0.00015780
+Cubesort,333,183,0.00016020
+Cubesort,333,184,0.00015400
+Cubesort,333,185,0.00014920
+Cubesort,333,186,0.00015950
+Cubesort,333,187,0.00015300
+Cubesort,333,188,0.00015170
+Cubesort,333,189,0.00015010
+Cubesort,333,190,0.00015790
+Cubesort,333,191,0.00015240
+Cubesort,333,192,0.00015540
+Cubesort,333,193,0.00015900
+Cubesort,333,194,0.00016120
+Cubesort,333,195,0.00016030
+Cubesort,333,196,0.00015460
+Cubesort,333,197,0.00015150
+Cubesort,333,198,0.00015730
+Cubesort,333,199,0.00015280
+Cubesort,333,200,0.00015860
+Cubesort,333,201,0.00015850
+Cubesort,333,202,0.00015190
+Cubesort,333,203,0.00016140
+Cubesort,333,204,0.00015710
+Cubesort,333,205,0.00015310
+Cubesort,333,206,0.00015390
+Cubesort,333,207,0.00015390
+Cubesort,333,208,0.00015570
+Cubesort,333,209,0.00015080
+Cubesort,333,210,0.00015120
+Cubesort,333,211,0.00015330
+Cubesort,333,212,0.00015520
+Cubesort,333,213,0.00015330
+Cubesort,333,214,0.00015160
+Cubesort,333,215,0.00015360
+Cubesort,333,216,0.00015020
+Cubesort,333,217,0.00015030
+Cubesort,333,218,0.00015010
+Cubesort,333,219,0.00014660
+Cubesort,333,220,0.00015440
+Cubesort,333,221,0.00014670
+Cubesort,333,222,0.00014450
+Cubesort,333,223,0.00014650
+Cubesort,333,224,0.00016990
+Cubesort,333,225,0.00016350
+Cubesort,333,226,0.00015620
+Cubesort,333,227,0.00014620
+Cubesort,333,228,0.00015230
+Cubesort,333,229,0.00015320
+Cubesort,333,230,0.00014940
+Cubesort,333,231,0.00015220
+Cubesort,333,232,0.00015130
+Cubesort,333,233,0.00015020
+Cubesort,333,234,0.00014660
+Cubesort,333,235,0.00015120
+Cubesort,333,236,0.00014560
+Cubesort,333,237,0.00014230
+Cubesort,333,238,0.00015090
+Cubesort,333,239,0.00015620
+Cubesort,333,240,0.00015050
+Cubesort,333,241,0.00015730
+Cubesort,333,242,0.00015170
+Cubesort,333,243,0.00014640
+Cubesort,333,244,0.00014830
+Cubesort,333,245,0.00014750
+Cubesort,333,246,0.00016420
+Cubesort,333,247,0.00014630
+Cubesort,333,248,0.00014630
+Cubesort,333,249,0.00016550
+Cubesort,333,250,0.00015010
+Cubesort,333,251,0.00014950
+Cubesort,333,252,0.00016020
+Cubesort,333,253,0.00014560
+Cubesort,333,254,0.00014440
+Cubesort,333,255,0.00014840
+Cubesort,333,256,0.00014490
+Cubesort,333,257,0.00014460
+Cubesort,333,258,0.00014860
+Cubesort,333,259,0.00014630
+Cubesort,333,260,0.00014700
+Cubesort,333,261,0.00015310
+Cubesort,333,262,0.00015250
+Cubesort,333,263,0.00017230
+Cubesort,333,264,0.00014980
+Cubesort,333,265,0.00015600
+Cubesort,333,266,0.00015410
+Cubesort,333,267,0.00015010
+Cubesort,333,268,0.00047370
+Cubesort,333,269,0.00015610
+Cubesort,333,270,0.00014860
+Cubesort,333,271,0.00015330
+Cubesort,333,272,0.00015280
+Cubesort,333,273,0.00041130
+Cubesort,333,274,0.00014910
+Cubesort,333,275,0.00016000
+Cubesort,333,276,0.00015100
+Cubesort,333,277,0.00013490
+Cubesort,333,278,0.00012600
+Cubesort,333,279,0.00011920
+Cubesort,333,280,0.00015600
+Cubesort,333,281,0.00014990
+Cubesort,333,282,0.00015950
+Cubesort,333,283,0.00014590
+Cubesort,333,284,0.00016060
+Cubesort,333,285,0.00016120
+Cubesort,333,286,0.00015440
+Cubesort,333,287,0.00015820
+Cubesort,333,288,0.00014530
+Cubesort,333,289,0.00016090
+Cubesort,333,290,0.00015810
+Cubesort,333,291,0.00014980
+Cubesort,333,292,0.00016340
+Cubesort,333,293,0.00014800
+Cubesort,333,294,0.00016470
+Cubesort,333,295,0.00015860
+Cubesort,333,296,0.00015050
+Cubesort,333,297,0.00015710
+Cubesort,333,298,0.00018980
+Cubesort,333,299,0.00016070
+Cubesort,333,300,0.00016910
+Cubesort,333,301,0.00014930
+Cubesort,333,302,0.00016710
+Cubesort,333,303,0.00015490
+Cubesort,333,304,0.00017020
+Cubesort,333,305,0.00015970
+Cubesort,333,306,0.00015770
+Cubesort,333,307,0.00016110
+Cubesort,333,308,0.00016280
+Cubesort,333,309,0.00015770
+Cubesort,333,310,0.01075070
+Cubesort,333,311,0.00016340
+Cubesort,333,312,0.00015120
+Cubesort,333,313,0.00014790
+Cubesort,333,314,0.00015000
+Cubesort,333,315,0.00014800
+Cubesort,333,316,0.00014770
+Cubesort,333,317,0.00014760
+Cubesort,333,318,0.00014430
+Cubesort,333,319,0.00014660
+Cubesort,333,320,0.00014940
+Cubesort,333,321,0.00014700
+Cubesort,333,322,0.00014470
+Cubesort,333,323,0.00015390
+Cubesort,333,324,0.00014870
+Cubesort,333,325,0.00014580
+Cubesort,333,326,0.00015390
+Cubesort,333,327,0.00014540
+Cubesort,333,328,0.00027760
+Cubesort,333,329,0.00037960
+Cubesort,333,330,0.00014430
+Cubesort,333,331,0.00014690
+Cubesort,333,332,0.00014380
+Cubesort,333,333,0.00036810
+Cubesort,333,334,0.00022820
+Cubesort,333,335,0.00014530
+Cubesort,333,336,0.00154570
+Cubesort,333,337,0.00014450
+Cubesort,333,338,0.00014430
+Cubesort,333,339,0.00015780
+Cubesort,333,340,0.00014890
+Cubesort,333,341,0.00016650
+Cubesort,333,342,0.00016350
+Cubesort,333,343,0.00014360
+Cubesort,333,344,0.00014270
+Cubesort,333,345,0.00015040
+Cubesort,333,346,0.00014440
+Cubesort,333,347,0.00015920
+Cubesort,333,348,0.00015950
+Cubesort,333,349,0.00014700
+Cubesort,333,350,0.00014430
+Cubesort,333,351,0.00017080
+Cubesort,333,352,0.00015480
+Cubesort,333,353,0.00017430
+Cubesort,333,354,0.00015050
+Cubesort,333,355,0.00014540
+Cubesort,333,356,0.00015200
+Cubesort,333,357,0.00014170
+Cubesort,333,358,0.00014510
+Cubesort,333,359,0.00015370
+Cubesort,333,360,0.00023280
+Cubesort,333,361,0.00014450
+Cubesort,333,362,0.00015100
+Cubesort,333,363,0.00013940
+Cubesort,333,364,0.00014400
+Cubesort,333,365,0.00018980
+Cubesort,333,366,0.00015400
+Cubesort,333,367,0.00014430
+Cubesort,333,368,0.00014750
+Cubesort,333,369,0.00014190
+Cubesort,333,370,0.00019500
+Cubesort,333,371,0.00014450
+Cubesort,333,372,0.00014380
+Cubesort,333,373,0.00015710
+Cubesort,333,374,0.00014560
+Cubesort,333,375,0.00021770
+Cubesort,333,376,0.00014450
+Cubesort,333,377,0.00015330
+Cubesort,333,378,0.00014380
+Cubesort,333,379,0.00018040
+Cubesort,333,380,0.00016580
+Cubesort,333,381,0.00015900
+Cubesort,333,382,0.00014030
+Cubesort,333,383,0.00014010
+Cubesort,333,384,0.00014960
+Cubesort,333,385,0.00014670
+Cubesort,333,386,0.00014220
+Cubesort,333,387,0.00019380
+Cubesort,333,388,0.00015180
+Cubesort,333,389,0.00014960
+Cubesort,333,390,0.00022550
+Cubesort,333,391,0.00014630
+Cubesort,333,392,0.00014530
+Cubesort,333,393,0.00014460
+Cubesort,333,394,0.00014310
+Cubesort,333,395,0.00015610
+Cubesort,333,396,0.00015810
+Cubesort,333,397,0.00016050
+Cubesort,333,398,0.00014120
+Cubesort,333,399,0.00015860
+Cubesort,333,400,0.00014110
+Cubesort,333,401,0.00015180
+Cubesort,333,402,0.00014200
+Cubesort,333,403,0.00014860
+Cubesort,333,404,0.00014600
+Cubesort,333,405,0.00015830
+Cubesort,333,406,0.00014790
+Cubesort,333,407,0.00014910
+Cubesort,333,408,0.00014570
+Cubesort,333,409,0.00015540
+Cubesort,333,410,0.00014060
+Cubesort,333,411,0.00014610
+Cubesort,333,412,0.00014320
+Cubesort,333,413,0.00015610
+Cubesort,333,414,0.00015010
+Cubesort,333,415,0.00015610
+Cubesort,333,416,0.00015150
+Cubesort,333,417,0.00014170
+Cubesort,333,418,0.00015160
+Cubesort,333,419,0.00015460
+Cubesort,333,420,0.00018700
+Cubesort,333,421,0.00014160
+Cubesort,333,422,0.00015590
+Cubesort,333,423,0.00015120
+Cubesort,333,424,0.00016310
+Cubesort,333,425,0.00014520
+Cubesort,333,426,0.00015410
+Cubesort,333,427,0.00015120
+Cubesort,333,428,0.00015100
+Cubesort,333,429,0.00015690
+Cubesort,333,430,0.00015530
+Cubesort,333,431,0.00015270
+Cubesort,333,432,0.00014370
+Cubesort,333,433,0.00015450
+Cubesort,333,434,0.00015110
+Cubesort,333,435,0.00015110
+Cubesort,333,436,0.00014410
+Cubesort,333,437,0.00015780
+Cubesort,333,438,0.00015020
+Cubesort,333,439,0.00015650
+Cubesort,333,440,0.00014000
+Cubesort,333,441,0.00015130
+Cubesort,333,442,0.00015530
+Cubesort,333,443,0.00015090
+Cubesort,333,444,0.00018550
+Cubesort,333,445,0.00015030
+Cubesort,333,446,0.00015440
+Cubesort,333,447,0.00015060
+Cubesort,333,448,0.00015980
+Cubesort,333,449,0.00015350
+Cubesort,333,450,0.00015000
+Cubesort,333,451,0.00015280
+Cubesort,333,452,0.00015180
+Cubesort,333,453,0.00014750
+Cubesort,333,454,0.00015610
+Cubesort,333,455,0.00015090
+Cubesort,333,456,0.00015090
+Cubesort,333,457,0.00014740
+Cubesort,333,458,0.00015080
+Cubesort,333,459,0.00015670
+Cubesort,333,460,0.00015140
+Cubesort,333,461,0.00014290
+Cubesort,333,462,0.00015130
+Cubesort,333,463,0.00015630
+Cubesort,333,464,0.00015600
+Cubesort,333,465,0.00014180
+Cubesort,333,466,0.00015080
+Cubesort,333,467,0.00015780
+Cubesort,333,468,0.00015100
+Cubesort,333,469,0.00014630
+Cubesort,333,470,0.00015130
+Cubesort,333,471,0.00015900
+Cubesort,333,472,0.00015050
+Cubesort,333,473,0.00014700
+Cubesort,333,474,0.00015250
+Cubesort,333,475,0.00016060
+Cubesort,333,476,0.00015040
+Cubesort,333,477,0.00014710
+Cubesort,333,478,0.00015250
+Cubesort,333,479,0.00015160
+Cubesort,333,480,0.00015160
+Cubesort,333,481,0.00015790
+Cubesort,333,482,0.00015640
+Cubesort,333,483,0.00015090
+Cubesort,333,484,0.00021000
+Cubesort,333,485,0.00015400
+Cubesort,333,486,0.00015130
+Cubesort,333,487,0.00015070
+Cubesort,333,488,0.00015930
+Cubesort,333,489,0.00015110
+Cubesort,333,490,0.00014920
+Cubesort,333,491,0.00015290
+Cubesort,333,492,0.00015630
+Cubesort,333,493,0.00015090
+Cubesort,333,494,0.00014180
+Cubesort,333,495,0.00016260
+Cubesort,333,496,0.00016350
+Cubesort,333,497,0.00015420
+Cubesort,333,498,0.00016130
+Cubesort,333,499,0.00015810
+Cubesort,333,500,0.00016390
+Cycle Sort,333,1,0.00919050
+Cycle Sort,333,2,0.00928250
+Cycle Sort,333,3,0.00916260
+Cycle Sort,333,4,0.00925650
+Cycle Sort,333,5,0.00914320
+Cycle Sort,333,6,0.00936900
+Cycle Sort,333,7,0.00927480
+Cycle Sort,333,8,0.00910050
+Cycle Sort,333,9,0.00910170
+Cycle Sort,333,10,0.00916920
+Cycle Sort,333,11,0.00953270
+Cycle Sort,333,12,0.00904940
+Cycle Sort,333,13,0.00892220
+Cycle Sort,333,14,0.00927460
+Cycle Sort,333,15,0.00922280
+Cycle Sort,333,16,0.00913230
+Cycle Sort,333,17,0.01002260
+Cycle Sort,333,18,0.00952920
+Cycle Sort,333,19,0.00906550
+Cycle Sort,333,20,0.00962600
+Cycle Sort,333,21,0.00952360
+Cycle Sort,333,22,0.01209930
+Cycle Sort,333,23,0.02228570
+Cycle Sort,333,24,0.02147690
+Cycle Sort,333,25,0.01012780
+Cycle Sort,333,26,0.00900520
+Cycle Sort,333,27,0.00964370
+Cycle Sort,333,28,0.01009370
+Cycle Sort,333,29,0.01023750
+Cycle Sort,333,30,0.01103010
+Cycle Sort,333,31,0.01595220
+Cycle Sort,333,32,0.00899350
+Cycle Sort,333,33,0.00955780
+Cycle Sort,333,34,0.00962480
+Cycle Sort,333,35,0.00985680
+Cycle Sort,333,36,0.01510190
+Cycle Sort,333,37,0.00930370
+Cycle Sort,333,38,0.00903090
+Cycle Sort,333,39,0.00973910
+Cycle Sort,333,40,0.00932810
+Cycle Sort,333,41,0.01359260
+Cycle Sort,333,42,0.00926900
+Cycle Sort,333,43,0.00908190
+Cycle Sort,333,44,0.00913000
+Cycle Sort,333,45,0.00921850
+Cycle Sort,333,46,0.01010720
+Cycle Sort,333,47,0.01003740
+Cycle Sort,333,48,0.00864750
+Cycle Sort,333,49,0.01372180
+Cycle Sort,333,50,0.00918900
+Cycle Sort,333,51,0.00965560
+Cycle Sort,333,52,0.00918950
+Cycle Sort,333,53,0.01455090
+Cycle Sort,333,54,0.00974870
+Cycle Sort,333,55,0.00929080
+Cycle Sort,333,56,0.01020020
+Cycle Sort,333,57,0.00871260
+Cycle Sort,333,58,0.00903800
+Cycle Sort,333,59,0.00921350
+Cycle Sort,333,60,0.00911640
+Cycle Sort,333,61,0.00931000
+Cycle Sort,333,62,0.00994700
+Cycle Sort,333,63,0.01690260
+Cycle Sort,333,64,0.00874190
+Cycle Sort,333,65,0.01032340
+Cycle Sort,333,66,0.01157200
+Cycle Sort,333,67,0.00913170
+Cycle Sort,333,68,0.00923770
+Cycle Sort,333,69,0.00986350
+Cycle Sort,333,70,0.01555800
+Cycle Sort,333,71,0.00909250
+Cycle Sort,333,72,0.00876630
+Cycle Sort,333,73,0.01016580
+Cycle Sort,333,74,0.00983580
+Cycle Sort,333,75,0.01542030
+Cycle Sort,333,76,0.00903720
+Cycle Sort,333,77,0.01175800
+Cycle Sort,333,78,0.00993630
+Cycle Sort,333,79,0.01005370
+Cycle Sort,333,80,0.00948300
+Cycle Sort,333,81,0.00945150
+Cycle Sort,333,82,0.01045600
+Cycle Sort,333,83,0.00930240
+Cycle Sort,333,84,0.00916110
+Cycle Sort,333,85,0.00915890
+Cycle Sort,333,86,0.01845610
+Cycle Sort,333,87,0.00996420
+Cycle Sort,333,88,0.00890440
+Cycle Sort,333,89,0.01231720
+Cycle Sort,333,90,0.00921390
+Cycle Sort,333,91,0.00949890
+Cycle Sort,333,92,0.01062580
+Cycle Sort,333,93,0.00908040
+Cycle Sort,333,94,0.01414280
+Cycle Sort,333,95,0.00890560
+Cycle Sort,333,96,0.00936910
+Cycle Sort,333,97,0.01021770
+Cycle Sort,333,98,0.00915980
+Cycle Sort,333,99,0.00913970
+Cycle Sort,333,100,0.00916830
+Cycle Sort,333,101,0.00950100
+Cycle Sort,333,102,0.00912090
+Cycle Sort,333,103,0.02065490
+Cycle Sort,333,104,0.00902620
+Cycle Sort,333,105,0.00899040
+Cycle Sort,333,106,0.01036330
+Cycle Sort,333,107,0.01770480
+Cycle Sort,333,108,0.00907850
+Cycle Sort,333,109,0.00999860
+Cycle Sort,333,110,0.01010500
+Cycle Sort,333,111,0.00904820
+Cycle Sort,333,112,0.00912130
+Cycle Sort,333,113,0.00985750
+Cycle Sort,333,114,0.00909860
+Cycle Sort,333,115,0.00967560
+Cycle Sort,333,116,0.00935760
+Cycle Sort,333,117,0.00881370
+Cycle Sort,333,118,0.01083750
+Cycle Sort,333,119,0.00904470
+Cycle Sort,333,120,0.01144660
+Cycle Sort,333,121,0.00991590
+Cycle Sort,333,122,0.02614950
+Cycle Sort,333,123,0.00918400
+Cycle Sort,333,124,0.00921580
+Cycle Sort,333,125,0.00918680
+Cycle Sort,333,126,0.00897560
+Cycle Sort,333,127,0.00914430
+Cycle Sort,333,128,0.01028410
+Cycle Sort,333,129,0.00936980
+Cycle Sort,333,130,0.01401580
+Cycle Sort,333,131,0.00915960
+Cycle Sort,333,132,0.00972170
+Cycle Sort,333,133,0.00909740
+Cycle Sort,333,134,0.00892420
+Cycle Sort,333,135,0.02071230
+Cycle Sort,333,136,0.01078290
+Cycle Sort,333,137,0.00956800
+Cycle Sort,333,138,0.00888810
+Cycle Sort,333,139,0.00841500
+Cycle Sort,333,140,0.01387070
+Cycle Sort,333,141,0.00914510
+Cycle Sort,333,142,0.01794940
+Cycle Sort,333,143,0.01933060
+Cycle Sort,333,144,0.01025740
+Cycle Sort,333,145,0.00934610
+Cycle Sort,333,146,0.01023340
+Cycle Sort,333,147,0.04060280
+Cycle Sort,333,148,0.00886980
+Cycle Sort,333,149,0.00892970
+Cycle Sort,333,150,0.00966620
+Cycle Sort,333,151,0.01045750
+Cycle Sort,333,152,0.00931920
+Cycle Sort,333,153,0.00987200
+Cycle Sort,333,154,0.00887640
+Cycle Sort,333,155,0.02437770
+Cycle Sort,333,156,0.00918390
+Cycle Sort,333,157,0.00911230
+Cycle Sort,333,158,0.02712930
+Cycle Sort,333,159,0.00924310
+Cycle Sort,333,160,0.00969610
+Cycle Sort,333,161,0.00861710
+Cycle Sort,333,162,0.00882340
+Cycle Sort,333,163,0.00910990
+Cycle Sort,333,164,0.00922440
+Cycle Sort,333,165,0.00912460
+Cycle Sort,333,166,0.00897290
+Cycle Sort,333,167,0.00931490
+Cycle Sort,333,168,0.01132630
+Cycle Sort,333,169,0.00891070
+Cycle Sort,333,170,0.01107150
+Cycle Sort,333,171,0.02639190
+Cycle Sort,333,172,0.01975630
+Cycle Sort,333,173,0.00891490
+Cycle Sort,333,174,0.00904260
+Cycle Sort,333,175,0.00931340
+Cycle Sort,333,176,0.01132370
+Cycle Sort,333,177,0.00907250
+Cycle Sort,333,178,0.01309330
+Cycle Sort,333,179,0.00887980
+Cycle Sort,333,180,0.00914530
+Cycle Sort,333,181,0.01144670
+Cycle Sort,333,182,0.00903090
+Cycle Sort,333,183,0.00909060
+Cycle Sort,333,184,0.00889320
+Cycle Sort,333,185,0.00893520
+Cycle Sort,333,186,0.02533850
+Cycle Sort,333,187,0.01735540
+Cycle Sort,333,188,0.01142260
+Cycle Sort,333,189,0.00890590
+Cycle Sort,333,190,0.01127710
+Cycle Sort,333,191,0.02287560
+Cycle Sort,333,192,0.00944810
+Cycle Sort,333,193,0.00867980
+Cycle Sort,333,194,0.00866210
+Cycle Sort,333,195,0.00892280
+Cycle Sort,333,196,0.00918160
+Cycle Sort,333,197,0.00929230
+Cycle Sort,333,198,0.01111020
+Cycle Sort,333,199,0.00909090
+Cycle Sort,333,200,0.00877870
+Cycle Sort,333,201,0.01050170
+Cycle Sort,333,202,0.00965060
+Cycle Sort,333,203,0.00948860
+Cycle Sort,333,204,0.00926050
+Cycle Sort,333,205,0.00908430
+Cycle Sort,333,206,0.00894040
+Cycle Sort,333,207,0.00888020
+Cycle Sort,333,208,0.00988160
+Cycle Sort,333,209,0.01001890
+Cycle Sort,333,210,0.01012600
+Cycle Sort,333,211,0.00930900
+Cycle Sort,333,212,0.00974230
+Cycle Sort,333,213,0.00915020
+Cycle Sort,333,214,0.01075150
+Cycle Sort,333,215,0.00889530
+Cycle Sort,333,216,0.00916680
+Cycle Sort,333,217,0.00967380
+Cycle Sort,333,218,0.01009330
+Cycle Sort,333,219,0.01062370
+Cycle Sort,333,220,0.00902850
+Cycle Sort,333,221,0.01016690
+Cycle Sort,333,222,0.00905720
+Cycle Sort,333,223,0.00911870
+Cycle Sort,333,224,0.00988260
+Cycle Sort,333,225,0.01090510
+Cycle Sort,333,226,0.00931770
+Cycle Sort,333,227,0.01194510
+Cycle Sort,333,228,0.01042390
+Cycle Sort,333,229,0.00930120
+Cycle Sort,333,230,0.00976040
+Cycle Sort,333,231,0.00912070
+Cycle Sort,333,232,0.01018220
+Cycle Sort,333,233,0.01057540
+Cycle Sort,333,234,0.01141690
+Cycle Sort,333,235,0.00892790
+Cycle Sort,333,236,0.01071610
+Cycle Sort,333,237,0.00924470
+Cycle Sort,333,238,0.00868560
+Cycle Sort,333,239,0.00909680
+Cycle Sort,333,240,0.00952890
+Cycle Sort,333,241,0.00904800
+Cycle Sort,333,242,0.01021450
+Cycle Sort,333,243,0.01108820
+Cycle Sort,333,244,0.00981020
+Cycle Sort,333,245,0.00906970
+Cycle Sort,333,246,0.00888500
+Cycle Sort,333,247,0.01044700
+Cycle Sort,333,248,0.00896540
+Cycle Sort,333,249,0.00918400
+Cycle Sort,333,250,0.01040020
+Cycle Sort,333,251,0.00924530
+Cycle Sort,333,252,0.01386150
+Cycle Sort,333,253,0.01008360
+Cycle Sort,333,254,0.00871000
+Cycle Sort,333,255,0.00887830
+Cycle Sort,333,256,0.00918960
+Cycle Sort,333,257,0.00915110
+Cycle Sort,333,258,0.00883960
+Cycle Sort,333,259,0.01034580
+Cycle Sort,333,260,0.00944690
+Cycle Sort,333,261,0.00901220
+Cycle Sort,333,262,0.00967070
+Cycle Sort,333,263,0.00889050
+Cycle Sort,333,264,0.01051440
+Cycle Sort,333,265,0.01065100
+Cycle Sort,333,266,0.01022860
+Cycle Sort,333,267,0.00954540
+Cycle Sort,333,268,0.00993660
+Cycle Sort,333,269,0.00965820
+Cycle Sort,333,270,0.00885100
+Cycle Sort,333,271,0.00905780
+Cycle Sort,333,272,0.00909560
+Cycle Sort,333,273,0.00904530
+Cycle Sort,333,274,0.00924630
+Cycle Sort,333,275,0.01416270
+Cycle Sort,333,276,0.00965630
+Cycle Sort,333,277,0.01084640
+Cycle Sort,333,278,0.00939510
+Cycle Sort,333,279,0.00949950
+Cycle Sort,333,280,0.00901170
+Cycle Sort,333,281,0.01048570
+Cycle Sort,333,282,0.01101040
+Cycle Sort,333,283,0.00894080
+Cycle Sort,333,284,0.01103110
+Cycle Sort,333,285,0.00915060
+Cycle Sort,333,286,0.01195980
+Cycle Sort,333,287,0.01052900
+Cycle Sort,333,288,0.00882920
+Cycle Sort,333,289,0.00880060
+Cycle Sort,333,290,0.00991850
+Cycle Sort,333,291,0.00900690
+Cycle Sort,333,292,0.01545010
+Cycle Sort,333,293,0.01086780
+Cycle Sort,333,294,0.00921870
+Cycle Sort,333,295,0.00918630
+Cycle Sort,333,296,0.00946880
+Cycle Sort,333,297,0.01014930
+Cycle Sort,333,298,0.01124950
+Cycle Sort,333,299,0.00908340
+Cycle Sort,333,300,0.00884940
+Cycle Sort,333,301,0.00909200
+Cycle Sort,333,302,0.01004370
+Cycle Sort,333,303,0.00908820
+Cycle Sort,333,304,0.01033590
+Cycle Sort,333,305,0.01445380
+Cycle Sort,333,306,0.01067810
+Cycle Sort,333,307,0.00981710
+Cycle Sort,333,308,0.00887970
+Cycle Sort,333,309,0.01002130
+Cycle Sort,333,310,0.00920760
+Cycle Sort,333,311,0.00910990
+Cycle Sort,333,312,0.00968270
+Cycle Sort,333,313,0.01036350
+Cycle Sort,333,314,0.00888890
+Cycle Sort,333,315,0.00909200
+Cycle Sort,333,316,0.00902240
+Cycle Sort,333,317,0.01088150
+Cycle Sort,333,318,0.01097340
+Cycle Sort,333,319,0.00914700
+Cycle Sort,333,320,0.00911960
+Cycle Sort,333,321,0.01293310
+Cycle Sort,333,322,0.00890590
+Cycle Sort,333,323,0.01264160
+Cycle Sort,333,324,0.01112580
+Cycle Sort,333,325,0.00910550
+Cycle Sort,333,326,0.01244590
+Cycle Sort,333,327,0.00953260
+Cycle Sort,333,328,0.00893620
+Cycle Sort,333,329,0.00925220
+Cycle Sort,333,330,0.01085710
+Cycle Sort,333,331,0.00904460
+Cycle Sort,333,332,0.01523330
+Cycle Sort,333,333,0.01178920
+Cycle Sort,333,334,0.01157390
+Cycle Sort,333,335,0.01252240
+Cycle Sort,333,336,0.00890790
+Cycle Sort,333,337,0.00936070
+Cycle Sort,333,338,0.00927320
+Cycle Sort,333,339,0.00910060
+Cycle Sort,333,340,0.01204180
+Cycle Sort,333,341,0.01280390
+Cycle Sort,333,342,0.00895140
+Cycle Sort,333,343,0.01192900
+Cycle Sort,333,344,0.01003090
+Cycle Sort,333,345,0.01333280
+Cycle Sort,333,346,0.01116820
+Cycle Sort,333,347,0.01206370
+Cycle Sort,333,348,0.00892470
+Cycle Sort,333,349,0.00889420
+Cycle Sort,333,350,0.00903130
+Cycle Sort,333,351,0.01003510
+Cycle Sort,333,352,0.01021550
+Cycle Sort,333,353,0.00917410
+Cycle Sort,333,354,0.00887320
+Cycle Sort,333,355,0.00964750
+Cycle Sort,333,356,0.00991110
+Cycle Sort,333,357,0.00894790
+Cycle Sort,333,358,0.00886200
+Cycle Sort,333,359,0.00886250
+Cycle Sort,333,360,0.00941500
+Cycle Sort,333,361,0.00938190
+Cycle Sort,333,362,0.00944920
+Cycle Sort,333,363,0.00947510
+Cycle Sort,333,364,0.00950170
+Cycle Sort,333,365,0.00938210
+Cycle Sort,333,366,0.01052660
+Cycle Sort,333,367,0.00896980
+Cycle Sort,333,368,0.00888140
+Cycle Sort,333,369,0.00931850
+Cycle Sort,333,370,0.00880580
+Cycle Sort,333,371,0.00890580
+Cycle Sort,333,372,0.00980490
+Cycle Sort,333,373,0.01087800
+Cycle Sort,333,374,0.00989910
+Cycle Sort,333,375,0.00893860
+Cycle Sort,333,376,0.01002160
+Cycle Sort,333,377,0.00901440
+Cycle Sort,333,378,0.00915300
+Cycle Sort,333,379,0.00892910
+Cycle Sort,333,380,0.00911570
+Cycle Sort,333,381,0.00993250
+Cycle Sort,333,382,0.00903090
+Cycle Sort,333,383,0.00981960
+Cycle Sort,333,384,0.01053360
+Cycle Sort,333,385,0.00887350
+Cycle Sort,333,386,0.00984210
+Cycle Sort,333,387,0.00932790
+Cycle Sort,333,388,0.00978600
+Cycle Sort,333,389,0.00908280
+Cycle Sort,333,390,0.00904050
+Cycle Sort,333,391,0.01013740
+Cycle Sort,333,392,0.00896510
+Cycle Sort,333,393,0.00993140
+Cycle Sort,333,394,0.01022680
+Cycle Sort,333,395,0.00883890
+Cycle Sort,333,396,0.00920680
+Cycle Sort,333,397,0.01037100
+Cycle Sort,333,398,0.00904630
+Cycle Sort,333,399,0.00908180
+Cycle Sort,333,400,0.00863960
+Cycle Sort,333,401,0.00967120
+Cycle Sort,333,402,0.00961040
+Cycle Sort,333,403,0.01006720
+Cycle Sort,333,404,0.01010440
+Cycle Sort,333,405,0.00901210
+Cycle Sort,333,406,0.00899810
+Cycle Sort,333,407,0.00987660
+Cycle Sort,333,408,0.00910130
+Cycle Sort,333,409,0.00894450
+Cycle Sort,333,410,0.00984970
+Cycle Sort,333,411,0.00953720
+Cycle Sort,333,412,0.00943830
+Cycle Sort,333,413,0.01057160
+Cycle Sort,333,414,0.00915300
+Cycle Sort,333,415,0.00891620
+Cycle Sort,333,416,0.01055400
+Cycle Sort,333,417,0.00936930
+Cycle Sort,333,418,0.00913380
+Cycle Sort,333,419,0.01013530
+Cycle Sort,333,420,0.00935680
+Cycle Sort,333,421,0.00913090
+Cycle Sort,333,422,0.00968140
+Cycle Sort,333,423,0.00923500
+Cycle Sort,333,424,0.00887920
+Cycle Sort,333,425,0.01026540
+Cycle Sort,333,426,0.00924720
+Cycle Sort,333,427,0.00957200
+Cycle Sort,333,428,0.01046490
+Cycle Sort,333,429,0.00923690
+Cycle Sort,333,430,0.00982630
+Cycle Sort,333,431,0.00893150
+Cycle Sort,333,432,0.00921990
+Cycle Sort,333,433,0.00976660
+Cycle Sort,333,434,0.00931600
+Cycle Sort,333,435,0.00926970
+Cycle Sort,333,436,0.00994640
+Cycle Sort,333,437,0.01046810
+Cycle Sort,333,438,0.00943310
+Cycle Sort,333,439,0.00968240
+Cycle Sort,333,440,0.00972130
+Cycle Sort,333,441,0.00917210
+Cycle Sort,333,442,0.00928850
+Cycle Sort,333,443,0.00908020
+Cycle Sort,333,444,0.00916160
+Cycle Sort,333,445,0.01065990
+Cycle Sort,333,446,0.00906760
+Cycle Sort,333,447,0.00910160
+Cycle Sort,333,448,0.01227560
+Cycle Sort,333,449,0.00911970
+Cycle Sort,333,450,0.01096480
+Cycle Sort,333,451,0.01013620
+Cycle Sort,333,452,0.00892990
+Cycle Sort,333,453,0.00917680
+Cycle Sort,333,454,0.01220590
+Cycle Sort,333,455,0.00910160
+Cycle Sort,333,456,0.00922840
+Cycle Sort,333,457,0.01034430
+Cycle Sort,333,458,0.02296290
+Cycle Sort,333,459,0.00950730
+Cycle Sort,333,460,0.00977230
+Cycle Sort,333,461,0.00899840
+Cycle Sort,333,462,0.01007650
+Cycle Sort,333,463,0.00907800
+Cycle Sort,333,464,0.00905890
+Cycle Sort,333,465,0.01035090
+Cycle Sort,333,466,0.01058550
+Cycle Sort,333,467,0.00925850
+Cycle Sort,333,468,0.00918430
+Cycle Sort,333,469,0.00909170
+Cycle Sort,333,470,0.01014080
+Cycle Sort,333,471,0.01042630
+Cycle Sort,333,472,0.01119900
+Cycle Sort,333,473,0.00911100
+Cycle Sort,333,474,0.01461750
+Cycle Sort,333,475,0.01011250
+Cycle Sort,333,476,0.00907960
+Cycle Sort,333,477,0.00919550
+Cycle Sort,333,478,0.01043460
+Cycle Sort,333,479,0.01089610
+Cycle Sort,333,480,0.00919660
+Cycle Sort,333,481,0.01217430
+Cycle Sort,333,482,0.00910980
+Cycle Sort,333,483,0.00917800
+Cycle Sort,333,484,0.00930770
+Cycle Sort,333,485,0.01515970
+Cycle Sort,333,486,0.01179910
+Cycle Sort,333,487,0.01148830
+Cycle Sort,333,488,0.01073050
+Cycle Sort,333,489,0.00906140
+Cycle Sort,333,490,0.00915550
+Cycle Sort,333,491,0.00901830
+Cycle Sort,333,492,0.01213590
+Cycle Sort,333,493,0.01093430
+Cycle Sort,333,494,0.01455030
+Cycle Sort,333,495,0.00924580
+Cycle Sort,333,496,0.01223200
+Cycle Sort,333,497,0.01291850
+Cycle Sort,333,498,0.00916750
+Cycle Sort,333,499,0.00999530
+Cycle Sort,333,500,0.00912950
+Exchange Sort,333,1,0.00580780
+Exchange Sort,333,2,0.00574770
+Exchange Sort,333,3,0.00516330
+Exchange Sort,333,4,0.00473010
+Exchange Sort,333,5,0.00571000
+Exchange Sort,333,6,0.00684650
+Exchange Sort,333,7,0.00485590
+Exchange Sort,333,8,0.00621960
+Exchange Sort,333,9,0.00681220
+Exchange Sort,333,10,0.00488760
+Exchange Sort,333,11,0.00801710
+Exchange Sort,333,12,0.00589360
+Exchange Sort,333,13,0.00481540
+Exchange Sort,333,14,0.00480700
+Exchange Sort,333,15,0.00808030
+Exchange Sort,333,16,0.00498290
+Exchange Sort,333,17,0.00648030
+Exchange Sort,333,18,0.00494950
+Exchange Sort,333,19,0.00478420
+Exchange Sort,333,20,0.00522160
+Exchange Sort,333,21,0.00605600
+Exchange Sort,333,22,0.00493440
+Exchange Sort,333,23,0.00580020
+Exchange Sort,333,24,0.00540860
+Exchange Sort,333,25,0.00485370
+Exchange Sort,333,26,0.00474460
+Exchange Sort,333,27,0.00506690
+Exchange Sort,333,28,0.00480680
+Exchange Sort,333,29,0.00567730
+Exchange Sort,333,30,0.00560540
+Exchange Sort,333,31,0.00565250
+Exchange Sort,333,32,0.00493170
+Exchange Sort,333,33,0.00568030
+Exchange Sort,333,34,0.00505540
+Exchange Sort,333,35,0.00624850
+Exchange Sort,333,36,0.00479460
+Exchange Sort,333,37,0.00511130
+Exchange Sort,333,38,0.00549370
+Exchange Sort,333,39,0.00493060
+Exchange Sort,333,40,0.00596830
+Exchange Sort,333,41,0.00489090
+Exchange Sort,333,42,0.00581010
+Exchange Sort,333,43,0.00659710
+Exchange Sort,333,44,0.00483500
+Exchange Sort,333,45,0.00489620
+Exchange Sort,333,46,0.00620830
+Exchange Sort,333,47,0.00622370
+Exchange Sort,333,48,0.00489570
+Exchange Sort,333,49,0.00480340
+Exchange Sort,333,50,0.00920910
+Exchange Sort,333,51,0.00490090
+Exchange Sort,333,52,0.00577620
+Exchange Sort,333,53,0.00474830
+Exchange Sort,333,54,0.00562880
+Exchange Sort,333,55,0.00533650
+Exchange Sort,333,56,0.00481690
+Exchange Sort,333,57,0.00479540
+Exchange Sort,333,58,0.00575490
+Exchange Sort,333,59,0.00482570
+Exchange Sort,333,60,0.00482850
+Exchange Sort,333,61,0.00555490
+Exchange Sort,333,62,0.00571820
+Exchange Sort,333,63,0.00480710
+Exchange Sort,333,64,0.00502760
+Exchange Sort,333,65,0.00533080
+Exchange Sort,333,66,0.00555310
+Exchange Sort,333,67,0.00616820
+Exchange Sort,333,68,0.00533490
+Exchange Sort,333,69,0.00489560
+Exchange Sort,333,70,0.00545190
+Exchange Sort,333,71,0.00484380
+Exchange Sort,333,72,0.00475610
+Exchange Sort,333,73,0.00565850
+Exchange Sort,333,74,0.00718780
+Exchange Sort,333,75,0.00629760
+Exchange Sort,333,76,0.00489740
+Exchange Sort,333,77,0.00461550
+Exchange Sort,333,78,0.00640230
+Exchange Sort,333,79,0.00601290
+Exchange Sort,333,80,0.00489700
+Exchange Sort,333,81,0.00494190
+Exchange Sort,333,82,0.00542500
+Exchange Sort,333,83,0.00466330
+Exchange Sort,333,84,0.00499920
+Exchange Sort,333,85,0.00500680
+Exchange Sort,333,86,0.00560840
+Exchange Sort,333,87,0.01448630
+Exchange Sort,333,88,0.00479680
+Exchange Sort,333,89,0.00556070
+Exchange Sort,333,90,0.00475660
+Exchange Sort,333,91,0.00503370
+Exchange Sort,333,92,0.00476690
+Exchange Sort,333,93,0.00488110
+Exchange Sort,333,94,0.00702200
+Exchange Sort,333,95,0.00699270
+Exchange Sort,333,96,0.00474840
+Exchange Sort,333,97,0.00481790
+Exchange Sort,333,98,0.00761920
+Exchange Sort,333,99,0.00526870
+Exchange Sort,333,100,0.00483710
+Exchange Sort,333,101,0.00563360
+Exchange Sort,333,102,0.00480120
+Exchange Sort,333,103,0.00478180
+Exchange Sort,333,104,0.00473400
+Exchange Sort,333,105,0.00634960
+Exchange Sort,333,106,0.00490550
+Exchange Sort,333,107,0.00532390
+Exchange Sort,333,108,0.00529010
+Exchange Sort,333,109,0.00770150
+Exchange Sort,333,110,0.00490690
+Exchange Sort,333,111,0.00492850
+Exchange Sort,333,112,0.00484380
+Exchange Sort,333,113,0.00507820
+Exchange Sort,333,114,0.00498410
+Exchange Sort,333,115,0.00562710
+Exchange Sort,333,116,0.00555220
+Exchange Sort,333,117,0.00639540
+Exchange Sort,333,118,0.00475940
+Exchange Sort,333,119,0.00495090
+Exchange Sort,333,120,0.00462940
+Exchange Sort,333,121,0.00604960
+Exchange Sort,333,122,0.00856510
+Exchange Sort,333,123,0.00495600
+Exchange Sort,333,124,0.00613260
+Exchange Sort,333,125,0.00739360
+Exchange Sort,333,126,0.00494880
+Exchange Sort,333,127,0.00477910
+Exchange Sort,333,128,0.00483510
+Exchange Sort,333,129,0.00535390
+Exchange Sort,333,130,0.00495030
+Exchange Sort,333,131,0.00480600
+Exchange Sort,333,132,0.00672990
+Exchange Sort,333,133,0.00552290
+Exchange Sort,333,134,0.00474890
+Exchange Sort,333,135,0.00589580
+Exchange Sort,333,136,0.00529340
+Exchange Sort,333,137,0.00516580
+Exchange Sort,333,138,0.00497100
+Exchange Sort,333,139,0.00502390
+Exchange Sort,333,140,0.00472420
+Exchange Sort,333,141,0.00486850
+Exchange Sort,333,142,0.00583920
+Exchange Sort,333,143,0.00540620
+Exchange Sort,333,144,0.00471570
+Exchange Sort,333,145,0.00484600
+Exchange Sort,333,146,0.00479060
+Exchange Sort,333,147,0.00484480
+Exchange Sort,333,148,0.00497230
+Exchange Sort,333,149,0.00502100
+Exchange Sort,333,150,0.00477560
+Exchange Sort,333,151,0.00492030
+Exchange Sort,333,152,0.00488680
+Exchange Sort,333,153,0.00477010
+Exchange Sort,333,154,0.00477700
+Exchange Sort,333,155,0.00514450
+Exchange Sort,333,156,0.00485660
+Exchange Sort,333,157,0.00546710
+Exchange Sort,333,158,0.00501490
+Exchange Sort,333,159,0.00479910
+Exchange Sort,333,160,0.00519520
+Exchange Sort,333,161,0.00486270
+Exchange Sort,333,162,0.00480320
+Exchange Sort,333,163,0.00492670
+Exchange Sort,333,164,0.00491330
+Exchange Sort,333,165,0.00560020
+Exchange Sort,333,166,0.00548040
+Exchange Sort,333,167,0.00541540
+Exchange Sort,333,168,0.00474070
+Exchange Sort,333,169,0.00496880
+Exchange Sort,333,170,0.00487620
+Exchange Sort,333,171,0.00473190
+Exchange Sort,333,172,0.00487620
+Exchange Sort,333,173,0.00499050
+Exchange Sort,333,174,0.00540370
+Exchange Sort,333,175,0.00475090
+Exchange Sort,333,176,0.00540770
+Exchange Sort,333,177,0.00480130
+Exchange Sort,333,178,0.00579840
+Exchange Sort,333,179,0.00521720
+Exchange Sort,333,180,0.00551840
+Exchange Sort,333,181,0.00496930
+Exchange Sort,333,182,0.00498090
+Exchange Sort,333,183,0.00532780
+Exchange Sort,333,184,0.00496040
+Exchange Sort,333,185,0.00479660
+Exchange Sort,333,186,0.00661090
+Exchange Sort,333,187,0.00470430
+Exchange Sort,333,188,0.00475860
+Exchange Sort,333,189,0.00484800
+Exchange Sort,333,190,0.00535870
+Exchange Sort,333,191,0.00588710
+Exchange Sort,333,192,0.00541660
+Exchange Sort,333,193,0.00508250
+Exchange Sort,333,194,0.00484710
+Exchange Sort,333,195,0.00541370
+Exchange Sort,333,196,0.00471780
+Exchange Sort,333,197,0.00577390
+Exchange Sort,333,198,0.00488200
+Exchange Sort,333,199,0.00469270
+Exchange Sort,333,200,0.00527910
+Exchange Sort,333,201,0.00580630
+Exchange Sort,333,202,0.00485080
+Exchange Sort,333,203,0.00501410
+Exchange Sort,333,204,0.00534410
+Exchange Sort,333,205,0.00538100
+Exchange Sort,333,206,0.00488050
+Exchange Sort,333,207,0.00468910
+Exchange Sort,333,208,0.00465290
+Exchange Sort,333,209,0.00482760
+Exchange Sort,333,210,0.00487750
+Exchange Sort,333,211,0.00470080
+Exchange Sort,333,212,0.00612290
+Exchange Sort,333,213,0.00598670
+Exchange Sort,333,214,0.00476970
+Exchange Sort,333,215,0.00480170
+Exchange Sort,333,216,0.00492580
+Exchange Sort,333,217,0.00460110
+Exchange Sort,333,218,0.00476380
+Exchange Sort,333,219,0.00476040
+Exchange Sort,333,220,0.00487810
+Exchange Sort,333,221,0.00611840
+Exchange Sort,333,222,0.00508620
+Exchange Sort,333,223,0.00484360
+Exchange Sort,333,224,0.00497940
+Exchange Sort,333,225,0.00694570
+Exchange Sort,333,226,0.00485520
+Exchange Sort,333,227,0.00481290
+Exchange Sort,333,228,0.00479150
+Exchange Sort,333,229,0.00488390
+Exchange Sort,333,230,0.00492610
+Exchange Sort,333,231,0.00489240
+Exchange Sort,333,232,0.00476580
+Exchange Sort,333,233,0.00593780
+Exchange Sort,333,234,0.00480790
+Exchange Sort,333,235,0.00570750
+Exchange Sort,333,236,0.00534880
+Exchange Sort,333,237,0.00478010
+Exchange Sort,333,238,0.00524740
+Exchange Sort,333,239,0.00481020
+Exchange Sort,333,240,0.00480600
+Exchange Sort,333,241,0.00483850
+Exchange Sort,333,242,0.00476210
+Exchange Sort,333,243,0.00567790
+Exchange Sort,333,244,0.00480750
+Exchange Sort,333,245,0.00521200
+Exchange Sort,333,246,0.00518710
+Exchange Sort,333,247,0.00545400
+Exchange Sort,333,248,0.00475500
+Exchange Sort,333,249,0.00484160
+Exchange Sort,333,250,0.00491120
+Exchange Sort,333,251,0.00506640
+Exchange Sort,333,252,0.00585300
+Exchange Sort,333,253,0.00485540
+Exchange Sort,333,254,0.00601410
+Exchange Sort,333,255,0.00492630
+Exchange Sort,333,256,0.00547310
+Exchange Sort,333,257,0.00491270
+Exchange Sort,333,258,0.00483640
+Exchange Sort,333,259,0.01025340
+Exchange Sort,333,260,0.00505220
+Exchange Sort,333,261,0.00492280
+Exchange Sort,333,262,0.00492510
+Exchange Sort,333,263,0.00497300
+Exchange Sort,333,264,0.00774880
+Exchange Sort,333,265,0.00601820
+Exchange Sort,333,266,0.00557280
+Exchange Sort,333,267,0.00480080
+Exchange Sort,333,268,0.00482180
+Exchange Sort,333,269,0.00488550
+Exchange Sort,333,270,0.00490300
+Exchange Sort,333,271,0.00661230
+Exchange Sort,333,272,0.00488870
+Exchange Sort,333,273,0.00517660
+Exchange Sort,333,274,0.00490630
+Exchange Sort,333,275,0.00491710
+Exchange Sort,333,276,0.00478070
+Exchange Sort,333,277,0.00554820
+Exchange Sort,333,278,0.00491640
+Exchange Sort,333,279,0.00475480
+Exchange Sort,333,280,0.00570150
+Exchange Sort,333,281,0.00631890
+Exchange Sort,333,282,0.00852150
+Exchange Sort,333,283,0.00489210
+Exchange Sort,333,284,0.00499530
+Exchange Sort,333,285,0.00993270
+Exchange Sort,333,286,0.00473240
+Exchange Sort,333,287,0.00485470
+Exchange Sort,333,288,0.01824650
+Exchange Sort,333,289,0.00492850
+Exchange Sort,333,290,0.00499900
+Exchange Sort,333,291,0.00487050
+Exchange Sort,333,292,0.00585380
+Exchange Sort,333,293,0.00490010
+Exchange Sort,333,294,0.00566150
+Exchange Sort,333,295,0.00630460
+Exchange Sort,333,296,0.00497120
+Exchange Sort,333,297,0.00564420
+Exchange Sort,333,298,0.00496610
+Exchange Sort,333,299,0.00474890
+Exchange Sort,333,300,0.00488150
+Exchange Sort,333,301,0.00494280
+Exchange Sort,333,302,0.00562540
+Exchange Sort,333,303,0.00494060
+Exchange Sort,333,304,0.00830360
+Exchange Sort,333,305,0.00502000
+Exchange Sort,333,306,0.00480980
+Exchange Sort,333,307,0.00531030
+Exchange Sort,333,308,0.00491110
+Exchange Sort,333,309,0.00488050
+Exchange Sort,333,310,0.00547810
+Exchange Sort,333,311,0.00585550
+Exchange Sort,333,312,0.00498190
+Exchange Sort,333,313,0.00556180
+Exchange Sort,333,314,0.00486690
+Exchange Sort,333,315,0.00569500
+Exchange Sort,333,316,0.00498250
+Exchange Sort,333,317,0.00480980
+Exchange Sort,333,318,0.01992450
+Exchange Sort,333,319,0.00505410
+Exchange Sort,333,320,0.00483620
+Exchange Sort,333,321,0.00490050
+Exchange Sort,333,322,0.00574420
+Exchange Sort,333,323,0.00489940
+Exchange Sort,333,324,0.00573510
+Exchange Sort,333,325,0.00486620
+Exchange Sort,333,326,0.00574190
+Exchange Sort,333,327,0.00485800
+Exchange Sort,333,328,0.00533280
+Exchange Sort,333,329,0.00497840
+Exchange Sort,333,330,0.00593770
+Exchange Sort,333,331,0.00531450
+Exchange Sort,333,332,0.00485860
+Exchange Sort,333,333,0.00617780
+Exchange Sort,333,334,0.00648050
+Exchange Sort,333,335,0.00490680
+Exchange Sort,333,336,0.00787750
+Exchange Sort,333,337,0.00478270
+Exchange Sort,333,338,0.01296730
+Exchange Sort,333,339,0.00498140
+Exchange Sort,333,340,0.00997200
+Exchange Sort,333,341,0.00478290
+Exchange Sort,333,342,0.00641090
+Exchange Sort,333,343,0.00588240
+Exchange Sort,333,344,0.00491790
+Exchange Sort,333,345,0.00480020
+Exchange Sort,333,346,0.00496190
+Exchange Sort,333,347,0.00489290
+Exchange Sort,333,348,0.00490800
+Exchange Sort,333,349,0.00568220
+Exchange Sort,333,350,0.00580850
+Exchange Sort,333,351,0.00515890
+Exchange Sort,333,352,0.00477760
+Exchange Sort,333,353,0.00499080
+Exchange Sort,333,354,0.00583220
+Exchange Sort,333,355,0.00550850
+Exchange Sort,333,356,0.00540040
+Exchange Sort,333,357,0.00922270
+Exchange Sort,333,358,0.00481750
+Exchange Sort,333,359,0.00505390
+Exchange Sort,333,360,0.00493600
+Exchange Sort,333,361,0.00767400
+Exchange Sort,333,362,0.00489170
+Exchange Sort,333,363,0.00599960
+Exchange Sort,333,364,0.00473630
+Exchange Sort,333,365,0.00646090
+Exchange Sort,333,366,0.00481750
+Exchange Sort,333,367,0.00484510
+Exchange Sort,333,368,0.00500060
+Exchange Sort,333,369,0.00485660
+Exchange Sort,333,370,0.00530490
+Exchange Sort,333,371,0.00487630
+Exchange Sort,333,372,0.00529850
+Exchange Sort,333,373,0.00863150
+Exchange Sort,333,374,0.00666260
+Exchange Sort,333,375,0.00760990
+Exchange Sort,333,376,0.00492050
+Exchange Sort,333,377,0.00531870
+Exchange Sort,333,378,0.00519580
+Exchange Sort,333,379,0.00508210
+Exchange Sort,333,380,0.00532310
+Exchange Sort,333,381,0.00496840
+Exchange Sort,333,382,0.00496380
+Exchange Sort,333,383,0.00484320
+Exchange Sort,333,384,0.00480640
+Exchange Sort,333,385,0.00561990
+Exchange Sort,333,386,0.00553540
+Exchange Sort,333,387,0.00529600
+Exchange Sort,333,388,0.00512860
+Exchange Sort,333,389,0.00554020
+Exchange Sort,333,390,0.00472530
+Exchange Sort,333,391,0.00490060
+Exchange Sort,333,392,0.00507240
+Exchange Sort,333,393,0.00476700
+Exchange Sort,333,394,0.00631630
+Exchange Sort,333,395,0.00488600
+Exchange Sort,333,396,0.00573940
+Exchange Sort,333,397,0.00530670
+Exchange Sort,333,398,0.00511220
+Exchange Sort,333,399,0.00516760
+Exchange Sort,333,400,0.00486220
+Exchange Sort,333,401,0.00479220
+Exchange Sort,333,402,0.00574560
+Exchange Sort,333,403,0.00489820
+Exchange Sort,333,404,0.00529630
+Exchange Sort,333,405,0.00532490
+Exchange Sort,333,406,0.00598050
+Exchange Sort,333,407,0.00478080
+Exchange Sort,333,408,0.00485100
+Exchange Sort,333,409,0.00481780
+Exchange Sort,333,410,0.00471250
+Exchange Sort,333,411,0.00561650
+Exchange Sort,333,412,0.00489420
+Exchange Sort,333,413,0.00567500
+Exchange Sort,333,414,0.00486180
+Exchange Sort,333,415,0.00562800
+Exchange Sort,333,416,0.00479600
+Exchange Sort,333,417,0.00536950
+Exchange Sort,333,418,0.00487820
+Exchange Sort,333,419,0.00477200
+Exchange Sort,333,420,0.00528350
+Exchange Sort,333,421,0.00589230
+Exchange Sort,333,422,0.00525400
+Exchange Sort,333,423,0.00519200
+Exchange Sort,333,424,0.00546430
+Exchange Sort,333,425,0.00506400
+Exchange Sort,333,426,0.00542490
+Exchange Sort,333,427,0.00534390
+Exchange Sort,333,428,0.00507150
+Exchange Sort,333,429,0.00480790
+Exchange Sort,333,430,0.00507160
+Exchange Sort,333,431,0.00485690
+Exchange Sort,333,432,0.00469800
+Exchange Sort,333,433,0.00547860
+Exchange Sort,333,434,0.00565040
+Exchange Sort,333,435,0.00483770
+Exchange Sort,333,436,0.00509600
+Exchange Sort,333,437,0.00522700
+Exchange Sort,333,438,0.00560310
+Exchange Sort,333,439,0.00483530
+Exchange Sort,333,440,0.00474270
+Exchange Sort,333,441,0.00484040
+Exchange Sort,333,442,0.00528810
+Exchange Sort,333,443,0.00492590
+Exchange Sort,333,444,0.00481580
+Exchange Sort,333,445,0.00514710
+Exchange Sort,333,446,0.00508070
+Exchange Sort,333,447,0.00493780
+Exchange Sort,333,448,0.00483270
+Exchange Sort,333,449,0.00580520
+Exchange Sort,333,450,0.00472410
+Exchange Sort,333,451,0.00521130
+Exchange Sort,333,452,0.00487770
+Exchange Sort,333,453,0.00473130
+Exchange Sort,333,454,0.00511260
+Exchange Sort,333,455,0.00471370
+Exchange Sort,333,456,0.00479710
+Exchange Sort,333,457,0.00480620
+Exchange Sort,333,458,0.00484740
+Exchange Sort,333,459,0.00563970
+Exchange Sort,333,460,0.00477700
+Exchange Sort,333,461,0.00484540
+Exchange Sort,333,462,0.00531870
+Exchange Sort,333,463,0.00483770
+Exchange Sort,333,464,0.00553790
+Exchange Sort,333,465,0.00478960
+Exchange Sort,333,466,0.00514500
+Exchange Sort,333,467,0.00485190
+Exchange Sort,333,468,0.00486050
+Exchange Sort,333,469,0.00488270
+Exchange Sort,333,470,0.00535050
+Exchange Sort,333,471,0.00476700
+Exchange Sort,333,472,0.00503950
+Exchange Sort,333,473,0.00594630
+Exchange Sort,333,474,0.00478660
+Exchange Sort,333,475,0.00476990
+Exchange Sort,333,476,0.00504120
+Exchange Sort,333,477,0.00804010
+Exchange Sort,333,478,0.00485050
+Exchange Sort,333,479,0.00481200
+Exchange Sort,333,480,0.00474920
+Exchange Sort,333,481,0.00636440
+Exchange Sort,333,482,0.00592540
+Exchange Sort,333,483,0.00487390
+Exchange Sort,333,484,0.00490420
+Exchange Sort,333,485,0.00484550
+Exchange Sort,333,486,0.00489270
+Exchange Sort,333,487,0.00478160
+Exchange Sort,333,488,0.00481960
+Exchange Sort,333,489,0.00556470
+Exchange Sort,333,490,0.00520300
+Exchange Sort,333,491,0.00490310
+Exchange Sort,333,492,0.00486800
+Exchange Sort,333,493,0.00524140
+Exchange Sort,333,494,0.00496830
+Exchange Sort,333,495,0.00563150
+Exchange Sort,333,496,0.00482770
+Exchange Sort,333,497,0.00546330
+Exchange Sort,333,498,0.00528650
+Exchange Sort,333,499,0.00477800
+Exchange Sort,333,500,0.00642660
+Flash Sort,333,1,0.00031110
+Flash Sort,333,2,0.00031420
+Flash Sort,333,3,0.00030470
+Flash Sort,333,4,0.00029470
+Flash Sort,333,5,0.00029260
+Flash Sort,333,6,0.00047960
+Flash Sort,333,7,0.00028400
+Flash Sort,333,8,0.00028910
+Flash Sort,333,9,0.00032480
+Flash Sort,333,10,0.00031800
+Flash Sort,333,11,0.00050260
+Flash Sort,333,12,0.00030280
+Flash Sort,333,13,0.00029350
+Flash Sort,333,14,0.00029060
+Flash Sort,333,15,0.00031190
+Flash Sort,333,16,0.00029640
+Flash Sort,333,17,0.00030190
+Flash Sort,333,18,0.00029570
+Flash Sort,333,19,0.00028510
+Flash Sort,333,20,0.00029520
+Flash Sort,333,21,0.00030300
+Flash Sort,333,22,0.00028750
+Flash Sort,333,23,0.00029660
+Flash Sort,333,24,0.00028230
+Flash Sort,333,25,0.00036330
+Flash Sort,333,26,0.00029150
+Flash Sort,333,27,0.00029390
+Flash Sort,333,28,0.00028820
+Flash Sort,333,29,0.00030980
+Flash Sort,333,30,0.00028640
+Flash Sort,333,31,0.00030410
+Flash Sort,333,32,0.00029670
+Flash Sort,333,33,0.00030790
+Flash Sort,333,34,0.00029810
+Flash Sort,333,35,0.00035390
+Flash Sort,333,36,0.00029470
+Flash Sort,333,37,0.00028440
+Flash Sort,333,38,0.00029850
+Flash Sort,333,39,0.00029590
+Flash Sort,333,40,0.00030550
+Flash Sort,333,41,0.00031040
+Flash Sort,333,42,0.00028440
+Flash Sort,333,43,0.00029940
+Flash Sort,333,44,0.00030140
+Flash Sort,333,45,0.00028810
+Flash Sort,333,46,0.00030610
+Flash Sort,333,47,0.00030510
+Flash Sort,333,48,0.00030270
+Flash Sort,333,49,0.00030230
+Flash Sort,333,50,0.00028270
+Flash Sort,333,51,0.00030700
+Flash Sort,333,52,0.00030420
+Flash Sort,333,53,0.00028010
+Flash Sort,333,54,0.00029550
+Flash Sort,333,55,0.00029460
+Flash Sort,333,56,0.00030110
+Flash Sort,333,57,0.00029650
+Flash Sort,333,58,0.00029010
+Flash Sort,333,59,0.00028870
+Flash Sort,333,60,0.00033010
+Flash Sort,333,61,0.00028410
+Flash Sort,333,62,0.00029300
+Flash Sort,333,63,0.00028940
+Flash Sort,333,64,0.00029790
+Flash Sort,333,65,0.00029480
+Flash Sort,333,66,0.00028260
+Flash Sort,333,67,0.00030100
+Flash Sort,333,68,0.00028990
+Flash Sort,333,69,0.00027820
+Flash Sort,333,70,0.00028720
+Flash Sort,333,71,0.00029150
+Flash Sort,333,72,0.00028470
+Flash Sort,333,73,0.00031660
+Flash Sort,333,74,0.00029780
+Flash Sort,333,75,0.00029000
+Flash Sort,333,76,0.00031070
+Flash Sort,333,77,0.00028810
+Flash Sort,333,78,0.00029660
+Flash Sort,333,79,0.00024040
+Flash Sort,333,80,0.00028340
+Flash Sort,333,81,0.00028130
+Flash Sort,333,82,0.00027240
+Flash Sort,333,83,0.00029810
+Flash Sort,333,84,0.00030390
+Flash Sort,333,85,0.00030120
+Flash Sort,333,86,0.00028200
+Flash Sort,333,87,0.00025590
+Flash Sort,333,88,0.00028840
+Flash Sort,333,89,0.00029830
+Flash Sort,333,90,0.00029480
+Flash Sort,333,91,0.00028390
+Flash Sort,333,92,0.00029250
+Flash Sort,333,93,0.00030100
+Flash Sort,333,94,0.00029040
+Flash Sort,333,95,0.00029200
+Flash Sort,333,96,0.00029420
+Flash Sort,333,97,0.00029620
+Flash Sort,333,98,0.00028940
+Flash Sort,333,99,0.00029010
+Flash Sort,333,100,0.00029150
+Flash Sort,333,101,0.00028980
+Flash Sort,333,102,0.00030060
+Flash Sort,333,103,0.00029080
+Flash Sort,333,104,0.00030160
+Flash Sort,333,105,0.00028060
+Flash Sort,333,106,0.00029870
+Flash Sort,333,107,0.00029370
+Flash Sort,333,108,0.00029230
+Flash Sort,333,109,0.00029740
+Flash Sort,333,110,0.00029210
+Flash Sort,333,111,0.00030390
+Flash Sort,333,112,0.00029490
+Flash Sort,333,113,0.00028770
+Flash Sort,333,114,0.00030510
+Flash Sort,333,115,0.00029470
+Flash Sort,333,116,0.00030140
+Flash Sort,333,117,0.00029690
+Flash Sort,333,118,0.00029370
+Flash Sort,333,119,0.00027440
+Flash Sort,333,120,0.00029730
+Flash Sort,333,121,0.00029090
+Flash Sort,333,122,0.00030450
+Flash Sort,333,123,0.00025850
+Flash Sort,333,124,0.00024380
+Flash Sort,333,125,0.00027700
+Flash Sort,333,126,0.00028720
+Flash Sort,333,127,0.00029850
+Flash Sort,333,128,0.00030740
+Flash Sort,333,129,0.00029540
+Flash Sort,333,130,0.00024090
+Flash Sort,333,131,0.00029860
+Flash Sort,333,132,0.00029410
+Flash Sort,333,133,0.00021590
+Flash Sort,333,134,0.00028660
+Flash Sort,333,135,0.00020220
+Flash Sort,333,136,0.00025960
+Flash Sort,333,137,0.00028130
+Flash Sort,333,138,0.00017600
+Flash Sort,333,139,0.00028490
+Flash Sort,333,140,0.00029740
+Flash Sort,333,141,0.00019080
+Flash Sort,333,142,0.00024270
+Flash Sort,333,143,0.00020370
+Flash Sort,333,144,0.00026570
+Flash Sort,333,145,0.00028560
+Flash Sort,333,146,0.00028870
+Flash Sort,333,147,0.00031190
+Flash Sort,333,148,0.00031540
+Flash Sort,333,149,0.00029180
+Flash Sort,333,150,0.00029800
+Flash Sort,333,151,0.00029610
+Flash Sort,333,152,0.00028610
+Flash Sort,333,153,0.00028890
+Flash Sort,333,154,0.00018490
+Flash Sort,333,155,0.00028670
+Flash Sort,333,156,0.00018800
+Flash Sort,333,157,0.00019520
+Flash Sort,333,158,0.00025540
+Flash Sort,333,159,0.00020600
+Flash Sort,333,160,0.00028050
+Flash Sort,333,161,0.00022870
+Flash Sort,333,162,0.00016770
+Flash Sort,333,163,0.00019980
+Flash Sort,333,164,0.00027800
+Flash Sort,333,165,0.00022500
+Flash Sort,333,166,0.00030510
+Flash Sort,333,167,0.00023460
+Flash Sort,333,168,0.00028920
+Flash Sort,333,169,0.00018570
+Flash Sort,333,170,0.00030930
+Flash Sort,333,171,0.00028640
+Flash Sort,333,172,0.00027470
+Flash Sort,333,173,0.00020820
+Flash Sort,333,174,0.00029580
+Flash Sort,333,175,0.00029300
+Flash Sort,333,176,0.00028260
+Flash Sort,333,177,0.00022630
+Flash Sort,333,178,0.00029300
+Flash Sort,333,179,0.00028530
+Flash Sort,333,180,0.00019390
+Flash Sort,333,181,0.00030160
+Flash Sort,333,182,0.00030360
+Flash Sort,333,183,0.00027760
+Flash Sort,333,184,0.00026990
+Flash Sort,333,185,0.00030650
+Flash Sort,333,186,0.00028760
+Flash Sort,333,187,0.00026300
+Flash Sort,333,188,0.00029910
+Flash Sort,333,189,0.00025060
+Flash Sort,333,190,0.00028680
+Flash Sort,333,191,0.00028610
+Flash Sort,333,192,0.00029080
+Flash Sort,333,193,0.00026650
+Flash Sort,333,194,0.00019210
+Flash Sort,333,195,0.00028440
+Flash Sort,333,196,0.00029730
+Flash Sort,333,197,0.00026400
+Flash Sort,333,198,0.00029400
+Flash Sort,333,199,0.00028120
+Flash Sort,333,200,0.00030110
+Flash Sort,333,201,0.00028880
+Flash Sort,333,202,0.00028930
+Flash Sort,333,203,0.00028770
+Flash Sort,333,204,0.00023710
+Flash Sort,333,205,0.00028130
+Flash Sort,333,206,0.00027730
+Flash Sort,333,207,0.00032100
+Flash Sort,333,208,0.00025420
+Flash Sort,333,209,0.00016320
+Flash Sort,333,210,0.00029880
+Flash Sort,333,211,0.00018900
+Flash Sort,333,212,0.00028450
+Flash Sort,333,213,0.00028810
+Flash Sort,333,214,0.00027980
+Flash Sort,333,215,0.00016130
+Flash Sort,333,216,0.00028820
+Flash Sort,333,217,0.00028050
+Flash Sort,333,218,0.00028290
+Flash Sort,333,219,0.00016240
+Flash Sort,333,220,0.00016690
+Flash Sort,333,221,0.00028950
+Flash Sort,333,222,0.00028820
+Flash Sort,333,223,0.00026290
+Flash Sort,333,224,0.00020660
+Flash Sort,333,225,0.00028380
+Flash Sort,333,226,0.00026040
+Flash Sort,333,227,0.00018160
+Flash Sort,333,228,0.00018900
+Flash Sort,333,229,0.00028410
+Flash Sort,333,230,0.00019280
+Flash Sort,333,231,0.00028170
+Flash Sort,333,232,0.00019840
+Flash Sort,333,233,0.00028110
+Flash Sort,333,234,0.00028100
+Flash Sort,333,235,0.00016060
+Flash Sort,333,236,0.00018020
+Flash Sort,333,237,0.00017000
+Flash Sort,333,238,0.00016570
+Flash Sort,333,239,0.00016070
+Flash Sort,333,240,0.00028910
+Flash Sort,333,241,0.00017620
+Flash Sort,333,242,0.00028700
+Flash Sort,333,243,0.00028310
+Flash Sort,333,244,0.00024260
+Flash Sort,333,245,0.00029170
+Flash Sort,333,246,0.00027210
+Flash Sort,333,247,0.00029490
+Flash Sort,333,248,0.00018870
+Flash Sort,333,249,0.00025190
+Flash Sort,333,250,0.00028980
+Flash Sort,333,251,0.00022480
+Flash Sort,333,252,0.00016180
+Flash Sort,333,253,0.00028970
+Flash Sort,333,254,0.00019890
+Flash Sort,333,255,0.00028700
+Flash Sort,333,256,0.00025570
+Flash Sort,333,257,0.00028810
+Flash Sort,333,258,0.00020330
+Flash Sort,333,259,0.00030900
+Flash Sort,333,260,0.00024690
+Flash Sort,333,261,0.00028180
+Flash Sort,333,262,0.00018470
+Flash Sort,333,263,0.00029060
+Flash Sort,333,264,0.00028790
+Flash Sort,333,265,0.00028950
+Flash Sort,333,266,0.00024790
+Flash Sort,333,267,0.00029170
+Flash Sort,333,268,0.00028740
+Flash Sort,333,269,0.00016290
+Flash Sort,333,270,0.00028230
+Flash Sort,333,271,0.00030850
+Flash Sort,333,272,0.00030770
+Flash Sort,333,273,0.00028320
+Flash Sort,333,274,0.00019500
+Flash Sort,333,275,0.00029700
+Flash Sort,333,276,0.00030840
+Flash Sort,333,277,0.00016740
+Flash Sort,333,278,0.00025110
+Flash Sort,333,279,0.00027060
+Flash Sort,333,280,0.00023060
+Flash Sort,333,281,0.00016410
+Flash Sort,333,282,0.00027480
+Flash Sort,333,283,0.00028860
+Flash Sort,333,284,0.00026730
+Flash Sort,333,285,0.00017570
+Flash Sort,333,286,0.00019660
+Flash Sort,333,287,0.00016210
+Flash Sort,333,288,0.00020840
+Flash Sort,333,289,0.00016040
+Flash Sort,333,290,0.00029050
+Flash Sort,333,291,0.00028280
+Flash Sort,333,292,0.00029310
+Flash Sort,333,293,0.00026990
+Flash Sort,333,294,0.00029060
+Flash Sort,333,295,0.00028330
+Flash Sort,333,296,0.00016220
+Flash Sort,333,297,0.00028630
+Flash Sort,333,298,0.00016130
+Flash Sort,333,299,0.00016870
+Flash Sort,333,300,0.00028330
+Flash Sort,333,301,0.00028320
+Flash Sort,333,302,0.00028730
+Flash Sort,333,303,0.00016210
+Flash Sort,333,304,0.00026300
+Flash Sort,333,305,0.00028290
+Flash Sort,333,306,0.00017020
+Flash Sort,333,307,0.00017630
+Flash Sort,333,308,0.00025690
+Flash Sort,333,309,0.00016680
+Flash Sort,333,310,0.00028770
+Flash Sort,333,311,0.00028560
+Flash Sort,333,312,0.00019720
+Flash Sort,333,313,0.00028450
+Flash Sort,333,314,0.00022750
+Flash Sort,333,315,0.00028420
+Flash Sort,333,316,0.00029030
+Flash Sort,333,317,0.00019760
+Flash Sort,333,318,0.00028100
+Flash Sort,333,319,0.00016220
+Flash Sort,333,320,0.00023400
+Flash Sort,333,321,0.00029680
+Flash Sort,333,322,0.00016300
+Flash Sort,333,323,0.00020200
+Flash Sort,333,324,0.00027990
+Flash Sort,333,325,0.00017420
+Flash Sort,333,326,0.00028810
+Flash Sort,333,327,0.00016200
+Flash Sort,333,328,0.00016120
+Flash Sort,333,329,0.00028950
+Flash Sort,333,330,0.00028430
+Flash Sort,333,331,0.00024280
+Flash Sort,333,332,0.00027410
+Flash Sort,333,333,0.00028200
+Flash Sort,333,334,0.00028470
+Flash Sort,333,335,0.00016390
+Flash Sort,333,336,0.00028560
+Flash Sort,333,337,0.00028620
+Flash Sort,333,338,0.00016400
+Flash Sort,333,339,0.00016080
+Flash Sort,333,340,0.00017940
+Flash Sort,333,341,0.00028140
+Flash Sort,333,342,0.00016100
+Flash Sort,333,343,0.00029340
+Flash Sort,333,344,0.00029860
+Flash Sort,333,345,0.00030200
+Flash Sort,333,346,0.00027660
+Flash Sort,333,347,0.00016750
+Flash Sort,333,348,0.00016170
+Flash Sort,333,349,0.00030270
+Flash Sort,333,350,0.00028940
+Flash Sort,333,351,0.00027950
+Flash Sort,333,352,0.00029950
+Flash Sort,333,353,0.00031610
+Flash Sort,333,354,0.00020580
+Flash Sort,333,355,0.00023430
+Flash Sort,333,356,0.00018190
+Flash Sort,333,357,0.00030680
+Flash Sort,333,358,0.00016480
+Flash Sort,333,359,0.00026270
+Flash Sort,333,360,0.00028550
+Flash Sort,333,361,0.00027850
+Flash Sort,333,362,0.00027050
+Flash Sort,333,363,0.00028470
+Flash Sort,333,364,0.00025530
+Flash Sort,333,365,0.00030320
+Flash Sort,333,366,0.00028510
+Flash Sort,333,367,0.00029090
+Flash Sort,333,368,0.00027280
+Flash Sort,333,369,0.00028670
+Flash Sort,333,370,0.00020200
+Flash Sort,333,371,0.00020700
+Flash Sort,333,372,0.00025100
+Flash Sort,333,373,0.00029930
+Flash Sort,333,374,0.00029950
+Flash Sort,333,375,0.00027190
+Flash Sort,333,376,0.00021430
+Flash Sort,333,377,0.00017540
+Flash Sort,333,378,0.00027890
+Flash Sort,333,379,0.00027990
+Flash Sort,333,380,0.00018300
+Flash Sort,333,381,0.00018800
+Flash Sort,333,382,0.00028560
+Flash Sort,333,383,0.00030170
+Flash Sort,333,384,0.00027180
+Flash Sort,333,385,0.00016080
+Flash Sort,333,386,0.00019380
+Flash Sort,333,387,0.00028410
+Flash Sort,333,388,0.00015980
+Flash Sort,333,389,0.00028810
+Flash Sort,333,390,0.00016330
+Flash Sort,333,391,0.00016240
+Flash Sort,333,392,0.00028210
+Flash Sort,333,393,0.00028750
+Flash Sort,333,394,0.00028980
+Flash Sort,333,395,0.00028160
+Flash Sort,333,396,0.00021010
+Flash Sort,333,397,0.00016830
+Flash Sort,333,398,0.00016190
+Flash Sort,333,399,0.00029210
+Flash Sort,333,400,0.00028790
+Flash Sort,333,401,0.00016800
+Flash Sort,333,402,0.00016260
+Flash Sort,333,403,0.00026570
+Flash Sort,333,404,0.00028480
+Flash Sort,333,405,0.00018830
+Flash Sort,333,406,0.00015930
+Flash Sort,333,407,0.00036200
+Flash Sort,333,408,0.00029150
+Flash Sort,333,409,0.00029530
+Flash Sort,333,410,0.00030450
+Flash Sort,333,411,0.00016190
+Flash Sort,333,412,0.00028940
+Flash Sort,333,413,0.00030310
+Flash Sort,333,414,0.00028640
+Flash Sort,333,415,0.00023670
+Flash Sort,333,416,0.00027670
+Flash Sort,333,417,0.00028910
+Flash Sort,333,418,0.00028970
+Flash Sort,333,419,0.00030930
+Flash Sort,333,420,0.00030320
+Flash Sort,333,421,0.00028710
+Flash Sort,333,422,0.00025440
+Flash Sort,333,423,0.00027910
+Flash Sort,333,424,0.00028790
+Flash Sort,333,425,0.00031480
+Flash Sort,333,426,0.00028910
+Flash Sort,333,427,0.00030560
+Flash Sort,333,428,0.00028880
+Flash Sort,333,429,0.00028660
+Flash Sort,333,430,0.00030790
+Flash Sort,333,431,0.00028420
+Flash Sort,333,432,0.00033260
+Flash Sort,333,433,0.00028580
+Flash Sort,333,434,0.00028610
+Flash Sort,333,435,0.00028230
+Flash Sort,333,436,0.00026060
+Flash Sort,333,437,0.00028900
+Flash Sort,333,438,0.00028730
+Flash Sort,333,439,0.00016890
+Flash Sort,333,440,0.00028910
+Flash Sort,333,441,0.00029610
+Flash Sort,333,442,0.00020110
+Flash Sort,333,443,0.00028760
+Flash Sort,333,444,0.00030600
+Flash Sort,333,445,0.00028420
+Flash Sort,333,446,0.00030540
+Flash Sort,333,447,0.00028880
+Flash Sort,333,448,0.00030360
+Flash Sort,333,449,0.00023450
+Flash Sort,333,450,0.00030560
+Flash Sort,333,451,0.00016030
+Flash Sort,333,452,0.00031050
+Flash Sort,333,453,0.00018730
+Flash Sort,333,454,0.00028580
+Flash Sort,333,455,0.00028640
+Flash Sort,333,456,0.00016360
+Flash Sort,333,457,0.00021240
+Flash Sort,333,458,0.00028290
+Flash Sort,333,459,0.00027940
+Flash Sort,333,460,0.00015950
+Flash Sort,333,461,0.00018810
+Flash Sort,333,462,0.00029020
+Flash Sort,333,463,0.00024510
+Flash Sort,333,464,0.00030450
+Flash Sort,333,465,0.00025620
+Flash Sort,333,466,0.00028910
+Flash Sort,333,467,0.00016290
+Flash Sort,333,468,0.00029770
+Flash Sort,333,469,0.00028970
+Flash Sort,333,470,0.00030090
+Flash Sort,333,471,0.00028660
+Flash Sort,333,472,0.00028190
+Flash Sort,333,473,0.00030460
+Flash Sort,333,474,0.00025400
+Flash Sort,333,475,0.00025750
+Flash Sort,333,476,0.00020650
+Flash Sort,333,477,0.00028630
+Flash Sort,333,478,0.00029270
+Flash Sort,333,479,0.00028680
+Flash Sort,333,480,0.00030750
+Flash Sort,333,481,0.00019860
+Flash Sort,333,482,0.00016540
+Flash Sort,333,483,0.00019250
+Flash Sort,333,484,0.00027450
+Flash Sort,333,485,0.00028200
+Flash Sort,333,486,0.00019100
+Flash Sort,333,487,0.00023970
+Flash Sort,333,488,0.00026550
+Flash Sort,333,489,0.00021810
+Flash Sort,333,490,0.00017300
+Flash Sort,333,491,0.00027990
+Flash Sort,333,492,0.00020220
+Flash Sort,333,493,0.00028310
+Flash Sort,333,494,0.00017320
+Flash Sort,333,495,0.00028090
+Flash Sort,333,496,0.00029010
+Flash Sort,333,497,0.00018370
+Flash Sort,333,498,0.00028500
+Flash Sort,333,499,0.00024500
+Flash Sort,333,500,0.00016310
+Franceschini's Method,333,1,0.00038210
+Franceschini's Method,333,2,0.00049700
+Franceschini's Method,333,3,0.00049500
+Franceschini's Method,333,4,0.00055190
+Franceschini's Method,333,5,0.00055300
+Franceschini's Method,333,6,0.00058240
+Franceschini's Method,333,7,0.00055640
+Franceschini's Method,333,8,0.00055470
+Franceschini's Method,333,9,0.00051780
+Franceschini's Method,333,10,0.00034650
+Franceschini's Method,333,11,0.00060090
+Franceschini's Method,333,12,0.00062160
+Franceschini's Method,333,13,0.00057320
+Franceschini's Method,333,14,0.00037060
+Franceschini's Method,333,15,0.00059690
+Franceschini's Method,333,16,0.00044770
+Franceschini's Method,333,17,0.00037030
+Franceschini's Method,333,18,0.00041800
+Franceschini's Method,333,19,0.00053430
+Franceschini's Method,333,20,0.00033540
+Franceschini's Method,333,21,0.00047580
+Franceschini's Method,333,22,0.00033290
+Franceschini's Method,333,23,0.00055150
+Franceschini's Method,333,24,0.00054800
+Franceschini's Method,333,25,0.00045950
+Franceschini's Method,333,26,0.00054170
+Franceschini's Method,333,27,0.00057780
+Franceschini's Method,333,28,0.00051090
+Franceschini's Method,333,29,0.00059970
+Franceschini's Method,333,30,0.00058620
+Franceschini's Method,333,31,0.00050060
+Franceschini's Method,333,32,0.00051450
+Franceschini's Method,333,33,0.00056960
+Franceschini's Method,333,34,0.00032740
+Franceschini's Method,333,35,0.00051950
+Franceschini's Method,333,36,0.00054120
+Franceschini's Method,333,37,0.00050290
+Franceschini's Method,333,38,0.00038250
+Franceschini's Method,333,39,0.00056370
+Franceschini's Method,333,40,0.00053590
+Franceschini's Method,333,41,0.00051730
+Franceschini's Method,333,42,0.00057260
+Franceschini's Method,333,43,0.00037640
+Franceschini's Method,333,44,0.00057340
+Franceschini's Method,333,45,0.00046980
+Franceschini's Method,333,46,0.00051170
+Franceschini's Method,333,47,0.00044210
+Franceschini's Method,333,48,0.00053210
+Franceschini's Method,333,49,0.00059600
+Franceschini's Method,333,50,0.00053960
+Franceschini's Method,333,51,0.00046080
+Franceschini's Method,333,52,0.00052850
+Franceschini's Method,333,53,0.00049490
+Franceschini's Method,333,54,0.00054440
+Franceschini's Method,333,55,0.00036010
+Franceschini's Method,333,56,0.00053340
+Franceschini's Method,333,57,0.00057110
+Franceschini's Method,333,58,0.00049540
+Franceschini's Method,333,59,0.00054280
+Franceschini's Method,333,60,0.00032930
+Franceschini's Method,333,61,0.00047850
+Franceschini's Method,333,62,0.00053370
+Franceschini's Method,333,63,0.00040930
+Franceschini's Method,333,64,0.00044380
+Franceschini's Method,333,65,0.00049520
+Franceschini's Method,333,66,0.00038060
+Franceschini's Method,333,67,0.00037500
+Franceschini's Method,333,68,0.00054210
+Franceschini's Method,333,69,0.00056390
+Franceschini's Method,333,70,0.00051490
+Franceschini's Method,333,71,0.00042280
+Franceschini's Method,333,72,0.00057330
+Franceschini's Method,333,73,0.00046820
+Franceschini's Method,333,74,0.00054900
+Franceschini's Method,333,75,0.00037280
+Franceschini's Method,333,76,0.00040770
+Franceschini's Method,333,77,0.00053630
+Franceschini's Method,333,78,0.00051470
+Franceschini's Method,333,79,0.00057350
+Franceschini's Method,333,80,0.00032990
+Franceschini's Method,333,81,0.00036300
+Franceschini's Method,333,82,0.00057540
+Franceschini's Method,333,83,0.00059140
+Franceschini's Method,333,84,0.00056920
+Franceschini's Method,333,85,0.00051610
+Franceschini's Method,333,86,0.00055620
+Franceschini's Method,333,87,0.00053410
+Franceschini's Method,333,88,0.00057650
+Franceschini's Method,333,89,0.00051660
+Franceschini's Method,333,90,0.00043980
+Franceschini's Method,333,91,0.00033490
+Franceschini's Method,333,92,0.00059600
+Franceschini's Method,333,93,0.00051470
+Franceschini's Method,333,94,0.00059810
+Franceschini's Method,333,95,0.00056150
+Franceschini's Method,333,96,0.00041950
+Franceschini's Method,333,97,0.00049110
+Franceschini's Method,333,98,0.00045690
+Franceschini's Method,333,99,0.00060060
+Franceschini's Method,333,100,0.00036030
+Franceschini's Method,333,101,0.00055060
+Franceschini's Method,333,102,0.00053270
+Franceschini's Method,333,103,0.00057440
+Franceschini's Method,333,104,0.00059690
+Franceschini's Method,333,105,0.00067750
+Franceschini's Method,333,106,0.00054570
+Franceschini's Method,333,107,0.00057240
+Franceschini's Method,333,108,0.00053390
+Franceschini's Method,333,109,0.00056190
+Franceschini's Method,333,110,0.00044140
+Franceschini's Method,333,111,0.00058100
+Franceschini's Method,333,112,0.00045570
+Franceschini's Method,333,113,0.00053950
+Franceschini's Method,333,114,0.00052010
+Franceschini's Method,333,115,0.00038590
+Franceschini's Method,333,116,0.00050610
+Franceschini's Method,333,117,0.00054700
+Franceschini's Method,333,118,0.00052240
+Franceschini's Method,333,119,0.00060090
+Franceschini's Method,333,120,0.00035950
+Franceschini's Method,333,121,0.00039110
+Franceschini's Method,333,122,0.00056550
+Franceschini's Method,333,123,0.00034760
+Franceschini's Method,333,124,0.00030640
+Franceschini's Method,333,125,0.00052920
+Franceschini's Method,333,126,0.00053760
+Franceschini's Method,333,127,0.00054240
+Franceschini's Method,333,128,0.00057830
+Franceschini's Method,333,129,0.00032940
+Franceschini's Method,333,130,0.00050620
+Franceschini's Method,333,131,0.00059430
+Franceschini's Method,333,132,0.00050760
+Franceschini's Method,333,133,0.00054530
+Franceschini's Method,333,134,0.00054730
+Franceschini's Method,333,135,0.00043720
+Franceschini's Method,333,136,0.00061920
+Franceschini's Method,333,137,0.00037670
+Franceschini's Method,333,138,0.00050610
+Franceschini's Method,333,139,0.00055510
+Franceschini's Method,333,140,0.00036570
+Franceschini's Method,333,141,0.00053830
+Franceschini's Method,333,142,0.00054680
+Franceschini's Method,333,143,0.00054030
+Franceschini's Method,333,144,0.00035600
+Franceschini's Method,333,145,0.00055280
+Franceschini's Method,333,146,0.00059140
+Franceschini's Method,333,147,0.00052100
+Franceschini's Method,333,148,0.00052910
+Franceschini's Method,333,149,0.00048580
+Franceschini's Method,333,150,0.00059220
+Franceschini's Method,333,151,0.00049730
+Franceschini's Method,333,152,0.00048500
+Franceschini's Method,333,153,0.00063860
+Franceschini's Method,333,154,0.00033470
+Franceschini's Method,333,155,0.00041000
+Franceschini's Method,333,156,0.00057290
+Franceschini's Method,333,157,0.00053440
+Franceschini's Method,333,158,0.00054770
+Franceschini's Method,333,159,0.00054880
+Franceschini's Method,333,160,0.00044990
+Franceschini's Method,333,161,0.00052550
+Franceschini's Method,333,162,0.00054750
+Franceschini's Method,333,163,0.00043110
+Franceschini's Method,333,164,0.00054130
+Franceschini's Method,333,165,0.00032650
+Franceschini's Method,333,166,0.00055390
+Franceschini's Method,333,167,0.00035960
+Franceschini's Method,333,168,0.00034990
+Franceschini's Method,333,169,0.00050490
+Franceschini's Method,333,170,0.00057680
+Franceschini's Method,333,171,0.00039020
+Franceschini's Method,333,172,0.00049940
+Franceschini's Method,333,173,0.00035760
+Franceschini's Method,333,174,0.00050950
+Franceschini's Method,333,175,0.00065100
+Franceschini's Method,333,176,0.00056270
+Franceschini's Method,333,177,0.00051590
+Franceschini's Method,333,178,0.00047630
+Franceschini's Method,333,179,0.00037280
+Franceschini's Method,333,180,0.00042270
+Franceschini's Method,333,181,0.00032230
+Franceschini's Method,333,182,0.00052140
+Franceschini's Method,333,183,0.00055400
+Franceschini's Method,333,184,0.00056700
+Franceschini's Method,333,185,0.00047680
+Franceschini's Method,333,186,0.00059540
+Franceschini's Method,333,187,0.00059620
+Franceschini's Method,333,188,0.00049410
+Franceschini's Method,333,189,0.00052030
+Franceschini's Method,333,190,0.00055590
+Franceschini's Method,333,191,0.00053000
+Franceschini's Method,333,192,0.00056520
+Franceschini's Method,333,193,0.00057890
+Franceschini's Method,333,194,0.00059260
+Franceschini's Method,333,195,0.00040430
+Franceschini's Method,333,196,0.00047050
+Franceschini's Method,333,197,0.00041790
+Franceschini's Method,333,198,0.00049410
+Franceschini's Method,333,199,0.00057490
+Franceschini's Method,333,200,0.00034720
+Franceschini's Method,333,201,0.00053770
+Franceschini's Method,333,202,0.00052690
+Franceschini's Method,333,203,0.00054470
+Franceschini's Method,333,204,0.00033300
+Franceschini's Method,333,205,0.00051740
+Franceschini's Method,333,206,0.00042890
+Franceschini's Method,333,207,0.00064980
+Franceschini's Method,333,208,0.00038310
+Franceschini's Method,333,209,0.00059310
+Franceschini's Method,333,210,0.00040520
+Franceschini's Method,333,211,0.00052440
+Franceschini's Method,333,212,0.00054220
+Franceschini's Method,333,213,0.00053910
+Franceschini's Method,333,214,0.00047140
+Franceschini's Method,333,215,0.00053870
+Franceschini's Method,333,216,0.00033870
+Franceschini's Method,333,217,0.00061020
+Franceschini's Method,333,218,0.00056290
+Franceschini's Method,333,219,0.00053400
+Franceschini's Method,333,220,0.00051470
+Franceschini's Method,333,221,0.00039290
+Franceschini's Method,333,222,0.00050740
+Franceschini's Method,333,223,0.00040780
+Franceschini's Method,333,224,0.00034480
+Franceschini's Method,333,225,0.00036710
+Franceschini's Method,333,226,0.00059480
+Franceschini's Method,333,227,0.00060130
+Franceschini's Method,333,228,0.00055280
+Franceschini's Method,333,229,0.00052060
+Franceschini's Method,333,230,0.00053650
+Franceschini's Method,333,231,0.00047250
+Franceschini's Method,333,232,0.00066320
+Franceschini's Method,333,233,0.00061000
+Franceschini's Method,333,234,0.00044190
+Franceschini's Method,333,235,0.00051560
+Franceschini's Method,333,236,0.00055080
+Franceschini's Method,333,237,0.00049330
+Franceschini's Method,333,238,0.00032880
+Franceschini's Method,333,239,0.00056850
+Franceschini's Method,333,240,0.00063590
+Franceschini's Method,333,241,0.00036810
+Franceschini's Method,333,242,0.00056940
+Franceschini's Method,333,243,0.00052240
+Franceschini's Method,333,244,0.00054160
+Franceschini's Method,333,245,0.00045450
+Franceschini's Method,333,246,0.00059260
+Franceschini's Method,333,247,0.00050050
+Franceschini's Method,333,248,0.00053660
+Franceschini's Method,333,249,0.00055860
+Franceschini's Method,333,250,0.00046240
+Franceschini's Method,333,251,0.00053230
+Franceschini's Method,333,252,0.00040770
+Franceschini's Method,333,253,0.00060020
+Franceschini's Method,333,254,0.00054000
+Franceschini's Method,333,255,0.00058400
+Franceschini's Method,333,256,0.00039470
+Franceschini's Method,333,257,0.00055040
+Franceschini's Method,333,258,0.00053340
+Franceschini's Method,333,259,0.00056830
+Franceschini's Method,333,260,0.00053350
+Franceschini's Method,333,261,0.00053860
+Franceschini's Method,333,262,0.00052520
+Franceschini's Method,333,263,0.00053850
+Franceschini's Method,333,264,0.00058550
+Franceschini's Method,333,265,0.00058250
+Franceschini's Method,333,266,0.00062940
+Franceschini's Method,333,267,0.00056870
+Franceschini's Method,333,268,0.00049760
+Franceschini's Method,333,269,0.00062050
+Franceschini's Method,333,270,0.00040060
+Franceschini's Method,333,271,0.00052850
+Franceschini's Method,333,272,0.00057900
+Franceschini's Method,333,273,0.00034620
+Franceschini's Method,333,274,0.00042090
+Franceschini's Method,333,275,0.00056150
+Franceschini's Method,333,276,0.00033710
+Franceschini's Method,333,277,0.00054680
+Franceschini's Method,333,278,0.00044060
+Franceschini's Method,333,279,0.00055270
+Franceschini's Method,333,280,0.00057630
+Franceschini's Method,333,281,0.00054360
+Franceschini's Method,333,282,0.00049260
+Franceschini's Method,333,283,0.00050750
+Franceschini's Method,333,284,0.00054250
+Franceschini's Method,333,285,0.00034590
+Franceschini's Method,333,286,0.00050990
+Franceschini's Method,333,287,0.00051110
+Franceschini's Method,333,288,0.00060090
+Franceschini's Method,333,289,0.00052990
+Franceschini's Method,333,290,0.00051970
+Franceschini's Method,333,291,0.00061810
+Franceschini's Method,333,292,0.00043530
+Franceschini's Method,333,293,0.00032220
+Franceschini's Method,333,294,0.00053330
+Franceschini's Method,333,295,0.00052200
+Franceschini's Method,333,296,0.00054860
+Franceschini's Method,333,297,0.00036590
+Franceschini's Method,333,298,0.00046740
+Franceschini's Method,333,299,0.00038490
+Franceschini's Method,333,300,0.00052030
+Franceschini's Method,333,301,0.00050910
+Franceschini's Method,333,302,0.00056980
+Franceschini's Method,333,303,0.00042510
+Franceschini's Method,333,304,0.00048990
+Franceschini's Method,333,305,0.00051780
+Franceschini's Method,333,306,0.00054180
+Franceschini's Method,333,307,0.00051190
+Franceschini's Method,333,308,0.00048150
+Franceschini's Method,333,309,0.00054290
+Franceschini's Method,333,310,0.00058650
+Franceschini's Method,333,311,0.00051450
+Franceschini's Method,333,312,0.00047040
+Franceschini's Method,333,313,0.00034080
+Franceschini's Method,333,314,0.00045110
+Franceschini's Method,333,315,0.00064760
+Franceschini's Method,333,316,0.00061080
+Franceschini's Method,333,317,0.00060230
+Franceschini's Method,333,318,0.00055270
+Franceschini's Method,333,319,0.00054010
+Franceschini's Method,333,320,0.00050460
+Franceschini's Method,333,321,0.00056950
+Franceschini's Method,333,322,0.00055560
+Franceschini's Method,333,323,0.00055320
+Franceschini's Method,333,324,0.00050480
+Franceschini's Method,333,325,0.00055430
+Franceschini's Method,333,326,0.00051690
+Franceschini's Method,333,327,0.00055820
+Franceschini's Method,333,328,0.00056850
+Franceschini's Method,333,329,0.00053650
+Franceschini's Method,333,330,0.00057770
+Franceschini's Method,333,331,0.00052200
+Franceschini's Method,333,332,0.00048900
+Franceschini's Method,333,333,0.00057590
+Franceschini's Method,333,334,0.00048240
+Franceschini's Method,333,335,0.00064800
+Franceschini's Method,333,336,0.00048160
+Franceschini's Method,333,337,0.00051750
+Franceschini's Method,333,338,0.00056370
+Franceschini's Method,333,339,0.00055490
+Franceschini's Method,333,340,0.00043420
+Franceschini's Method,333,341,0.00056970
+Franceschini's Method,333,342,0.00034250
+Franceschini's Method,333,343,0.00052840
+Franceschini's Method,333,344,0.00048860
+Franceschini's Method,333,345,0.00053320
+Franceschini's Method,333,346,0.00057380
+Franceschini's Method,333,347,0.00036710
+Franceschini's Method,333,348,0.00054390
+Franceschini's Method,333,349,0.00032480
+Franceschini's Method,333,350,0.00042720
+Franceschini's Method,333,351,0.00053970
+Franceschini's Method,333,352,0.00051920
+Franceschini's Method,333,353,0.00041190
+Franceschini's Method,333,354,0.00039870
+Franceschini's Method,333,355,0.00059650
+Franceschini's Method,333,356,0.00054350
+Franceschini's Method,333,357,0.00060190
+Franceschini's Method,333,358,0.00054570
+Franceschini's Method,333,359,0.00056690
+Franceschini's Method,333,360,0.00059440
+Franceschini's Method,333,361,0.00035920
+Franceschini's Method,333,362,0.00050070
+Franceschini's Method,333,363,0.00061450
+Franceschini's Method,333,364,0.00054690
+Franceschini's Method,333,365,0.00037960
+Franceschini's Method,333,366,0.00057720
+Franceschini's Method,333,367,0.00054480
+Franceschini's Method,333,368,0.00050700
+Franceschini's Method,333,369,0.00063850
+Franceschini's Method,333,370,0.00036080
+Franceschini's Method,333,371,0.00057880
+Franceschini's Method,333,372,0.00058850
+Franceschini's Method,333,373,0.00036280
+Franceschini's Method,333,374,0.00062880
+Franceschini's Method,333,375,0.00054620
+Franceschini's Method,333,376,0.00044780
+Franceschini's Method,333,377,0.00051560
+Franceschini's Method,333,378,0.00034230
+Franceschini's Method,333,379,0.00054110
+Franceschini's Method,333,380,0.00054380
+Franceschini's Method,333,381,0.00041610
+Franceschini's Method,333,382,0.00054850
+Franceschini's Method,333,383,0.00039940
+Franceschini's Method,333,384,0.00057830
+Franceschini's Method,333,385,0.00063970
+Franceschini's Method,333,386,0.00056490
+Franceschini's Method,333,387,0.00056950
+Franceschini's Method,333,388,0.00054390
+Franceschini's Method,333,389,0.00056300
+Franceschini's Method,333,390,0.00050010
+Franceschini's Method,333,391,0.00045720
+Franceschini's Method,333,392,0.00056430
+Franceschini's Method,333,393,0.00049410
+Franceschini's Method,333,394,0.00053420
+Franceschini's Method,333,395,0.00047870
+Franceschini's Method,333,396,0.00049730
+Franceschini's Method,333,397,0.00054940
+Franceschini's Method,333,398,0.00043990
+Franceschini's Method,333,399,0.00057980
+Franceschini's Method,333,400,0.00055240
+Franceschini's Method,333,401,0.00057850
+Franceschini's Method,333,402,0.00041240
+Franceschini's Method,333,403,0.00036470
+Franceschini's Method,333,404,0.00058620
+Franceschini's Method,333,405,0.00057380
+Franceschini's Method,333,406,0.00044660
+Franceschini's Method,333,407,0.00057430
+Franceschini's Method,333,408,0.00061050
+Franceschini's Method,333,409,0.00055960
+Franceschini's Method,333,410,0.00052050
+Franceschini's Method,333,411,0.00058230
+Franceschini's Method,333,412,0.00055390
+Franceschini's Method,333,413,0.00060870
+Franceschini's Method,333,414,0.00057170
+Franceschini's Method,333,415,0.00039980
+Franceschini's Method,333,416,0.00037240
+Franceschini's Method,333,417,0.00040760
+Franceschini's Method,333,418,0.00054290
+Franceschini's Method,333,419,0.00052670
+Franceschini's Method,333,420,0.00057950
+Franceschini's Method,333,421,0.00051230
+Franceschini's Method,333,422,0.00055730
+Franceschini's Method,333,423,0.00059390
+Franceschini's Method,333,424,0.00055530
+Franceschini's Method,333,425,0.00054550
+Franceschini's Method,333,426,0.00058240
+Franceschini's Method,333,427,0.00033800
+Franceschini's Method,333,428,0.00060040
+Franceschini's Method,333,429,0.00049780
+Franceschini's Method,333,430,0.00034620
+Franceschini's Method,333,431,0.00056270
+Franceschini's Method,333,432,0.00055050
+Franceschini's Method,333,433,0.00056180
+Franceschini's Method,333,434,0.00060410
+Franceschini's Method,333,435,0.00061840
+Franceschini's Method,333,436,0.00046780
+Franceschini's Method,333,437,0.00049650
+Franceschini's Method,333,438,0.00050340
+Franceschini's Method,333,439,0.00035150
+Franceschini's Method,333,440,0.00053090
+Franceschini's Method,333,441,0.00057510
+Franceschini's Method,333,442,0.00036010
+Franceschini's Method,333,443,0.00051140
+Franceschini's Method,333,444,0.00034140
+Franceschini's Method,333,445,0.00048050
+Franceschini's Method,333,446,0.00058110
+Franceschini's Method,333,447,0.00065000
+Franceschini's Method,333,448,0.00059480
+Franceschini's Method,333,449,0.00053370
+Franceschini's Method,333,450,0.00053170
+Franceschini's Method,333,451,0.00057630
+Franceschini's Method,333,452,0.00057980
+Franceschini's Method,333,453,0.00053540
+Franceschini's Method,333,454,0.00057270
+Franceschini's Method,333,455,0.00049450
+Franceschini's Method,333,456,0.00053160
+Franceschini's Method,333,457,0.00056290
+Franceschini's Method,333,458,0.00053050
+Franceschini's Method,333,459,0.00039900
+Franceschini's Method,333,460,0.00057370
+Franceschini's Method,333,461,0.00049140
+Franceschini's Method,333,462,0.00055260
+Franceschini's Method,333,463,0.00064690
+Franceschini's Method,333,464,0.00054840
+Franceschini's Method,333,465,0.00052350
+Franceschini's Method,333,466,0.00043120
+Franceschini's Method,333,467,0.00042250
+Franceschini's Method,333,468,0.00057610
+Franceschini's Method,333,469,0.00037290
+Franceschini's Method,333,470,0.00055860
+Franceschini's Method,333,471,0.00054790
+Franceschini's Method,333,472,0.00059060
+Franceschini's Method,333,473,0.00053540
+Franceschini's Method,333,474,0.00055720
+Franceschini's Method,333,475,0.00054550
+Franceschini's Method,333,476,0.00046540
+Franceschini's Method,333,477,0.00055380
+Franceschini's Method,333,478,0.00042390
+Franceschini's Method,333,479,0.00034230
+Franceschini's Method,333,480,0.00060900
+Franceschini's Method,333,481,0.00056030
+Franceschini's Method,333,482,0.00051180
+Franceschini's Method,333,483,0.00050240
+Franceschini's Method,333,484,0.00033920
+Franceschini's Method,333,485,0.00039450
+Franceschini's Method,333,486,0.00052360
+Franceschini's Method,333,487,0.00042240
+Franceschini's Method,333,488,0.00045000
+Franceschini's Method,333,489,0.00050960
+Franceschini's Method,333,490,0.00048010
+Franceschini's Method,333,491,0.00053520
+Franceschini's Method,333,492,0.00044680
+Franceschini's Method,333,493,0.00055100
+Franceschini's Method,333,494,0.00055780
+Franceschini's Method,333,495,0.00036610
+Franceschini's Method,333,496,0.00060060
+Franceschini's Method,333,497,0.00044270
+Franceschini's Method,333,498,0.00055820
+Franceschini's Method,333,499,0.00057510
+Franceschini's Method,333,500,0.00040370
+Gnome Sort,333,1,0.00845840
+Gnome Sort,333,2,0.00831490
+Gnome Sort,333,3,0.00805870
+Gnome Sort,333,4,0.00913370
+Gnome Sort,333,5,0.00832620
+Gnome Sort,333,6,0.00852800
+Gnome Sort,333,7,0.00919230
+Gnome Sort,333,8,0.01308990
+Gnome Sort,333,9,0.00868090
+Gnome Sort,333,10,0.00917180
+Gnome Sort,333,11,0.00880620
+Gnome Sort,333,12,0.00838510
+Gnome Sort,333,13,0.00816830
+Gnome Sort,333,14,0.01007510
+Gnome Sort,333,15,0.00869360
+Gnome Sort,333,16,0.00851390
+Gnome Sort,333,17,0.00916610
+Gnome Sort,333,18,0.00940720
+Gnome Sort,333,19,0.00867010
+Gnome Sort,333,20,0.00901680
+Gnome Sort,333,21,0.00836550
+Gnome Sort,333,22,0.00898920
+Gnome Sort,333,23,0.00852360
+Gnome Sort,333,24,0.00886250
+Gnome Sort,333,25,0.00834400
+Gnome Sort,333,26,0.01003360
+Gnome Sort,333,27,0.00895570
+Gnome Sort,333,28,0.00861550
+Gnome Sort,333,29,0.00859690
+Gnome Sort,333,30,0.00872790
+Gnome Sort,333,31,0.00861240
+Gnome Sort,333,32,0.00851350
+Gnome Sort,333,33,0.00896890
+Gnome Sort,333,34,0.00957810
+Gnome Sort,333,35,0.00932250
+Gnome Sort,333,36,0.00894100
+Gnome Sort,333,37,0.00885280
+Gnome Sort,333,38,0.00812680
+Gnome Sort,333,39,0.00891110
+Gnome Sort,333,40,0.00956400
+Gnome Sort,333,41,0.00839580
+Gnome Sort,333,42,0.00904840
+Gnome Sort,333,43,0.01023110
+Gnome Sort,333,44,0.00880830
+Gnome Sort,333,45,0.01070070
+Gnome Sort,333,46,0.00818750
+Gnome Sort,333,47,0.01040380
+Gnome Sort,333,48,0.00963120
+Gnome Sort,333,49,0.01125320
+Gnome Sort,333,50,0.01016810
+Gnome Sort,333,51,0.01098000
+Gnome Sort,333,52,0.01246380
+Gnome Sort,333,53,0.01520610
+Gnome Sort,333,54,0.00898110
+Gnome Sort,333,55,0.01405480
+Gnome Sort,333,56,0.00912470
+Gnome Sort,333,57,0.00926670
+Gnome Sort,333,58,0.00856330
+Gnome Sort,333,59,0.01285330
+Gnome Sort,333,60,0.01047010
+Gnome Sort,333,61,0.00873490
+Gnome Sort,333,62,0.01316960
+Gnome Sort,333,63,0.00863150
+Gnome Sort,333,64,0.01289380
+Gnome Sort,333,65,0.00976530
+Gnome Sort,333,66,0.01008430
+Gnome Sort,333,67,0.01045400
+Gnome Sort,333,68,0.00886060
+Gnome Sort,333,69,0.00885280
+Gnome Sort,333,70,0.00936370
+Gnome Sort,333,71,0.00918820
+Gnome Sort,333,72,0.01006360
+Gnome Sort,333,73,0.00955890
+Gnome Sort,333,74,0.00918480
+Gnome Sort,333,75,0.00891390
+Gnome Sort,333,76,0.00933450
+Gnome Sort,333,77,0.00992350
+Gnome Sort,333,78,0.00831770
+Gnome Sort,333,79,0.00801210
+Gnome Sort,333,80,0.00940930
+Gnome Sort,333,81,0.00880010
+Gnome Sort,333,82,0.00893140
+Gnome Sort,333,83,0.00827660
+Gnome Sort,333,84,0.00882650
+Gnome Sort,333,85,0.00944650
+Gnome Sort,333,86,0.00921230
+Gnome Sort,333,87,0.00950940
+Gnome Sort,333,88,0.00885050
+Gnome Sort,333,89,0.00929500
+Gnome Sort,333,90,0.00844060
+Gnome Sort,333,91,0.00920610
+Gnome Sort,333,92,0.00829070
+Gnome Sort,333,93,0.00985020
+Gnome Sort,333,94,0.00868480
+Gnome Sort,333,95,0.00841930
+Gnome Sort,333,96,0.00848700
+Gnome Sort,333,97,0.00932380
+Gnome Sort,333,98,0.00851250
+Gnome Sort,333,99,0.00819330
+Gnome Sort,333,100,0.00801470
+Gnome Sort,333,101,0.00925720
+Gnome Sort,333,102,0.00917710
+Gnome Sort,333,103,0.00974800
+Gnome Sort,333,104,0.00807600
+Gnome Sort,333,105,0.00888730
+Gnome Sort,333,106,0.00926260
+Gnome Sort,333,107,0.00896020
+Gnome Sort,333,108,0.00867770
+Gnome Sort,333,109,0.00816480
+Gnome Sort,333,110,0.00840710
+Gnome Sort,333,111,0.00865420
+Gnome Sort,333,112,0.00982670
+Gnome Sort,333,113,0.00933950
+Gnome Sort,333,114,0.00847340
+Gnome Sort,333,115,0.00924810
+Gnome Sort,333,116,0.00940300
+Gnome Sort,333,117,0.00896330
+Gnome Sort,333,118,0.00844200
+Gnome Sort,333,119,0.00834020
+Gnome Sort,333,120,0.00914030
+Gnome Sort,333,121,0.01034450
+Gnome Sort,333,122,0.00901550
+Gnome Sort,333,123,0.00840400
+Gnome Sort,333,124,0.00942980
+Gnome Sort,333,125,0.00894890
+Gnome Sort,333,126,0.00886630
+Gnome Sort,333,127,0.00845610
+Gnome Sort,333,128,0.00897070
+Gnome Sort,333,129,0.00893370
+Gnome Sort,333,130,0.00825360
+Gnome Sort,333,131,0.00952540
+Gnome Sort,333,132,0.00932780
+Gnome Sort,333,133,0.00903140
+Gnome Sort,333,134,0.00973560
+Gnome Sort,333,135,0.00869510
+Gnome Sort,333,136,0.00888640
+Gnome Sort,333,137,0.00881320
+Gnome Sort,333,138,0.00899620
+Gnome Sort,333,139,0.00866300
+Gnome Sort,333,140,0.00978540
+Gnome Sort,333,141,0.00915640
+Gnome Sort,333,142,0.00917060
+Gnome Sort,333,143,0.00851650
+Gnome Sort,333,144,0.00980160
+Gnome Sort,333,145,0.00870730
+Gnome Sort,333,146,0.00822660
+Gnome Sort,333,147,0.00835390
+Gnome Sort,333,148,0.00880090
+Gnome Sort,333,149,0.00970140
+Gnome Sort,333,150,0.00803790
+Gnome Sort,333,151,0.01045910
+Gnome Sort,333,152,0.01165450
+Gnome Sort,333,153,0.00885320
+Gnome Sort,333,154,0.00968460
+Gnome Sort,333,155,0.00895420
+Gnome Sort,333,156,0.00851870
+Gnome Sort,333,157,0.00941660
+Gnome Sort,333,158,0.00899530
+Gnome Sort,333,159,0.00921240
+Gnome Sort,333,160,0.00887360
+Gnome Sort,333,161,0.00941620
+Gnome Sort,333,162,0.00939650
+Gnome Sort,333,163,0.01251770
+Gnome Sort,333,164,0.00907970
+Gnome Sort,333,165,0.00828430
+Gnome Sort,333,166,0.01214630
+Gnome Sort,333,167,0.01121780
+Gnome Sort,333,168,0.00892960
+Gnome Sort,333,169,0.00890930
+Gnome Sort,333,170,0.00861250
+Gnome Sort,333,171,0.00850950
+Gnome Sort,333,172,0.01106360
+Gnome Sort,333,173,0.00841160
+Gnome Sort,333,174,0.00882440
+Gnome Sort,333,175,0.01039170
+Gnome Sort,333,176,0.00887270
+Gnome Sort,333,177,0.02004090
+Gnome Sort,333,178,0.00911490
+Gnome Sort,333,179,0.00839750
+Gnome Sort,333,180,0.00886400
+Gnome Sort,333,181,0.00905830
+Gnome Sort,333,182,0.01051670
+Gnome Sort,333,183,0.00853390
+Gnome Sort,333,184,0.00967950
+Gnome Sort,333,185,0.00874340
+Gnome Sort,333,186,0.00797700
+Gnome Sort,333,187,0.00981270
+Gnome Sort,333,188,0.00885650
+Gnome Sort,333,189,0.00889350
+Gnome Sort,333,190,0.00867800
+Gnome Sort,333,191,0.01302960
+Gnome Sort,333,192,0.00849030
+Gnome Sort,333,193,0.00947190
+Gnome Sort,333,194,0.00928020
+Gnome Sort,333,195,0.00849480
+Gnome Sort,333,196,0.00893700
+Gnome Sort,333,197,0.01363630
+Gnome Sort,333,198,0.00748330
+Gnome Sort,333,199,0.00899310
+Gnome Sort,333,200,0.00885190
+Gnome Sort,333,201,0.00832400
+Gnome Sort,333,202,0.00836880
+Gnome Sort,333,203,0.00859110
+Gnome Sort,333,204,0.00840950
+Gnome Sort,333,205,0.01200070
+Gnome Sort,333,206,0.00867140
+Gnome Sort,333,207,0.00848610
+Gnome Sort,333,208,0.01002930
+Gnome Sort,333,209,0.00970610
+Gnome Sort,333,210,0.00882400
+Gnome Sort,333,211,0.01172010
+Gnome Sort,333,212,0.00848310
+Gnome Sort,333,213,0.00859050
+Gnome Sort,333,214,0.01010200
+Gnome Sort,333,215,0.00903510
+Gnome Sort,333,216,0.00943790
+Gnome Sort,333,217,0.01004730
+Gnome Sort,333,218,0.00954570
+Gnome Sort,333,219,0.01176440
+Gnome Sort,333,220,0.00896000
+Gnome Sort,333,221,0.01009310
+Gnome Sort,333,222,0.00887640
+Gnome Sort,333,223,0.00823240
+Gnome Sort,333,224,0.00854860
+Gnome Sort,333,225,0.01019290
+Gnome Sort,333,226,0.00899800
+Gnome Sort,333,227,0.00963720
+Gnome Sort,333,228,0.01229330
+Gnome Sort,333,229,0.01060320
+Gnome Sort,333,230,0.01079380
+Gnome Sort,333,231,0.00993850
+Gnome Sort,333,232,0.00901240
+Gnome Sort,333,233,0.00969140
+Gnome Sort,333,234,0.01004040
+Gnome Sort,333,235,0.00903250
+Gnome Sort,333,236,0.00876930
+Gnome Sort,333,237,0.00894290
+Gnome Sort,333,238,0.01006790
+Gnome Sort,333,239,0.01078810
+Gnome Sort,333,240,0.01040540
+Gnome Sort,333,241,0.01032900
+Gnome Sort,333,242,0.01015610
+Gnome Sort,333,243,0.00979700
+Gnome Sort,333,244,0.00861110
+Gnome Sort,333,245,0.00859400
+Gnome Sort,333,246,0.00919410
+Gnome Sort,333,247,0.01000350
+Gnome Sort,333,248,0.00948390
+Gnome Sort,333,249,0.00967740
+Gnome Sort,333,250,0.00944890
+Gnome Sort,333,251,0.00835150
+Gnome Sort,333,252,0.00874520
+Gnome Sort,333,253,0.00923200
+Gnome Sort,333,254,0.00855220
+Gnome Sort,333,255,0.00884030
+Gnome Sort,333,256,0.00902720
+Gnome Sort,333,257,0.00868170
+Gnome Sort,333,258,0.00901910
+Gnome Sort,333,259,0.00874530
+Gnome Sort,333,260,0.00827470
+Gnome Sort,333,261,0.00908850
+Gnome Sort,333,262,0.00981540
+Gnome Sort,333,263,0.00989380
+Gnome Sort,333,264,0.00829000
+Gnome Sort,333,265,0.00897480
+Gnome Sort,333,266,0.00880490
+Gnome Sort,333,267,0.00853680
+Gnome Sort,333,268,0.00891880
+Gnome Sort,333,269,0.00857220
+Gnome Sort,333,270,0.00878100
+Gnome Sort,333,271,0.00879140
+Gnome Sort,333,272,0.00867680
+Gnome Sort,333,273,0.01010100
+Gnome Sort,333,274,0.01052960
+Gnome Sort,333,275,0.00858110
+Gnome Sort,333,276,0.00859480
+Gnome Sort,333,277,0.00901380
+Gnome Sort,333,278,0.00905920
+Gnome Sort,333,279,0.00908450
+Gnome Sort,333,280,0.00886780
+Gnome Sort,333,281,0.00940790
+Gnome Sort,333,282,0.00883320
+Gnome Sort,333,283,0.00920950
+Gnome Sort,333,284,0.00979590
+Gnome Sort,333,285,0.00893110
+Gnome Sort,333,286,0.00859080
+Gnome Sort,333,287,0.00933860
+Gnome Sort,333,288,0.00872370
+Gnome Sort,333,289,0.00883660
+Gnome Sort,333,290,0.00872480
+Gnome Sort,333,291,0.00856730
+Gnome Sort,333,292,0.00949860
+Gnome Sort,333,293,0.00887630
+Gnome Sort,333,294,0.00878690
+Gnome Sort,333,295,0.00904190
+Gnome Sort,333,296,0.00961630
+Gnome Sort,333,297,0.00859900
+Gnome Sort,333,298,0.00929040
+Gnome Sort,333,299,0.00977110
+Gnome Sort,333,300,0.00887700
+Gnome Sort,333,301,0.00967510
+Gnome Sort,333,302,0.00892410
+Gnome Sort,333,303,0.00911100
+Gnome Sort,333,304,0.00937400
+Gnome Sort,333,305,0.00899140
+Gnome Sort,333,306,0.00972520
+Gnome Sort,333,307,0.00870560
+Gnome Sort,333,308,0.00922170
+Gnome Sort,333,309,0.00852970
+Gnome Sort,333,310,0.00836450
+Gnome Sort,333,311,0.00855320
+Gnome Sort,333,312,0.00947840
+Gnome Sort,333,313,0.00877450
+Gnome Sort,333,314,0.00934520
+Gnome Sort,333,315,0.00933740
+Gnome Sort,333,316,0.00876630
+Gnome Sort,333,317,0.00875880
+Gnome Sort,333,318,0.00820680
+Gnome Sort,333,319,0.00833120
+Gnome Sort,333,320,0.00877540
+Gnome Sort,333,321,0.00842330
+Gnome Sort,333,322,0.00847470
+Gnome Sort,333,323,0.01076770
+Gnome Sort,333,324,0.00972180
+Gnome Sort,333,325,0.00822550
+Gnome Sort,333,326,0.00875490
+Gnome Sort,333,327,0.00929370
+Gnome Sort,333,328,0.00927540
+Gnome Sort,333,329,0.00899680
+Gnome Sort,333,330,0.00820680
+Gnome Sort,333,331,0.00851540
+Gnome Sort,333,332,0.00911880
+Gnome Sort,333,333,0.00902840
+Gnome Sort,333,334,0.00911910
+Gnome Sort,333,335,0.00919110
+Gnome Sort,333,336,0.00886410
+Gnome Sort,333,337,0.00915160
+Gnome Sort,333,338,0.00894110
+Gnome Sort,333,339,0.00994050
+Gnome Sort,333,340,0.00758800
+Gnome Sort,333,341,0.00946510
+Gnome Sort,333,342,0.00839770
+Gnome Sort,333,343,0.00872440
+Gnome Sort,333,344,0.00881830
+Gnome Sort,333,345,0.00866730
+Gnome Sort,333,346,0.00868480
+Gnome Sort,333,347,0.00861870
+Gnome Sort,333,348,0.00904200
+Gnome Sort,333,349,0.00963390
+Gnome Sort,333,350,0.00939810
+Gnome Sort,333,351,0.01042430
+Gnome Sort,333,352,0.00929050
+Gnome Sort,333,353,0.01034640
+Gnome Sort,333,354,0.00793680
+Gnome Sort,333,355,0.00901220
+Gnome Sort,333,356,0.00895770
+Gnome Sort,333,357,0.01173880
+Gnome Sort,333,358,0.00916760
+Gnome Sort,333,359,0.00956280
+Gnome Sort,333,360,0.00808930
+Gnome Sort,333,361,0.01061600
+Gnome Sort,333,362,0.01416760
+Gnome Sort,333,363,0.00847650
+Gnome Sort,333,364,0.00940500
+Gnome Sort,333,365,0.00909610
+Gnome Sort,333,366,0.00917720
+Gnome Sort,333,367,0.00878500
+Gnome Sort,333,368,0.00831720
+Gnome Sort,333,369,0.00888600
+Gnome Sort,333,370,0.00934270
+Gnome Sort,333,371,0.01331670
+Gnome Sort,333,372,0.01107080
+Gnome Sort,333,373,0.00951690
+Gnome Sort,333,374,0.00886850
+Gnome Sort,333,375,0.00895030
+Gnome Sort,333,376,0.00861610
+Gnome Sort,333,377,0.00900360
+Gnome Sort,333,378,0.00842810
+Gnome Sort,333,379,0.01804620
+Gnome Sort,333,380,0.00842670
+Gnome Sort,333,381,0.00842900
+Gnome Sort,333,382,0.00903250
+Gnome Sort,333,383,0.00906730
+Gnome Sort,333,384,0.00818020
+Gnome Sort,333,385,0.00850400
+Gnome Sort,333,386,0.00895560
+Gnome Sort,333,387,0.00950010
+Gnome Sort,333,388,0.01114170
+Gnome Sort,333,389,0.00894990
+Gnome Sort,333,390,0.00880590
+Gnome Sort,333,391,0.00894450
+Gnome Sort,333,392,0.00965990
+Gnome Sort,333,393,0.01312360
+Gnome Sort,333,394,0.00863480
+Gnome Sort,333,395,0.01385520
+Gnome Sort,333,396,0.00940100
+Gnome Sort,333,397,0.01129410
+Gnome Sort,333,398,0.00834480
+Gnome Sort,333,399,0.00894850
+Gnome Sort,333,400,0.00828270
+Gnome Sort,333,401,0.00989690
+Gnome Sort,333,402,0.00913910
+Gnome Sort,333,403,0.01123080
+Gnome Sort,333,404,0.01182660
+Gnome Sort,333,405,0.01034510
+Gnome Sort,333,406,0.00886520
+Gnome Sort,333,407,0.00842110
+Gnome Sort,333,408,0.01175140
+Gnome Sort,333,409,0.00912600
+Gnome Sort,333,410,0.00980820
+Gnome Sort,333,411,0.01154590
+Gnome Sort,333,412,0.01097070
+Gnome Sort,333,413,0.00857870
+Gnome Sort,333,414,0.00896270
+Gnome Sort,333,415,0.00815940
+Gnome Sort,333,416,0.00892560
+Gnome Sort,333,417,0.00922100
+Gnome Sort,333,418,0.00979130
+Gnome Sort,333,419,0.01212770
+Gnome Sort,333,420,0.00890390
+Gnome Sort,333,421,0.00908990
+Gnome Sort,333,422,0.01075480
+Gnome Sort,333,423,0.00907390
+Gnome Sort,333,424,0.00946040
+Gnome Sort,333,425,0.00862970
+Gnome Sort,333,426,0.00878750
+Gnome Sort,333,427,0.00872040
+Gnome Sort,333,428,0.00930740
+Gnome Sort,333,429,0.00904560
+Gnome Sort,333,430,0.00909060
+Gnome Sort,333,431,0.00891600
+Gnome Sort,333,432,0.00880510
+Gnome Sort,333,433,0.01438060
+Gnome Sort,333,434,0.00874390
+Gnome Sort,333,435,0.00881340
+Gnome Sort,333,436,0.00862110
+Gnome Sort,333,437,0.00997830
+Gnome Sort,333,438,0.00857370
+Gnome Sort,333,439,0.00896460
+Gnome Sort,333,440,0.00868930
+Gnome Sort,333,441,0.00855860
+Gnome Sort,333,442,0.00859550
+Gnome Sort,333,443,0.00843200
+Gnome Sort,333,444,0.00913990
+Gnome Sort,333,445,0.00855610
+Gnome Sort,333,446,0.00889910
+Gnome Sort,333,447,0.00908890
+Gnome Sort,333,448,0.00871820
+Gnome Sort,333,449,0.00922400
+Gnome Sort,333,450,0.00962600
+Gnome Sort,333,451,0.00963840
+Gnome Sort,333,452,0.00958860
+Gnome Sort,333,453,0.00949880
+Gnome Sort,333,454,0.00905550
+Gnome Sort,333,455,0.00886140
+Gnome Sort,333,456,0.00883920
+Gnome Sort,333,457,0.00867870
+Gnome Sort,333,458,0.00961830
+Gnome Sort,333,459,0.00917290
+Gnome Sort,333,460,0.00967000
+Gnome Sort,333,461,0.00903010
+Gnome Sort,333,462,0.00899700
+Gnome Sort,333,463,0.00862280
+Gnome Sort,333,464,0.00824340
+Gnome Sort,333,465,0.00944970
+Gnome Sort,333,466,0.00848580
+Gnome Sort,333,467,0.00939390
+Gnome Sort,333,468,0.00927460
+Gnome Sort,333,469,0.00849560
+Gnome Sort,333,470,0.00921300
+Gnome Sort,333,471,0.00857050
+Gnome Sort,333,472,0.00934050
+Gnome Sort,333,473,0.00750030
+Gnome Sort,333,474,0.00982230
+Gnome Sort,333,475,0.00899800
+Gnome Sort,333,476,0.00913900
+Gnome Sort,333,477,0.00980590
+Gnome Sort,333,478,0.00879850
+Gnome Sort,333,479,0.00977440
+Gnome Sort,333,480,0.00840770
+Gnome Sort,333,481,0.00859820
+Gnome Sort,333,482,0.00908740
+Gnome Sort,333,483,0.00945030
+Gnome Sort,333,484,0.00997410
+Gnome Sort,333,485,0.01025990
+Gnome Sort,333,486,0.00874630
+Gnome Sort,333,487,0.00975160
+Gnome Sort,333,488,0.00952720
+Gnome Sort,333,489,0.00970520
+Gnome Sort,333,490,0.00883350
+Gnome Sort,333,491,0.00834340
+Gnome Sort,333,492,0.00860050
+Gnome Sort,333,493,0.00923100
+Gnome Sort,333,494,0.00979600
+Gnome Sort,333,495,0.01125360
+Gnome Sort,333,496,0.00918930
+Gnome Sort,333,497,0.01103940
+Gnome Sort,333,498,0.00963380
+Gnome Sort,333,499,0.00885620
+Gnome Sort,333,500,0.00965910
+Heap Sort,333,1,0.00086690
+Heap Sort,333,2,0.00121950
+Heap Sort,333,3,0.00085400
+Heap Sort,333,4,0.00087300
+Heap Sort,333,5,0.00088560
+Heap Sort,333,6,0.00119600
+Heap Sort,333,7,0.00087570
+Heap Sort,333,8,0.00090020
+Heap Sort,333,9,0.00089610
+Heap Sort,333,10,0.00087990
+Heap Sort,333,11,0.00202900
+Heap Sort,333,12,0.00090070
+Heap Sort,333,13,0.00087770
+Heap Sort,333,14,0.00183980
+Heap Sort,333,15,0.00089950
+Heap Sort,333,16,0.00133750
+Heap Sort,333,17,0.00088470
+Heap Sort,333,18,0.00088150
+Heap Sort,333,19,0.00091330
+Heap Sort,333,20,0.00089920
+Heap Sort,333,21,0.00087610
+Heap Sort,333,22,0.00107410
+Heap Sort,333,23,0.00088200
+Heap Sort,333,24,0.00120590
+Heap Sort,333,25,0.00093110
+Heap Sort,333,26,0.00085260
+Heap Sort,333,27,0.00095210
+Heap Sort,333,28,0.00093970
+Heap Sort,333,29,0.00086690
+Heap Sort,333,30,0.00084980
+Heap Sort,333,31,0.00089270
+Heap Sort,333,32,0.00089070
+Heap Sort,333,33,0.00094990
+Heap Sort,333,34,0.00089670
+Heap Sort,333,35,0.00088720
+Heap Sort,333,36,0.00098850
+Heap Sort,333,37,0.00088350
+Heap Sort,333,38,0.00084460
+Heap Sort,333,39,0.00090180
+Heap Sort,333,40,0.00089440
+Heap Sort,333,41,0.00090200
+Heap Sort,333,42,0.00088370
+Heap Sort,333,43,0.00128790
+Heap Sort,333,44,0.00125580
+Heap Sort,333,45,0.00089550
+Heap Sort,333,46,0.00085470
+Heap Sort,333,47,0.00086880
+Heap Sort,333,48,0.00094500
+Heap Sort,333,49,0.00090410
+Heap Sort,333,50,0.00090400
+Heap Sort,333,51,0.00102510
+Heap Sort,333,52,0.00083200
+Heap Sort,333,53,0.00090170
+Heap Sort,333,54,0.00095410
+Heap Sort,333,55,0.00118010
+Heap Sort,333,56,0.00093600
+Heap Sort,333,57,0.00086810
+Heap Sort,333,58,0.00130850
+Heap Sort,333,59,0.00089540
+Heap Sort,333,60,0.00108300
+Heap Sort,333,61,0.00083450
+Heap Sort,333,62,0.00088270
+Heap Sort,333,63,0.00107730
+Heap Sort,333,64,0.00086350
+Heap Sort,333,65,0.00091540
+Heap Sort,333,66,0.00139230
+Heap Sort,333,67,0.00093650
+Heap Sort,333,68,0.00083280
+Heap Sort,333,69,0.00091860
+Heap Sort,333,70,0.00095320
+Heap Sort,333,71,0.00086350
+Heap Sort,333,72,0.00101700
+Heap Sort,333,73,0.00090990
+Heap Sort,333,74,0.00089970
+Heap Sort,333,75,0.00082840
+Heap Sort,333,76,0.00090690
+Heap Sort,333,77,0.00100610
+Heap Sort,333,78,0.00087350
+Heap Sort,333,79,0.00133600
+Heap Sort,333,80,0.00089590
+Heap Sort,333,81,0.00134190
+Heap Sort,333,82,0.00089110
+Heap Sort,333,83,0.00091290
+Heap Sort,333,84,0.00083540
+Heap Sort,333,85,0.00101440
+Heap Sort,333,86,0.00091670
+Heap Sort,333,87,0.00101350
+Heap Sort,333,88,0.00087580
+Heap Sort,333,89,0.00089530
+Heap Sort,333,90,0.00091100
+Heap Sort,333,91,0.00091800
+Heap Sort,333,92,0.00083370
+Heap Sort,333,93,0.00100550
+Heap Sort,333,94,0.00089080
+Heap Sort,333,95,0.00091130
+Heap Sort,333,96,0.00086050
+Heap Sort,333,97,0.00097320
+Heap Sort,333,98,0.00090400
+Heap Sort,333,99,0.00089820
+Heap Sort,333,100,0.00083540
+Heap Sort,333,101,0.00085510
+Heap Sort,333,102,0.00129580
+Heap Sort,333,103,0.00090640
+Heap Sort,333,104,0.00092690
+Heap Sort,333,105,0.00085810
+Heap Sort,333,106,0.00083990
+Heap Sort,333,107,0.00088590
+Heap Sort,333,108,0.00090330
+Heap Sort,333,109,0.00092590
+Heap Sort,333,110,0.00086540
+Heap Sort,333,111,0.00090230
+Heap Sort,333,112,0.00090280
+Heap Sort,333,113,0.00088780
+Heap Sort,333,114,0.00124720
+Heap Sort,333,115,0.00083810
+Heap Sort,333,116,0.00088600
+Heap Sort,333,117,0.00089370
+Heap Sort,333,118,0.00089440
+Heap Sort,333,119,0.00088330
+Heap Sort,333,120,0.00094170
+Heap Sort,333,121,0.00092270
+Heap Sort,333,122,0.00086390
+Heap Sort,333,123,0.00082830
+Heap Sort,333,124,0.00091100
+Heap Sort,333,125,0.00089090
+Heap Sort,333,126,0.00144230
+Heap Sort,333,127,0.00089310
+Heap Sort,333,128,0.00089240
+Heap Sort,333,129,0.00088070
+Heap Sort,333,130,0.00090100
+Heap Sort,333,131,0.00086210
+Heap Sort,333,132,0.00084060
+Heap Sort,333,133,0.00091690
+Heap Sort,333,134,0.00094870
+Heap Sort,333,135,0.00089730
+Heap Sort,333,136,0.00090320
+Heap Sort,333,137,0.00086420
+Heap Sort,333,138,0.00089950
+Heap Sort,333,139,0.00086340
+Heap Sort,333,140,0.00090020
+Heap Sort,333,141,0.00084890
+Heap Sort,333,142,0.00091850
+Heap Sort,333,143,0.00092370
+Heap Sort,333,144,0.00142700
+Heap Sort,333,145,0.00091180
+Heap Sort,333,146,0.00092570
+Heap Sort,333,147,0.00086040
+Heap Sort,333,148,0.00092540
+Heap Sort,333,149,0.00089930
+Heap Sort,333,150,0.00084660
+Heap Sort,333,151,0.00091580
+Heap Sort,333,152,0.00093100
+Heap Sort,333,153,0.00091340
+Heap Sort,333,154,0.00088280
+Heap Sort,333,155,0.00086900
+Heap Sort,333,156,0.00115800
+Heap Sort,333,157,0.00090620
+Heap Sort,333,158,0.00084190
+Heap Sort,333,159,0.00094320
+Heap Sort,333,160,0.00096700
+Heap Sort,333,161,0.00092090
+Heap Sort,333,162,0.00091380
+Heap Sort,333,163,0.00487830
+Heap Sort,333,164,0.00088330
+Heap Sort,333,165,0.00083370
+Heap Sort,333,166,0.00089980
+Heap Sort,333,167,0.00091980
+Heap Sort,333,168,0.00128150
+Heap Sort,333,169,0.00126070
+Heap Sort,333,170,0.00097060
+Heap Sort,333,171,0.00089010
+Heap Sort,333,172,0.00087290
+Heap Sort,333,173,0.00082490
+Heap Sort,333,174,0.00089990
+Heap Sort,333,175,0.00090720
+Heap Sort,333,176,0.00090490
+Heap Sort,333,177,0.00091150
+Heap Sort,333,178,0.00137880
+Heap Sort,333,179,0.00087340
+Heap Sort,333,180,0.00083220
+Heap Sort,333,181,0.00105080
+Heap Sort,333,182,0.00096560
+Heap Sort,333,183,0.00090120
+Heap Sort,333,184,0.00090730
+Heap Sort,333,185,0.00091200
+Heap Sort,333,186,0.00247990
+Heap Sort,333,187,0.00087420
+Heap Sort,333,188,0.00089710
+Heap Sort,333,189,0.00100620
+Heap Sort,333,190,0.00112860
+Heap Sort,333,191,0.00089270
+Heap Sort,333,192,0.00091190
+Heap Sort,333,193,0.00089810
+Heap Sort,333,194,0.00087390
+Heap Sort,333,195,0.00090970
+Heap Sort,333,196,0.00088770
+Heap Sort,333,197,0.00152210
+Heap Sort,333,198,0.00088900
+Heap Sort,333,199,0.00093130
+Heap Sort,333,200,0.00088870
+Heap Sort,333,201,0.00090030
+Heap Sort,333,202,0.00091820
+Heap Sort,333,203,0.00086630
+Heap Sort,333,204,0.00089810
+Heap Sort,333,205,0.00094770
+Heap Sort,333,206,0.00090230
+Heap Sort,333,207,0.00089660
+Heap Sort,333,208,0.00090040
+Heap Sort,333,209,0.00182380
+Heap Sort,333,210,0.00090450
+Heap Sort,333,211,0.00111850
+Heap Sort,333,212,0.00088630
+Heap Sort,333,213,0.00089400
+Heap Sort,333,214,0.00092130
+Heap Sort,333,215,0.00089320
+Heap Sort,333,216,0.00090020
+Heap Sort,333,217,0.00089640
+Heap Sort,333,218,0.00093950
+Heap Sort,333,219,0.00087320
+Heap Sort,333,220,0.00090260
+Heap Sort,333,221,0.00092020
+Heap Sort,333,222,0.00088930
+Heap Sort,333,223,0.00151470
+Heap Sort,333,224,0.00090880
+Heap Sort,333,225,0.00089770
+Heap Sort,333,226,0.00127480
+Heap Sort,333,227,0.00120710
+Heap Sort,333,228,0.00089670
+Heap Sort,333,229,0.00092260
+Heap Sort,333,230,0.00089590
+Heap Sort,333,231,0.00419000
+Heap Sort,333,232,0.00092760
+Heap Sort,333,233,0.00089800
+Heap Sort,333,234,0.00091970
+Heap Sort,333,235,0.00090870
+Heap Sort,333,236,0.00090660
+Heap Sort,333,237,0.00089660
+Heap Sort,333,238,0.00075240
+Heap Sort,333,239,0.00487550
+Heap Sort,333,240,0.00092140
+Heap Sort,333,241,0.00090260
+Heap Sort,333,242,0.00087840
+Heap Sort,333,243,0.00091540
+Heap Sort,333,244,0.00098440
+Heap Sort,333,245,0.00076810
+Heap Sort,333,246,0.00089220
+Heap Sort,333,247,0.00130030
+Heap Sort,333,248,0.00089690
+Heap Sort,333,249,0.00091190
+Heap Sort,333,250,0.00094550
+Heap Sort,333,251,0.00088240
+Heap Sort,333,252,0.00089550
+Heap Sort,333,253,0.00090020
+Heap Sort,333,254,0.00089330
+Heap Sort,333,255,0.00091800
+Heap Sort,333,256,0.00478100
+Heap Sort,333,257,0.00088640
+Heap Sort,333,258,0.00094920
+Heap Sort,333,259,0.00089610
+Heap Sort,333,260,0.00089410
+Heap Sort,333,261,0.00091780
+Heap Sort,333,262,0.00092150
+Heap Sort,333,263,0.00094000
+Heap Sort,333,264,0.00099190
+Heap Sort,333,265,0.00088520
+Heap Sort,333,266,0.00094420
+Heap Sort,333,267,0.00089420
+Heap Sort,333,268,0.00093270
+Heap Sort,333,269,0.00089250
+Heap Sort,333,270,0.00102540
+Heap Sort,333,271,0.00097750
+Heap Sort,333,272,0.00087920
+Heap Sort,333,273,0.00088810
+Heap Sort,333,274,0.00093180
+Heap Sort,333,275,0.00092850
+Heap Sort,333,276,0.00084160
+Heap Sort,333,277,0.00089350
+Heap Sort,333,278,0.00091110
+Heap Sort,333,279,0.00089080
+Heap Sort,333,280,0.00093390
+Heap Sort,333,281,0.00087830
+Heap Sort,333,282,0.00087900
+Heap Sort,333,283,0.00088200
+Heap Sort,333,284,0.00106130
+Heap Sort,333,285,0.00095030
+Heap Sort,333,286,0.00087890
+Heap Sort,333,287,0.00089960
+Heap Sort,333,288,0.00093570
+Heap Sort,333,289,0.00090480
+Heap Sort,333,290,0.00088800
+Heap Sort,333,291,0.00093220
+Heap Sort,333,292,0.00090320
+Heap Sort,333,293,0.00089590
+Heap Sort,333,294,0.00092380
+Heap Sort,333,295,0.00088550
+Heap Sort,333,296,0.00089090
+Heap Sort,333,297,0.00096620
+Heap Sort,333,298,0.00091060
+Heap Sort,333,299,0.00093430
+Heap Sort,333,300,0.00088340
+Heap Sort,333,301,0.00089040
+Heap Sort,333,302,0.00098810
+Heap Sort,333,303,0.00090490
+Heap Sort,333,304,0.00094120
+Heap Sort,333,305,0.00095570
+Heap Sort,333,306,0.00089180
+Heap Sort,333,307,0.00088890
+Heap Sort,333,308,0.00088900
+Heap Sort,333,309,0.00141860
+Heap Sort,333,310,0.00090750
+Heap Sort,333,311,0.00110680
+Heap Sort,333,312,0.00088120
+Heap Sort,333,313,0.00095270
+Heap Sort,333,314,0.00089530
+Heap Sort,333,315,0.00090160
+Heap Sort,333,316,0.00089540
+Heap Sort,333,317,0.00089660
+Heap Sort,333,318,0.00090880
+Heap Sort,333,319,0.00089070
+Heap Sort,333,320,0.00089070
+Heap Sort,333,321,0.00088940
+Heap Sort,333,322,0.00095400
+Heap Sort,333,323,0.00088040
+Heap Sort,333,324,0.00090730
+Heap Sort,333,325,0.00088350
+Heap Sort,333,326,0.00090150
+Heap Sort,333,327,0.00088740
+Heap Sort,333,328,0.00097810
+Heap Sort,333,329,0.00088530
+Heap Sort,333,330,0.00088560
+Heap Sort,333,331,0.00089170
+Heap Sort,333,332,0.00090740
+Heap Sort,333,333,0.00090250
+Heap Sort,333,334,0.00090150
+Heap Sort,333,335,0.00093620
+Heap Sort,333,336,0.00091100
+Heap Sort,333,337,0.00088920
+Heap Sort,333,338,0.00088880
+Heap Sort,333,339,0.00096460
+Heap Sort,333,340,0.00087560
+Heap Sort,333,341,0.00087670
+Heap Sort,333,342,0.00089750
+Heap Sort,333,343,0.00090990
+Heap Sort,333,344,0.00094410
+Heap Sort,333,345,0.00092360
+Heap Sort,333,346,0.00088530
+Heap Sort,333,347,0.00089370
+Heap Sort,333,348,0.00090800
+Heap Sort,333,349,0.00096590
+Heap Sort,333,350,0.00089370
+Heap Sort,333,351,0.00091530
+Heap Sort,333,352,0.00089470
+Heap Sort,333,353,0.00089330
+Heap Sort,333,354,0.00087450
+Heap Sort,333,355,0.00087450
+Heap Sort,333,356,0.00089520
+Heap Sort,333,357,0.00088900
+Heap Sort,333,358,0.00095910
+Heap Sort,333,359,0.00089070
+Heap Sort,333,360,0.00096440
+Heap Sort,333,361,0.00091880
+Heap Sort,333,362,0.00090080
+Heap Sort,333,363,0.00099510
+Heap Sort,333,364,0.00088210
+Heap Sort,333,365,0.00092480
+Heap Sort,333,366,0.00090600
+Heap Sort,333,367,0.00093890
+Heap Sort,333,368,0.00096540
+Heap Sort,333,369,0.00089710
+Heap Sort,333,370,0.00088680
+Heap Sort,333,371,0.00089120
+Heap Sort,333,372,0.00086310
+Heap Sort,333,373,0.00083370
+Heap Sort,333,374,0.00086940
+Heap Sort,333,375,0.00090560
+Heap Sort,333,376,0.00096400
+Heap Sort,333,377,0.00089370
+Heap Sort,333,378,0.00337660
+Heap Sort,333,379,0.00090170
+Heap Sort,333,380,0.00087840
+Heap Sort,333,381,0.00085480
+Heap Sort,333,382,0.00089220
+Heap Sort,333,383,0.00088480
+Heap Sort,333,384,0.00089350
+Heap Sort,333,385,0.00089900
+Heap Sort,333,386,0.00096740
+Heap Sort,333,387,0.00300280
+Heap Sort,333,388,0.00085500
+Heap Sort,333,389,0.00090310
+Heap Sort,333,390,0.00085420
+Heap Sort,333,391,0.00089630
+Heap Sort,333,392,0.00089690
+Heap Sort,333,393,0.00089220
+Heap Sort,333,394,0.00097600
+Heap Sort,333,395,0.00087700
+Heap Sort,333,396,0.00088250
+Heap Sort,333,397,0.00097720
+Heap Sort,333,398,0.00092180
+Heap Sort,333,399,0.00089260
+Heap Sort,333,400,0.00088340
+Heap Sort,333,401,0.00094590
+Heap Sort,333,402,0.00156440
+Heap Sort,333,403,0.00086280
+Heap Sort,333,404,0.00087570
+Heap Sort,333,405,0.00090260
+Heap Sort,333,406,0.00090890
+Heap Sort,333,407,0.00087940
+Heap Sort,333,408,0.00088530
+Heap Sort,333,409,0.00172920
+Heap Sort,333,410,0.00097990
+Heap Sort,333,411,0.00085230
+Heap Sort,333,412,0.00086390
+Heap Sort,333,413,0.00089590
+Heap Sort,333,414,0.00114480
+Heap Sort,333,415,0.00102910
+Heap Sort,333,416,0.00088050
+Heap Sort,333,417,0.00086760
+Heap Sort,333,418,0.00094660
+Heap Sort,333,419,0.00088880
+Heap Sort,333,420,0.00293050
+Heap Sort,333,421,0.00090510
+Heap Sort,333,422,0.00146300
+Heap Sort,333,423,0.00088080
+Heap Sort,333,424,0.00112160
+Heap Sort,333,425,0.00085860
+Heap Sort,333,426,0.00085600
+Heap Sort,333,427,0.00093950
+Heap Sort,333,428,0.00127080
+Heap Sort,333,429,0.00090220
+Heap Sort,333,430,0.00089950
+Heap Sort,333,431,0.00085910
+Heap Sort,333,432,0.00172540
+Heap Sort,333,433,0.00092740
+Heap Sort,333,434,0.00196740
+Heap Sort,333,435,0.00094550
+Heap Sort,333,436,0.00090130
+Heap Sort,333,437,0.00090400
+Heap Sort,333,438,0.00196680
+Heap Sort,333,439,0.00087700
+Heap Sort,333,440,0.00091020
+Heap Sort,333,441,0.00190820
+Heap Sort,333,442,0.00092390
+Heap Sort,333,443,0.00088900
+Heap Sort,333,444,0.00092410
+Heap Sort,333,445,0.00085850
+Heap Sort,333,446,0.00251290
+Heap Sort,333,447,0.00090500
+Heap Sort,333,448,0.00090320
+Heap Sort,333,449,0.00088140
+Heap Sort,333,450,0.00212270
+Heap Sort,333,451,0.00088870
+Heap Sort,333,452,0.00089690
+Heap Sort,333,453,0.00089450
+Heap Sort,333,454,0.00101430
+Heap Sort,333,455,0.00092790
+Heap Sort,333,456,0.00088780
+Heap Sort,333,457,0.00087690
+Heap Sort,333,458,0.00091910
+Heap Sort,333,459,0.00089960
+Heap Sort,333,460,0.00094110
+Heap Sort,333,461,0.00090000
+Heap Sort,333,462,0.00087480
+Heap Sort,333,463,0.00089860
+Heap Sort,333,464,0.00129940
+Heap Sort,333,465,0.00089430
+Heap Sort,333,466,0.00087180
+Heap Sort,333,467,0.00089070
+Heap Sort,333,468,0.00089470
+Heap Sort,333,469,0.00089020
+Heap Sort,333,470,0.00091160
+Heap Sort,333,471,0.00088510
+Heap Sort,333,472,0.00088590
+Heap Sort,333,473,0.00089440
+Heap Sort,333,474,0.00089630
+Heap Sort,333,475,0.00115010
+Heap Sort,333,476,0.00089010
+Heap Sort,333,477,0.00089310
+Heap Sort,333,478,0.00089330
+Heap Sort,333,479,0.00089390
+Heap Sort,333,480,0.00088200
+Heap Sort,333,481,0.00090220
+Heap Sort,333,482,0.00087870
+Heap Sort,333,483,0.00089470
+Heap Sort,333,484,0.00089000
+Heap Sort,333,485,0.00088870
+Heap Sort,333,486,0.00096130
+Heap Sort,333,487,0.00089630
+Heap Sort,333,488,0.00089930
+Heap Sort,333,489,0.00089270
+Heap Sort,333,490,0.00088390
+Heap Sort,333,491,0.00091830
+Heap Sort,333,492,0.00335940
+Heap Sort,333,493,0.00089740
+Heap Sort,333,494,0.00089580
+Heap Sort,333,495,0.00091750
+Heap Sort,333,496,0.00093900
+Heap Sort,333,497,0.00098730
+Heap Sort,333,498,0.00091930
+Heap Sort,333,499,0.00089570
+Heap Sort,333,500,0.00094660
+Hyper Quick,333,1,0.00066510
+Hyper Quick,333,2,0.00062120
+Hyper Quick,333,3,0.00066130
+Hyper Quick,333,4,0.00067360
+Hyper Quick,333,5,0.00062590
+Hyper Quick,333,6,0.00113230
+Hyper Quick,333,7,0.00067640
+Hyper Quick,333,8,0.00063400
+Hyper Quick,333,9,0.00062910
+Hyper Quick,333,10,0.00063190
+Hyper Quick,333,11,0.00065050
+Hyper Quick,333,12,0.00067350
+Hyper Quick,333,13,0.00061560
+Hyper Quick,333,14,0.00115390
+Hyper Quick,333,15,0.00065740
+Hyper Quick,333,16,0.00065300
+Hyper Quick,333,17,0.00062110
+Hyper Quick,333,18,0.00061640
+Hyper Quick,333,19,0.00063050
+Hyper Quick,333,20,0.00061150
+Hyper Quick,333,21,0.00065410
+Hyper Quick,333,22,0.00061360
+Hyper Quick,333,23,0.00062640
+Hyper Quick,333,24,0.00060890
+Hyper Quick,333,25,0.00061940
+Hyper Quick,333,26,0.00057990
+Hyper Quick,333,27,0.00063410
+Hyper Quick,333,28,0.00062060
+Hyper Quick,333,29,0.00061680
+Hyper Quick,333,30,0.00063500
+Hyper Quick,333,31,0.00060980
+Hyper Quick,333,32,0.00060480
+Hyper Quick,333,33,0.00062750
+Hyper Quick,333,34,0.00062260
+Hyper Quick,333,35,0.00058420
+Hyper Quick,333,36,0.00061170
+Hyper Quick,333,37,0.00059690
+Hyper Quick,333,38,0.00059370
+Hyper Quick,333,39,0.00063030
+Hyper Quick,333,40,0.00136600
+Hyper Quick,333,41,0.00064630
+Hyper Quick,333,42,0.00061490
+Hyper Quick,333,43,0.00063370
+Hyper Quick,333,44,0.00059390
+Hyper Quick,333,45,0.00066070
+Hyper Quick,333,46,0.00060300
+Hyper Quick,333,47,0.00070230
+Hyper Quick,333,48,0.00062960
+Hyper Quick,333,49,0.00079810
+Hyper Quick,333,50,0.00066980
+Hyper Quick,333,51,0.00063810
+Hyper Quick,333,52,0.00062440
+Hyper Quick,333,53,0.00065420
+Hyper Quick,333,54,0.00063050
+Hyper Quick,333,55,0.00064500
+Hyper Quick,333,56,0.00067380
+Hyper Quick,333,57,0.00064000
+Hyper Quick,333,58,0.00058350
+Hyper Quick,333,59,0.00062960
+Hyper Quick,333,60,0.00061830
+Hyper Quick,333,61,0.00070030
+Hyper Quick,333,62,0.00062600
+Hyper Quick,333,63,0.00061580
+Hyper Quick,333,64,0.00064520
+Hyper Quick,333,65,0.00058140
+Hyper Quick,333,66,0.00069460
+Hyper Quick,333,67,0.00062290
+Hyper Quick,333,68,0.00057550
+Hyper Quick,333,69,0.00060760
+Hyper Quick,333,70,0.00067810
+Hyper Quick,333,71,0.00064230
+Hyper Quick,333,72,0.00063650
+Hyper Quick,333,73,0.00066500
+Hyper Quick,333,74,0.00064630
+Hyper Quick,333,75,0.00068450
+Hyper Quick,333,76,0.00065020
+Hyper Quick,333,77,0.00057950
+Hyper Quick,333,78,0.00058350
+Hyper Quick,333,79,0.00068350
+Hyper Quick,333,80,0.00061400
+Hyper Quick,333,81,0.00070060
+Hyper Quick,333,82,0.00062050
+Hyper Quick,333,83,0.00062190
+Hyper Quick,333,84,0.00058540
+Hyper Quick,333,85,0.00061490
+Hyper Quick,333,86,0.00070970
+Hyper Quick,333,87,0.00058730
+Hyper Quick,333,88,0.00059840
+Hyper Quick,333,89,0.00067710
+Hyper Quick,333,90,0.00063990
+Hyper Quick,333,91,0.00061130
+Hyper Quick,333,92,0.00059990
+Hyper Quick,333,93,0.00060950
+Hyper Quick,333,94,0.00061220
+Hyper Quick,333,95,0.00060850
+Hyper Quick,333,96,0.00066380
+Hyper Quick,333,97,0.00061460
+Hyper Quick,333,98,0.00063440
+Hyper Quick,333,99,0.00062000
+Hyper Quick,333,100,0.00063440
+Hyper Quick,333,101,0.00065770
+Hyper Quick,333,102,0.00058990
+Hyper Quick,333,103,0.00067160
+Hyper Quick,333,104,0.00058500
+Hyper Quick,333,105,0.00063090
+Hyper Quick,333,106,0.00077530
+Hyper Quick,333,107,0.00063600
+Hyper Quick,333,108,0.00057400
+Hyper Quick,333,109,0.00062050
+Hyper Quick,333,110,0.00066260
+Hyper Quick,333,111,0.00076240
+Hyper Quick,333,112,0.00066900
+Hyper Quick,333,113,0.00061810
+Hyper Quick,333,114,0.00066840
+Hyper Quick,333,115,0.00066180
+Hyper Quick,333,116,0.00061440
+Hyper Quick,333,117,0.00060180
+Hyper Quick,333,118,0.00060970
+Hyper Quick,333,119,0.00061120
+Hyper Quick,333,120,0.00064320
+Hyper Quick,333,121,0.00063670
+Hyper Quick,333,122,0.00058370
+Hyper Quick,333,123,0.00061920
+Hyper Quick,333,124,0.00073170
+Hyper Quick,333,125,0.00061970
+Hyper Quick,333,126,0.00064570
+Hyper Quick,333,127,0.00073750
+Hyper Quick,333,128,0.00060340
+Hyper Quick,333,129,0.00060650
+Hyper Quick,333,130,0.00062460
+Hyper Quick,333,131,0.00062990
+Hyper Quick,333,132,0.00061300
+Hyper Quick,333,133,0.00059000
+Hyper Quick,333,134,0.00064330
+Hyper Quick,333,135,0.00070380
+Hyper Quick,333,136,0.00057120
+Hyper Quick,333,137,0.00060920
+Hyper Quick,333,138,0.00059710
+Hyper Quick,333,139,0.00062530
+Hyper Quick,333,140,0.00065950
+Hyper Quick,333,141,0.00062660
+Hyper Quick,333,142,0.00058470
+Hyper Quick,333,143,0.00069150
+Hyper Quick,333,144,0.00059500
+Hyper Quick,333,145,0.00069570
+Hyper Quick,333,146,0.00058500
+Hyper Quick,333,147,0.00062290
+Hyper Quick,333,148,0.00061560
+Hyper Quick,333,149,0.00061650
+Hyper Quick,333,150,0.00063280
+Hyper Quick,333,151,0.00065680
+Hyper Quick,333,152,0.00058540
+Hyper Quick,333,153,0.00059230
+Hyper Quick,333,154,0.00058690
+Hyper Quick,333,155,0.00074680
+Hyper Quick,333,156,0.00059900
+Hyper Quick,333,157,0.00065280
+Hyper Quick,333,158,0.00066140
+Hyper Quick,333,159,0.00065110
+Hyper Quick,333,160,0.00059150
+Hyper Quick,333,161,0.00057380
+Hyper Quick,333,162,0.00062010
+Hyper Quick,333,163,0.00053760
+Hyper Quick,333,164,0.00052220
+Hyper Quick,333,165,0.00057050
+Hyper Quick,333,166,0.00063200
+Hyper Quick,333,167,0.00072980
+Hyper Quick,333,168,0.00060920
+Hyper Quick,333,169,0.00068100
+Hyper Quick,333,170,0.00061520
+Hyper Quick,333,171,0.00065230
+Hyper Quick,333,172,0.00063790
+Hyper Quick,333,173,0.00064850
+Hyper Quick,333,174,0.00059260
+Hyper Quick,333,175,0.00066650
+Hyper Quick,333,176,0.00070130
+Hyper Quick,333,177,0.00069800
+Hyper Quick,333,178,0.00060660
+Hyper Quick,333,179,0.00053020
+Hyper Quick,333,180,0.00071830
+Hyper Quick,333,181,0.00062670
+Hyper Quick,333,182,0.00072770
+Hyper Quick,333,183,0.00060610
+Hyper Quick,333,184,0.00073200
+Hyper Quick,333,185,0.00050490
+Hyper Quick,333,186,0.00066070
+Hyper Quick,333,187,0.00060760
+Hyper Quick,333,188,0.00066410
+Hyper Quick,333,189,0.00052000
+Hyper Quick,333,190,0.00061950
+Hyper Quick,333,191,0.00058570
+Hyper Quick,333,192,0.00072040
+Hyper Quick,333,193,0.00060780
+Hyper Quick,333,194,0.00043810
+Hyper Quick,333,195,0.00065570
+Hyper Quick,333,196,0.00060880
+Hyper Quick,333,197,0.00060160
+Hyper Quick,333,198,0.00059860
+Hyper Quick,333,199,0.00060830
+Hyper Quick,333,200,0.00071340
+Hyper Quick,333,201,0.00065760
+Hyper Quick,333,202,0.00055080
+Hyper Quick,333,203,0.00058120
+Hyper Quick,333,204,0.00061850
+Hyper Quick,333,205,0.00060320
+Hyper Quick,333,206,0.00060240
+Hyper Quick,333,207,0.00071400
+Hyper Quick,333,208,0.00058970
+Hyper Quick,333,209,0.00061570
+Hyper Quick,333,210,0.00059430
+Hyper Quick,333,211,0.00065850
+Hyper Quick,333,212,0.00071750
+Hyper Quick,333,213,0.00044470
+Hyper Quick,333,214,0.00068720
+Hyper Quick,333,215,0.00062350
+Hyper Quick,333,216,0.00063170
+Hyper Quick,333,217,0.00064630
+Hyper Quick,333,218,0.00068260
+Hyper Quick,333,219,0.00069320
+Hyper Quick,333,220,0.00058940
+Hyper Quick,333,221,0.00058540
+Hyper Quick,333,222,0.00062020
+Hyper Quick,333,223,0.00048050
+Hyper Quick,333,224,0.00063140
+Hyper Quick,333,225,0.00067500
+Hyper Quick,333,226,0.00052650
+Hyper Quick,333,227,0.00062760
+Hyper Quick,333,228,0.00058070
+Hyper Quick,333,229,0.00061660
+Hyper Quick,333,230,0.00060300
+Hyper Quick,333,231,0.00059890
+Hyper Quick,333,232,0.00066170
+Hyper Quick,333,233,0.00066400
+Hyper Quick,333,234,0.00058530
+Hyper Quick,333,235,0.00059480
+Hyper Quick,333,236,0.00061650
+Hyper Quick,333,237,0.00052440
+Hyper Quick,333,238,0.00069450
+Hyper Quick,333,239,0.00066910
+Hyper Quick,333,240,0.00043900
+Hyper Quick,333,241,0.00058130
+Hyper Quick,333,242,0.00066270
+Hyper Quick,333,243,0.00058050
+Hyper Quick,333,244,0.00063020
+Hyper Quick,333,245,0.00058080
+Hyper Quick,333,246,0.00067690
+Hyper Quick,333,247,0.00063930
+Hyper Quick,333,248,0.00070270
+Hyper Quick,333,249,0.00059350
+Hyper Quick,333,250,0.00061340
+Hyper Quick,333,251,0.00066970
+Hyper Quick,333,252,0.00050030
+Hyper Quick,333,253,0.00059100
+Hyper Quick,333,254,0.00048660
+Hyper Quick,333,255,0.00053980
+Hyper Quick,333,256,0.00062050
+Hyper Quick,333,257,0.00063440
+Hyper Quick,333,258,0.00050700
+Hyper Quick,333,259,0.00069670
+Hyper Quick,333,260,0.00074280
+Hyper Quick,333,261,0.00062440
+Hyper Quick,333,262,0.00055460
+Hyper Quick,333,263,0.00056640
+Hyper Quick,333,264,0.00069830
+Hyper Quick,333,265,0.00068380
+Hyper Quick,333,266,0.00041280
+Hyper Quick,333,267,0.00065890
+Hyper Quick,333,268,0.00051800
+Hyper Quick,333,269,0.00057650
+Hyper Quick,333,270,0.00053220
+Hyper Quick,333,271,0.00063620
+Hyper Quick,333,272,0.00063140
+Hyper Quick,333,273,0.00059510
+Hyper Quick,333,274,0.00040700
+Hyper Quick,333,275,0.00047030
+Hyper Quick,333,276,0.00060350
+Hyper Quick,333,277,0.00057640
+Hyper Quick,333,278,0.00069740
+Hyper Quick,333,279,0.00055270
+Hyper Quick,333,280,0.00064750
+Hyper Quick,333,281,0.00063370
+Hyper Quick,333,282,0.00058610
+Hyper Quick,333,283,0.00062700
+Hyper Quick,333,284,0.00056500
+Hyper Quick,333,285,0.00050850
+Hyper Quick,333,286,0.00046420
+Hyper Quick,333,287,0.00062860
+Hyper Quick,333,288,0.00058150
+Hyper Quick,333,289,0.00062760
+Hyper Quick,333,290,0.00059370
+Hyper Quick,333,291,0.00068810
+Hyper Quick,333,292,0.00066720
+Hyper Quick,333,293,0.00050230
+Hyper Quick,333,294,0.00062460
+Hyper Quick,333,295,0.00069920
+Hyper Quick,333,296,0.00061200
+Hyper Quick,333,297,0.00057880
+Hyper Quick,333,298,0.00074930
+Hyper Quick,333,299,0.00061950
+Hyper Quick,333,300,0.00066040
+Hyper Quick,333,301,0.00066620
+Hyper Quick,333,302,0.00049120
+Hyper Quick,333,303,0.00059010
+Hyper Quick,333,304,0.00067210
+Hyper Quick,333,305,0.00061030
+Hyper Quick,333,306,0.00070980
+Hyper Quick,333,307,0.00058880
+Hyper Quick,333,308,0.00044500
+Hyper Quick,333,309,0.00048690
+Hyper Quick,333,310,0.00060090
+Hyper Quick,333,311,0.00065160
+Hyper Quick,333,312,0.00058310
+Hyper Quick,333,313,0.00062970
+Hyper Quick,333,314,0.00066410
+Hyper Quick,333,315,0.00063040
+Hyper Quick,333,316,0.00064680
+Hyper Quick,333,317,0.00056810
+Hyper Quick,333,318,0.00057240
+Hyper Quick,333,319,0.00060510
+Hyper Quick,333,320,0.00047280
+Hyper Quick,333,321,0.00067590
+Hyper Quick,333,322,0.00063510
+Hyper Quick,333,323,0.00063580
+Hyper Quick,333,324,0.00066710
+Hyper Quick,333,325,0.00060270
+Hyper Quick,333,326,0.00058660
+Hyper Quick,333,327,0.00058270
+Hyper Quick,333,328,0.00057710
+Hyper Quick,333,329,0.00063700
+Hyper Quick,333,330,0.00042970
+Hyper Quick,333,331,0.00069020
+Hyper Quick,333,332,0.00063390
+Hyper Quick,333,333,0.00060870
+Hyper Quick,333,334,0.00065870
+Hyper Quick,333,335,0.00053300
+Hyper Quick,333,336,0.00057260
+Hyper Quick,333,337,0.00063360
+Hyper Quick,333,338,0.00067240
+Hyper Quick,333,339,0.00061170
+Hyper Quick,333,340,0.00061570
+Hyper Quick,333,341,0.00060680
+Hyper Quick,333,342,0.00070230
+Hyper Quick,333,343,0.00044510
+Hyper Quick,333,344,0.00059960
+Hyper Quick,333,345,0.00063720
+Hyper Quick,333,346,0.00047480
+Hyper Quick,333,347,0.00067580
+Hyper Quick,333,348,0.00059470
+Hyper Quick,333,349,0.00069830
+Hyper Quick,333,350,0.00057320
+Hyper Quick,333,351,0.00062460
+Hyper Quick,333,352,0.00062720
+Hyper Quick,333,353,0.00060360
+Hyper Quick,333,354,0.00050560
+Hyper Quick,333,355,0.00066750
+Hyper Quick,333,356,0.00067840
+Hyper Quick,333,357,0.00058920
+Hyper Quick,333,358,0.00052140
+Hyper Quick,333,359,0.00065700
+Hyper Quick,333,360,0.00066080
+Hyper Quick,333,361,0.00058980
+Hyper Quick,333,362,0.00068170
+Hyper Quick,333,363,0.00061380
+Hyper Quick,333,364,0.00071080
+Hyper Quick,333,365,0.00065360
+Hyper Quick,333,366,0.00063940
+Hyper Quick,333,367,0.00069340
+Hyper Quick,333,368,0.00060760
+Hyper Quick,333,369,0.00055520
+Hyper Quick,333,370,0.00058810
+Hyper Quick,333,371,0.00060460
+Hyper Quick,333,372,0.00061160
+Hyper Quick,333,373,0.00063320
+Hyper Quick,333,374,0.00070010
+Hyper Quick,333,375,0.00041960
+Hyper Quick,333,376,0.00047180
+Hyper Quick,333,377,0.00058550
+Hyper Quick,333,378,0.00067970
+Hyper Quick,333,379,0.00064690
+Hyper Quick,333,380,0.00061330
+Hyper Quick,333,381,0.00043750
+Hyper Quick,333,382,0.00068630
+Hyper Quick,333,383,0.00060940
+Hyper Quick,333,384,0.00063080
+Hyper Quick,333,385,0.00059130
+Hyper Quick,333,386,0.00059010
+Hyper Quick,333,387,0.00061430
+Hyper Quick,333,388,0.00056500
+Hyper Quick,333,389,0.00059590
+Hyper Quick,333,390,0.00053270
+Hyper Quick,333,391,0.00060220
+Hyper Quick,333,392,0.00057600
+Hyper Quick,333,393,0.00061360
+Hyper Quick,333,394,0.00063740
+Hyper Quick,333,395,0.00060770
+Hyper Quick,333,396,0.00056450
+Hyper Quick,333,397,0.00063850
+Hyper Quick,333,398,0.00061310
+Hyper Quick,333,399,0.00040610
+Hyper Quick,333,400,0.00053580
+Hyper Quick,333,401,0.00059550
+Hyper Quick,333,402,0.00057950
+Hyper Quick,333,403,0.00059370
+Hyper Quick,333,404,0.00037430
+Hyper Quick,333,405,0.00062040
+Hyper Quick,333,406,0.00059820
+Hyper Quick,333,407,0.00059020
+Hyper Quick,333,408,0.00057990
+Hyper Quick,333,409,0.00054030
+Hyper Quick,333,410,0.00042680
+Hyper Quick,333,411,0.00062770
+Hyper Quick,333,412,0.00056160
+Hyper Quick,333,413,0.00058070
+Hyper Quick,333,414,0.00040470
+Hyper Quick,333,415,0.00063380
+Hyper Quick,333,416,0.00053000
+Hyper Quick,333,417,0.00057140
+Hyper Quick,333,418,0.00062390
+Hyper Quick,333,419,0.00062490
+Hyper Quick,333,420,0.00061120
+Hyper Quick,333,421,0.00061160
+Hyper Quick,333,422,0.00060310
+Hyper Quick,333,423,0.00059930
+Hyper Quick,333,424,0.00043150
+Hyper Quick,333,425,0.00058600
+Hyper Quick,333,426,0.00038140
+Hyper Quick,333,427,0.00060870
+Hyper Quick,333,428,0.00065810
+Hyper Quick,333,429,0.00064300
+Hyper Quick,333,430,0.00038230
+Hyper Quick,333,431,0.00056680
+Hyper Quick,333,432,0.00062590
+Hyper Quick,333,433,0.00065160
+Hyper Quick,333,434,0.00037740
+Hyper Quick,333,435,0.00062950
+Hyper Quick,333,436,0.00055780
+Hyper Quick,333,437,0.00064120
+Hyper Quick,333,438,0.00059550
+Hyper Quick,333,439,0.00072510
+Hyper Quick,333,440,0.00038540
+Hyper Quick,333,441,0.00061430
+Hyper Quick,333,442,0.00067690
+Hyper Quick,333,443,0.00064430
+Hyper Quick,333,444,0.00072760
+Hyper Quick,333,445,0.00054680
+Hyper Quick,333,446,0.00058330
+Hyper Quick,333,447,0.00057870
+Hyper Quick,333,448,0.00059470
+Hyper Quick,333,449,0.00067040
+Hyper Quick,333,450,0.00072220
+Hyper Quick,333,451,0.00070490
+Hyper Quick,333,452,0.00061950
+Hyper Quick,333,453,0.00070040
+Hyper Quick,333,454,0.00060620
+Hyper Quick,333,455,0.00062370
+Hyper Quick,333,456,0.00060520
+Hyper Quick,333,457,0.00066690
+Hyper Quick,333,458,0.00053510
+Hyper Quick,333,459,0.00060610
+Hyper Quick,333,460,0.00038640
+Hyper Quick,333,461,0.00062040
+Hyper Quick,333,462,0.00058120
+Hyper Quick,333,463,0.00060080
+Hyper Quick,333,464,0.00061890
+Hyper Quick,333,465,0.00062470
+Hyper Quick,333,466,0.00040670
+Hyper Quick,333,467,0.00058940
+Hyper Quick,333,468,0.00059270
+Hyper Quick,333,469,0.00057140
+Hyper Quick,333,470,0.00051400
+Hyper Quick,333,471,0.00056340
+Hyper Quick,333,472,0.00058130
+Hyper Quick,333,473,0.00060240
+Hyper Quick,333,474,0.00060140
+Hyper Quick,333,475,0.00063140
+Hyper Quick,333,476,0.00061550
+Hyper Quick,333,477,0.00067880
+Hyper Quick,333,478,0.00057900
+Hyper Quick,333,479,0.00058640
+Hyper Quick,333,480,0.00037960
+Hyper Quick,333,481,0.00044580
+Hyper Quick,333,482,0.00063690
+Hyper Quick,333,483,0.00067240
+Hyper Quick,333,484,0.00064190
+Hyper Quick,333,485,0.00061880
+Hyper Quick,333,486,0.00055140
+Hyper Quick,333,487,0.00060030
+Hyper Quick,333,488,0.00062840
+Hyper Quick,333,489,0.00044570
+Hyper Quick,333,490,0.00058500
+Hyper Quick,333,491,0.00064490
+Hyper Quick,333,492,0.00042500
+Hyper Quick,333,493,0.00046880
+Hyper Quick,333,494,0.00038430
+Hyper Quick,333,495,0.00058830
+Hyper Quick,333,496,0.00067310
+Hyper Quick,333,497,0.00045750
+Hyper Quick,333,498,0.00061890
+Hyper Quick,333,499,0.00060540
+Hyper Quick,333,500,0.00059310
+I Can't Believe It Can Sort,333,1,0.00057860
+I Can't Believe It Can Sort,333,2,0.00081840
+I Can't Believe It Can Sort,333,3,0.00070870
+I Can't Believe It Can Sort,333,4,0.00079850
+I Can't Believe It Can Sort,333,5,0.00058590
+I Can't Believe It Can Sort,333,6,0.00054580
+I Can't Believe It Can Sort,333,7,0.00081060
+I Can't Believe It Can Sort,333,8,0.00080450
+I Can't Believe It Can Sort,333,9,0.00049250
+I Can't Believe It Can Sort,333,10,0.00077400
+I Can't Believe It Can Sort,333,11,0.00078260
+I Can't Believe It Can Sort,333,12,0.00077320
+I Can't Believe It Can Sort,333,13,0.00048850
+I Can't Believe It Can Sort,333,14,0.00077480
+I Can't Believe It Can Sort,333,15,0.00079460
+I Can't Believe It Can Sort,333,16,0.00071150
+I Can't Believe It Can Sort,333,17,0.00078110
+I Can't Believe It Can Sort,333,18,0.00074790
+I Can't Believe It Can Sort,333,19,0.00082760
+I Can't Believe It Can Sort,333,20,0.00082420
+I Can't Believe It Can Sort,333,21,0.00079650
+I Can't Believe It Can Sort,333,22,0.00082900
+I Can't Believe It Can Sort,333,23,0.00080540
+I Can't Believe It Can Sort,333,24,0.00083690
+I Can't Believe It Can Sort,333,25,0.00086230
+I Can't Believe It Can Sort,333,26,0.00076220
+I Can't Believe It Can Sort,333,27,0.00064000
+I Can't Believe It Can Sort,333,28,0.00088380
+I Can't Believe It Can Sort,333,29,0.00085430
+I Can't Believe It Can Sort,333,30,0.00081900
+I Can't Believe It Can Sort,333,31,0.00058830
+I Can't Believe It Can Sort,333,32,0.00076620
+I Can't Believe It Can Sort,333,33,0.00081140
+I Can't Believe It Can Sort,333,34,0.00077100
+I Can't Believe It Can Sort,333,35,0.00081820
+I Can't Believe It Can Sort,333,36,0.00073520
+I Can't Believe It Can Sort,333,37,0.00078760
+I Can't Believe It Can Sort,333,38,0.00074910
+I Can't Believe It Can Sort,333,39,0.00075960
+I Can't Believe It Can Sort,333,40,0.00072830
+I Can't Believe It Can Sort,333,41,0.00074060
+I Can't Believe It Can Sort,333,42,0.00064510
+I Can't Believe It Can Sort,333,43,0.00081290
+I Can't Believe It Can Sort,333,44,0.00081060
+I Can't Believe It Can Sort,333,45,0.00079980
+I Can't Believe It Can Sort,333,46,0.00055980
+I Can't Believe It Can Sort,333,47,0.00075550
+I Can't Believe It Can Sort,333,48,0.00079880
+I Can't Believe It Can Sort,333,49,0.00073640
+I Can't Believe It Can Sort,333,50,0.00074950
+I Can't Believe It Can Sort,333,51,0.00076470
+I Can't Believe It Can Sort,333,52,0.00076740
+I Can't Believe It Can Sort,333,53,0.00075460
+I Can't Believe It Can Sort,333,54,0.00082830
+I Can't Believe It Can Sort,333,55,0.00076950
+I Can't Believe It Can Sort,333,56,0.00075150
+I Can't Believe It Can Sort,333,57,0.00078630
+I Can't Believe It Can Sort,333,58,0.00075910
+I Can't Believe It Can Sort,333,59,0.00075610
+I Can't Believe It Can Sort,333,60,0.00076600
+I Can't Believe It Can Sort,333,61,0.00076840
+I Can't Believe It Can Sort,333,62,0.00075360
+I Can't Believe It Can Sort,333,63,0.00083710
+I Can't Believe It Can Sort,333,64,0.00074840
+I Can't Believe It Can Sort,333,65,0.00075130
+I Can't Believe It Can Sort,333,66,0.00059840
+I Can't Believe It Can Sort,333,67,0.00052840
+I Can't Believe It Can Sort,333,68,0.00075360
+I Can't Believe It Can Sort,333,69,0.00062260
+I Can't Believe It Can Sort,333,70,0.00080140
+I Can't Believe It Can Sort,333,71,0.00050980
+I Can't Believe It Can Sort,333,72,0.00081610
+I Can't Believe It Can Sort,333,73,0.00073810
+I Can't Believe It Can Sort,333,74,0.00049350
+I Can't Believe It Can Sort,333,75,0.00076330
+I Can't Believe It Can Sort,333,76,0.00075990
+I Can't Believe It Can Sort,333,77,0.00081560
+I Can't Believe It Can Sort,333,78,0.00079150
+I Can't Believe It Can Sort,333,79,0.00080980
+I Can't Believe It Can Sort,333,80,0.00079760
+I Can't Believe It Can Sort,333,81,0.00077330
+I Can't Believe It Can Sort,333,82,0.00079600
+I Can't Believe It Can Sort,333,83,0.00078110
+I Can't Believe It Can Sort,333,84,0.00075740
+I Can't Believe It Can Sort,333,85,0.00052250
+I Can't Believe It Can Sort,333,86,0.00087170
+I Can't Believe It Can Sort,333,87,0.00079840
+I Can't Believe It Can Sort,333,88,0.00074110
+I Can't Believe It Can Sort,333,89,0.00072820
+I Can't Believe It Can Sort,333,90,0.00078730
+I Can't Believe It Can Sort,333,91,0.00061420
+I Can't Believe It Can Sort,333,92,0.00074890
+I Can't Believe It Can Sort,333,93,0.00073200
+I Can't Believe It Can Sort,333,94,0.00075090
+I Can't Believe It Can Sort,333,95,0.00075030
+I Can't Believe It Can Sort,333,96,0.00054410
+I Can't Believe It Can Sort,333,97,0.00075430
+I Can't Believe It Can Sort,333,98,0.00052560
+I Can't Believe It Can Sort,333,99,0.00067900
+I Can't Believe It Can Sort,333,100,0.00048640
+I Can't Believe It Can Sort,333,101,0.00080480
+I Can't Believe It Can Sort,333,102,0.00074750
+I Can't Believe It Can Sort,333,103,0.00076060
+I Can't Believe It Can Sort,333,104,0.00081170
+I Can't Believe It Can Sort,333,105,0.00075730
+I Can't Believe It Can Sort,333,106,0.00078230
+I Can't Believe It Can Sort,333,107,0.00074790
+I Can't Believe It Can Sort,333,108,0.00048500
+I Can't Believe It Can Sort,333,109,0.00079620
+I Can't Believe It Can Sort,333,110,0.00075380
+I Can't Believe It Can Sort,333,111,0.00080120
+I Can't Believe It Can Sort,333,112,0.00079990
+I Can't Believe It Can Sort,333,113,0.00076270
+I Can't Believe It Can Sort,333,114,0.00050080
+I Can't Believe It Can Sort,333,115,0.00076040
+I Can't Believe It Can Sort,333,116,0.00070670
+I Can't Believe It Can Sort,333,117,0.00047500
+I Can't Believe It Can Sort,333,118,0.00057240
+I Can't Believe It Can Sort,333,119,0.00076040
+I Can't Believe It Can Sort,333,120,0.00075900
+I Can't Believe It Can Sort,333,121,0.00074940
+I Can't Believe It Can Sort,333,122,0.00073530
+I Can't Believe It Can Sort,333,123,0.00077240
+I Can't Believe It Can Sort,333,124,0.00057950
+I Can't Believe It Can Sort,333,125,0.00069510
+I Can't Believe It Can Sort,333,126,0.00080660
+I Can't Believe It Can Sort,333,127,0.00070620
+I Can't Believe It Can Sort,333,128,0.00051870
+I Can't Believe It Can Sort,333,129,0.00077040
+I Can't Believe It Can Sort,333,130,0.00078100
+I Can't Believe It Can Sort,333,131,0.00079030
+I Can't Believe It Can Sort,333,132,0.00076750
+I Can't Believe It Can Sort,333,133,0.00082340
+I Can't Believe It Can Sort,333,134,0.00077590
+I Can't Believe It Can Sort,333,135,0.00067460
+I Can't Believe It Can Sort,333,136,0.00070740
+I Can't Believe It Can Sort,333,137,0.00057350
+I Can't Believe It Can Sort,333,138,0.00077900
+I Can't Believe It Can Sort,333,139,0.00056460
+I Can't Believe It Can Sort,333,140,0.00055300
+I Can't Believe It Can Sort,333,141,0.00080010
+I Can't Believe It Can Sort,333,142,0.00085430
+I Can't Believe It Can Sort,333,143,0.00073570
+I Can't Believe It Can Sort,333,144,0.00076050
+I Can't Believe It Can Sort,333,145,0.00082700
+I Can't Believe It Can Sort,333,146,0.00074970
+I Can't Believe It Can Sort,333,147,0.00079200
+I Can't Believe It Can Sort,333,148,0.00079690
+I Can't Believe It Can Sort,333,149,0.00076480
+I Can't Believe It Can Sort,333,150,0.00081600
+I Can't Believe It Can Sort,333,151,0.00072820
+I Can't Believe It Can Sort,333,152,0.00078930
+I Can't Believe It Can Sort,333,153,0.00084610
+I Can't Believe It Can Sort,333,154,0.00083210
+I Can't Believe It Can Sort,333,155,0.00062690
+I Can't Believe It Can Sort,333,156,0.00073300
+I Can't Believe It Can Sort,333,157,0.00082380
+I Can't Believe It Can Sort,333,158,0.00076190
+I Can't Believe It Can Sort,333,159,0.00080380
+I Can't Believe It Can Sort,333,160,0.00075290
+I Can't Believe It Can Sort,333,161,0.00067010
+I Can't Believe It Can Sort,333,162,0.00075830
+I Can't Believe It Can Sort,333,163,0.00079920
+I Can't Believe It Can Sort,333,164,0.00074750
+I Can't Believe It Can Sort,333,165,0.00049650
+I Can't Believe It Can Sort,333,166,0.00061400
+I Can't Believe It Can Sort,333,167,0.00075270
+I Can't Believe It Can Sort,333,168,0.00059160
+I Can't Believe It Can Sort,333,169,0.00076750
+I Can't Believe It Can Sort,333,170,0.00078620
+I Can't Believe It Can Sort,333,171,0.00065410
+I Can't Believe It Can Sort,333,172,0.00080100
+I Can't Believe It Can Sort,333,173,0.00075210
+I Can't Believe It Can Sort,333,174,0.00046170
+I Can't Believe It Can Sort,333,175,0.00067110
+I Can't Believe It Can Sort,333,176,0.00075130
+I Can't Believe It Can Sort,333,177,0.00054320
+I Can't Believe It Can Sort,333,178,0.00075750
+I Can't Believe It Can Sort,333,179,0.00080450
+I Can't Believe It Can Sort,333,180,0.00080970
+I Can't Believe It Can Sort,333,181,0.00074250
+I Can't Believe It Can Sort,333,182,0.00075960
+I Can't Believe It Can Sort,333,183,0.00075300
+I Can't Believe It Can Sort,333,184,0.00059200
+I Can't Believe It Can Sort,333,185,0.00078600
+I Can't Believe It Can Sort,333,186,0.00079980
+I Can't Believe It Can Sort,333,187,0.00072440
+I Can't Believe It Can Sort,333,188,0.00051780
+I Can't Believe It Can Sort,333,189,0.00077430
+I Can't Believe It Can Sort,333,190,0.00055490
+I Can't Believe It Can Sort,333,191,0.00054080
+I Can't Believe It Can Sort,333,192,0.00049030
+I Can't Believe It Can Sort,333,193,0.00076210
+I Can't Believe It Can Sort,333,194,0.00063680
+I Can't Believe It Can Sort,333,195,0.00075540
+I Can't Believe It Can Sort,333,196,0.00073390
+I Can't Believe It Can Sort,333,197,0.00048530
+I Can't Believe It Can Sort,333,198,0.00071250
+I Can't Believe It Can Sort,333,199,0.00075580
+I Can't Believe It Can Sort,333,200,0.00061160
+I Can't Believe It Can Sort,333,201,0.00076090
+I Can't Believe It Can Sort,333,202,0.00050200
+I Can't Believe It Can Sort,333,203,0.00048380
+I Can't Believe It Can Sort,333,204,0.00076230
+I Can't Believe It Can Sort,333,205,0.00054070
+I Can't Believe It Can Sort,333,206,0.00050010
+I Can't Believe It Can Sort,333,207,0.00049040
+I Can't Believe It Can Sort,333,208,0.00057590
+I Can't Believe It Can Sort,333,209,0.00079520
+I Can't Believe It Can Sort,333,210,0.00082230
+I Can't Believe It Can Sort,333,211,0.00082290
+I Can't Believe It Can Sort,333,212,0.00076970
+I Can't Believe It Can Sort,333,213,0.00078420
+I Can't Believe It Can Sort,333,214,0.00080320
+I Can't Believe It Can Sort,333,215,0.00083090
+I Can't Believe It Can Sort,333,216,0.00078450
+I Can't Believe It Can Sort,333,217,0.00067690
+I Can't Believe It Can Sort,333,218,0.00083370
+I Can't Believe It Can Sort,333,219,0.00086210
+I Can't Believe It Can Sort,333,220,0.00077890
+I Can't Believe It Can Sort,333,221,0.00075730
+I Can't Believe It Can Sort,333,222,0.00071410
+I Can't Believe It Can Sort,333,223,0.00067190
+I Can't Believe It Can Sort,333,224,0.00068750
+I Can't Believe It Can Sort,333,225,0.00078850
+I Can't Believe It Can Sort,333,226,0.00079500
+I Can't Believe It Can Sort,333,227,0.00077810
+I Can't Believe It Can Sort,333,228,0.00080510
+I Can't Believe It Can Sort,333,229,0.00077000
+I Can't Believe It Can Sort,333,230,0.00072400
+I Can't Believe It Can Sort,333,231,0.00075880
+I Can't Believe It Can Sort,333,232,0.00081360
+I Can't Believe It Can Sort,333,233,0.00053760
+I Can't Believe It Can Sort,333,234,0.00078650
+I Can't Believe It Can Sort,333,235,0.00081190
+I Can't Believe It Can Sort,333,236,0.00053900
+I Can't Believe It Can Sort,333,237,0.00082300
+I Can't Believe It Can Sort,333,238,0.00075280
+I Can't Believe It Can Sort,333,239,0.00060470
+I Can't Believe It Can Sort,333,240,0.00082380
+I Can't Believe It Can Sort,333,241,0.00075680
+I Can't Believe It Can Sort,333,242,0.00073660
+I Can't Believe It Can Sort,333,243,0.00077020
+I Can't Believe It Can Sort,333,244,0.00082640
+I Can't Believe It Can Sort,333,245,0.00075370
+I Can't Believe It Can Sort,333,246,0.00075300
+I Can't Believe It Can Sort,333,247,0.00082610
+I Can't Believe It Can Sort,333,248,0.00076570
+I Can't Believe It Can Sort,333,249,0.00059190
+I Can't Believe It Can Sort,333,250,0.00075760
+I Can't Believe It Can Sort,333,251,0.00080980
+I Can't Believe It Can Sort,333,252,0.00079700
+I Can't Believe It Can Sort,333,253,0.00079430
+I Can't Believe It Can Sort,333,254,0.00078650
+I Can't Believe It Can Sort,333,255,0.00064800
+I Can't Believe It Can Sort,333,256,0.00065890
+I Can't Believe It Can Sort,333,257,0.00084390
+I Can't Believe It Can Sort,333,258,0.00080570
+I Can't Believe It Can Sort,333,259,0.00081050
+I Can't Believe It Can Sort,333,260,0.00076030
+I Can't Believe It Can Sort,333,261,0.00065880
+I Can't Believe It Can Sort,333,262,0.00084250
+I Can't Believe It Can Sort,333,263,0.00077880
+I Can't Believe It Can Sort,333,264,0.00073180
+I Can't Believe It Can Sort,333,265,0.00066660
+I Can't Believe It Can Sort,333,266,0.00082280
+I Can't Believe It Can Sort,333,267,0.00080290
+I Can't Believe It Can Sort,333,268,0.00080900
+I Can't Believe It Can Sort,333,269,0.00080020
+I Can't Believe It Can Sort,333,270,0.00075460
+I Can't Believe It Can Sort,333,271,0.00063070
+I Can't Believe It Can Sort,333,272,0.00077790
+I Can't Believe It Can Sort,333,273,0.00083390
+I Can't Believe It Can Sort,333,274,0.00073360
+I Can't Believe It Can Sort,333,275,0.00080030
+I Can't Believe It Can Sort,333,276,0.00078980
+I Can't Believe It Can Sort,333,277,0.00078020
+I Can't Believe It Can Sort,333,278,0.00071460
+I Can't Believe It Can Sort,333,279,0.00078170
+I Can't Believe It Can Sort,333,280,0.00081230
+I Can't Believe It Can Sort,333,281,0.00084960
+I Can't Believe It Can Sort,333,282,0.00068480
+I Can't Believe It Can Sort,333,283,0.00073560
+I Can't Believe It Can Sort,333,284,0.00081810
+I Can't Believe It Can Sort,333,285,0.00078600
+I Can't Believe It Can Sort,333,286,0.00075790
+I Can't Believe It Can Sort,333,287,0.00083950
+I Can't Believe It Can Sort,333,288,0.00079490
+I Can't Believe It Can Sort,333,289,0.00082880
+I Can't Believe It Can Sort,333,290,0.00080120
+I Can't Believe It Can Sort,333,291,0.00082380
+I Can't Believe It Can Sort,333,292,0.00082410
+I Can't Believe It Can Sort,333,293,0.00078020
+I Can't Believe It Can Sort,333,294,0.00080070
+I Can't Believe It Can Sort,333,295,0.00080310
+I Can't Believe It Can Sort,333,296,0.00082060
+I Can't Believe It Can Sort,333,297,0.00081330
+I Can't Believe It Can Sort,333,298,0.00081460
+I Can't Believe It Can Sort,333,299,0.00078320
+I Can't Believe It Can Sort,333,300,0.00067900
+I Can't Believe It Can Sort,333,301,0.00082240
+I Can't Believe It Can Sort,333,302,0.00075970
+I Can't Believe It Can Sort,333,303,0.00079250
+I Can't Believe It Can Sort,333,304,0.00079490
+I Can't Believe It Can Sort,333,305,0.00080890
+I Can't Believe It Can Sort,333,306,0.00081400
+I Can't Believe It Can Sort,333,307,0.00078400
+I Can't Believe It Can Sort,333,308,0.00082130
+I Can't Believe It Can Sort,333,309,0.00079440
+I Can't Believe It Can Sort,333,310,0.00083310
+I Can't Believe It Can Sort,333,311,0.00074210
+I Can't Believe It Can Sort,333,312,0.00082470
+I Can't Believe It Can Sort,333,313,0.00082770
+I Can't Believe It Can Sort,333,314,0.00079910
+I Can't Believe It Can Sort,333,315,0.00078630
+I Can't Believe It Can Sort,333,316,0.00081480
+I Can't Believe It Can Sort,333,317,0.00084660
+I Can't Believe It Can Sort,333,318,0.00079580
+I Can't Believe It Can Sort,333,319,0.00072060
+I Can't Believe It Can Sort,333,320,0.00069260
+I Can't Believe It Can Sort,333,321,0.00079810
+I Can't Believe It Can Sort,333,322,0.00078300
+I Can't Believe It Can Sort,333,323,0.00078750
+I Can't Believe It Can Sort,333,324,0.00084750
+I Can't Believe It Can Sort,333,325,0.00079270
+I Can't Believe It Can Sort,333,326,0.00078760
+I Can't Believe It Can Sort,333,327,0.00066840
+I Can't Believe It Can Sort,333,328,0.00079450
+I Can't Believe It Can Sort,333,329,0.00078140
+I Can't Believe It Can Sort,333,330,0.00078740
+I Can't Believe It Can Sort,333,331,0.00079640
+I Can't Believe It Can Sort,333,332,0.00079330
+I Can't Believe It Can Sort,333,333,0.00065800
+I Can't Believe It Can Sort,333,334,0.00086070
+I Can't Believe It Can Sort,333,335,0.00080300
+I Can't Believe It Can Sort,333,336,0.00081180
+I Can't Believe It Can Sort,333,337,0.00079130
+I Can't Believe It Can Sort,333,338,0.00080940
+I Can't Believe It Can Sort,333,339,0.00079750
+I Can't Believe It Can Sort,333,340,0.00070130
+I Can't Believe It Can Sort,333,341,0.00080990
+I Can't Believe It Can Sort,333,342,0.00080210
+I Can't Believe It Can Sort,333,343,0.00083570
+I Can't Believe It Can Sort,333,344,0.00082980
+I Can't Believe It Can Sort,333,345,0.00079060
+I Can't Believe It Can Sort,333,346,0.00079850
+I Can't Believe It Can Sort,333,347,0.00069770
+I Can't Believe It Can Sort,333,348,0.00081020
+I Can't Believe It Can Sort,333,349,0.00079690
+I Can't Believe It Can Sort,333,350,0.00079490
+I Can't Believe It Can Sort,333,351,0.00080120
+I Can't Believe It Can Sort,333,352,0.00080520
+I Can't Believe It Can Sort,333,353,0.00083830
+I Can't Believe It Can Sort,333,354,0.00085930
+I Can't Believe It Can Sort,333,355,0.00078170
+I Can't Believe It Can Sort,333,356,0.00085990
+I Can't Believe It Can Sort,333,357,0.00067970
+I Can't Believe It Can Sort,333,358,0.00080900
+I Can't Believe It Can Sort,333,359,0.00075090
+I Can't Believe It Can Sort,333,360,0.00080250
+I Can't Believe It Can Sort,333,361,0.00079620
+I Can't Believe It Can Sort,333,362,0.00077760
+I Can't Believe It Can Sort,333,363,0.00079800
+I Can't Believe It Can Sort,333,364,0.00063990
+I Can't Believe It Can Sort,333,365,0.00084190
+I Can't Believe It Can Sort,333,366,0.00079630
+I Can't Believe It Can Sort,333,367,0.00075050
+I Can't Believe It Can Sort,333,368,0.00080510
+I Can't Believe It Can Sort,333,369,0.00080750
+I Can't Believe It Can Sort,333,370,0.00080330
+I Can't Believe It Can Sort,333,371,0.00074980
+I Can't Believe It Can Sort,333,372,0.00082760
+I Can't Believe It Can Sort,333,373,0.00081240
+I Can't Believe It Can Sort,333,374,0.00066540
+I Can't Believe It Can Sort,333,375,0.00079930
+I Can't Believe It Can Sort,333,376,0.00078970
+I Can't Believe It Can Sort,333,377,0.00079820
+I Can't Believe It Can Sort,333,378,0.00074480
+I Can't Believe It Can Sort,333,379,0.00083770
+I Can't Believe It Can Sort,333,380,0.00079860
+I Can't Believe It Can Sort,333,381,0.00078570
+I Can't Believe It Can Sort,333,382,0.00065020
+I Can't Believe It Can Sort,333,383,0.00069360
+I Can't Believe It Can Sort,333,384,0.00079640
+I Can't Believe It Can Sort,333,385,0.00079910
+I Can't Believe It Can Sort,333,386,0.00079120
+I Can't Believe It Can Sort,333,387,0.00074620
+I Can't Believe It Can Sort,333,388,0.00085160
+I Can't Believe It Can Sort,333,389,0.00079170
+I Can't Believe It Can Sort,333,390,0.00080350
+I Can't Believe It Can Sort,333,391,0.00079750
+I Can't Believe It Can Sort,333,392,0.00074990
+I Can't Believe It Can Sort,333,393,0.00383090
+I Can't Believe It Can Sort,333,394,0.00078730
+I Can't Believe It Can Sort,333,395,0.00079510
+I Can't Believe It Can Sort,333,396,0.00078240
+I Can't Believe It Can Sort,333,397,0.00077750
+I Can't Believe It Can Sort,333,398,0.00077010
+I Can't Believe It Can Sort,333,399,0.00081600
+I Can't Believe It Can Sort,333,400,0.00079610
+I Can't Believe It Can Sort,333,401,0.00075690
+I Can't Believe It Can Sort,333,402,0.00078430
+I Can't Believe It Can Sort,333,403,0.00080110
+I Can't Believe It Can Sort,333,404,0.00083380
+I Can't Believe It Can Sort,333,405,0.00070940
+I Can't Believe It Can Sort,333,406,0.00076730
+I Can't Believe It Can Sort,333,407,0.00075060
+I Can't Believe It Can Sort,333,408,0.00082970
+I Can't Believe It Can Sort,333,409,0.00079300
+I Can't Believe It Can Sort,333,410,0.00078750
+I Can't Believe It Can Sort,333,411,0.00080230
+I Can't Believe It Can Sort,333,412,0.00066570
+I Can't Believe It Can Sort,333,413,0.00083580
+I Can't Believe It Can Sort,333,414,0.00077010
+I Can't Believe It Can Sort,333,415,0.00075710
+I Can't Believe It Can Sort,333,416,0.00079240
+I Can't Believe It Can Sort,333,417,0.00106750
+I Can't Believe It Can Sort,333,418,0.00077920
+I Can't Believe It Can Sort,333,419,0.00080050
+I Can't Believe It Can Sort,333,420,0.00064840
+I Can't Believe It Can Sort,333,421,0.00080410
+I Can't Believe It Can Sort,333,422,0.00076020
+I Can't Believe It Can Sort,333,423,0.00074880
+I Can't Believe It Can Sort,333,424,0.00075400
+I Can't Believe It Can Sort,333,425,0.00079190
+I Can't Believe It Can Sort,333,426,0.00078370
+I Can't Believe It Can Sort,333,427,0.00068990
+I Can't Believe It Can Sort,333,428,0.00084750
+I Can't Believe It Can Sort,333,429,0.00080030
+I Can't Believe It Can Sort,333,430,0.00080320
+I Can't Believe It Can Sort,333,431,0.00076740
+I Can't Believe It Can Sort,333,432,0.00069110
+I Can't Believe It Can Sort,333,433,0.00081410
+I Can't Believe It Can Sort,333,434,0.00078490
+I Can't Believe It Can Sort,333,435,0.00077980
+I Can't Believe It Can Sort,333,436,0.00080450
+I Can't Believe It Can Sort,333,437,0.00082260
+I Can't Believe It Can Sort,333,438,0.00084770
+I Can't Believe It Can Sort,333,439,0.00077720
+I Can't Believe It Can Sort,333,440,0.00076810
+I Can't Believe It Can Sort,333,441,0.00080320
+I Can't Believe It Can Sort,333,442,0.00078390
+I Can't Believe It Can Sort,333,443,0.00078020
+I Can't Believe It Can Sort,333,444,0.00080740
+I Can't Believe It Can Sort,333,445,0.00081010
+I Can't Believe It Can Sort,333,446,0.00084580
+I Can't Believe It Can Sort,333,447,0.00084330
+I Can't Believe It Can Sort,333,448,0.00080700
+I Can't Believe It Can Sort,333,449,0.00076600
+I Can't Believe It Can Sort,333,450,0.00078700
+I Can't Believe It Can Sort,333,451,0.00077650
+I Can't Believe It Can Sort,333,452,0.00080140
+I Can't Believe It Can Sort,333,453,0.00080050
+I Can't Believe It Can Sort,333,454,0.00079350
+I Can't Believe It Can Sort,333,455,0.00081420
+I Can't Believe It Can Sort,333,456,0.00080110
+I Can't Believe It Can Sort,333,457,0.00079750
+I Can't Believe It Can Sort,333,458,0.00076480
+I Can't Believe It Can Sort,333,459,0.00079100
+I Can't Believe It Can Sort,333,460,0.00079070
+I Can't Believe It Can Sort,333,461,0.00080530
+I Can't Believe It Can Sort,333,462,0.00080640
+I Can't Believe It Can Sort,333,463,0.00079650
+I Can't Believe It Can Sort,333,464,0.00084010
+I Can't Believe It Can Sort,333,465,0.00086680
+I Can't Believe It Can Sort,333,466,0.00082180
+I Can't Believe It Can Sort,333,467,0.00077750
+I Can't Believe It Can Sort,333,468,0.00079360
+I Can't Believe It Can Sort,333,469,0.00078900
+I Can't Believe It Can Sort,333,470,0.00082210
+I Can't Believe It Can Sort,333,471,0.00080200
+I Can't Believe It Can Sort,333,472,0.00081040
+I Can't Believe It Can Sort,333,473,0.00080040
+I Can't Believe It Can Sort,333,474,0.00079660
+I Can't Believe It Can Sort,333,475,0.00077060
+I Can't Believe It Can Sort,333,476,0.00076470
+I Can't Believe It Can Sort,333,477,0.00081130
+I Can't Believe It Can Sort,333,478,0.00080020
+I Can't Believe It Can Sort,333,479,0.00079950
+I Can't Believe It Can Sort,333,480,0.00066070
+I Can't Believe It Can Sort,333,481,0.00078990
+I Can't Believe It Can Sort,333,482,0.00081430
+I Can't Believe It Can Sort,333,483,0.00081380
+I Can't Believe It Can Sort,333,484,0.00084610
+I Can't Believe It Can Sort,333,485,0.00076610
+I Can't Believe It Can Sort,333,486,0.00079160
+I Can't Believe It Can Sort,333,487,0.00079060
+I Can't Believe It Can Sort,333,488,0.00064030
+I Can't Believe It Can Sort,333,489,0.00079470
+I Can't Believe It Can Sort,333,490,0.00078990
+I Can't Believe It Can Sort,333,491,0.00081960
+I Can't Believe It Can Sort,333,492,0.00081610
+I Can't Believe It Can Sort,333,493,0.00078230
+I Can't Believe It Can Sort,333,494,0.00079780
+I Can't Believe It Can Sort,333,495,0.00080780
+I Can't Believe It Can Sort,333,496,0.00080030
+I Can't Believe It Can Sort,333,497,0.00081250
+I Can't Believe It Can Sort,333,498,0.00080090
+I Can't Believe It Can Sort,333,499,0.00078740
+I Can't Believe It Can Sort,333,500,0.00077200
+Insertion Sort,333,1,0.00316400
+Insertion Sort,333,2,0.00323390
+Insertion Sort,333,3,0.00321000
+Insertion Sort,333,4,0.00301770
+Insertion Sort,333,5,0.00316250
+Insertion Sort,333,6,0.00299770
+Insertion Sort,333,7,0.00297380
+Insertion Sort,333,8,0.00319860
+Insertion Sort,333,9,0.00327710
+Insertion Sort,333,10,0.00323270
+Insertion Sort,333,11,0.00328580
+Insertion Sort,333,12,0.00322280
+Insertion Sort,333,13,0.00300260
+Insertion Sort,333,14,0.00306080
+Insertion Sort,333,15,0.00321640
+Insertion Sort,333,16,0.00325650
+Insertion Sort,333,17,0.00318670
+Insertion Sort,333,18,0.00306050
+Insertion Sort,333,19,0.00313010
+Insertion Sort,333,20,0.00302670
+Insertion Sort,333,21,0.00314310
+Insertion Sort,333,22,0.00292260
+Insertion Sort,333,23,0.00320980
+Insertion Sort,333,24,0.00311950
+Insertion Sort,333,25,0.00300470
+Insertion Sort,333,26,0.00310090
+Insertion Sort,333,27,0.00368460
+Insertion Sort,333,28,0.00301130
+Insertion Sort,333,29,0.00313370
+Insertion Sort,333,30,0.00291200
+Insertion Sort,333,31,0.00316510
+Insertion Sort,333,32,0.00298680
+Insertion Sort,333,33,0.00303970
+Insertion Sort,333,34,0.00314360
+Insertion Sort,333,35,0.00347980
+Insertion Sort,333,36,0.00310460
+Insertion Sort,333,37,0.00293290
+Insertion Sort,333,38,0.00318250
+Insertion Sort,333,39,0.00311580
+Insertion Sort,333,40,0.00320730
+Insertion Sort,333,41,0.00304310
+Insertion Sort,333,42,0.00307960
+Insertion Sort,333,43,0.00294300
+Insertion Sort,333,44,0.00305590
+Insertion Sort,333,45,0.00327700
+Insertion Sort,333,46,0.00313500
+Insertion Sort,333,47,0.00276400
+Insertion Sort,333,48,0.00331220
+Insertion Sort,333,49,0.00333490
+Insertion Sort,333,50,0.00315610
+Insertion Sort,333,51,0.00331610
+Insertion Sort,333,52,0.00382450
+Insertion Sort,333,53,0.00325580
+Insertion Sort,333,54,0.00289630
+Insertion Sort,333,55,0.00321210
+Insertion Sort,333,56,0.00314560
+Insertion Sort,333,57,0.00335060
+Insertion Sort,333,58,0.00313050
+Insertion Sort,333,59,0.00313200
+Insertion Sort,333,60,0.00314100
+Insertion Sort,333,61,0.00297520
+Insertion Sort,333,62,0.00408670
+Insertion Sort,333,63,0.00310220
+Insertion Sort,333,64,0.00323600
+Insertion Sort,333,65,0.00303040
+Insertion Sort,333,66,0.00347590
+Insertion Sort,333,67,0.00297950
+Insertion Sort,333,68,0.00412570
+Insertion Sort,333,69,0.00307050
+Insertion Sort,333,70,0.00382250
+Insertion Sort,333,71,0.00315340
+Insertion Sort,333,72,0.00345530
+Insertion Sort,333,73,0.00340660
+Insertion Sort,333,74,0.00582620
+Insertion Sort,333,75,0.00293340
+Insertion Sort,333,76,0.00309500
+Insertion Sort,333,77,0.00321330
+Insertion Sort,333,78,0.00321990
+Insertion Sort,333,79,0.00327540
+Insertion Sort,333,80,0.00314240
+Insertion Sort,333,81,0.00308670
+Insertion Sort,333,82,0.00320990
+Insertion Sort,333,83,0.00320070
+Insertion Sort,333,84,0.00326460
+Insertion Sort,333,85,0.00307110
+Insertion Sort,333,86,0.00316070
+Insertion Sort,333,87,0.00407140
+Insertion Sort,333,88,0.00291740
+Insertion Sort,333,89,0.00483620
+Insertion Sort,333,90,0.00529320
+Insertion Sort,333,91,0.00314770
+Insertion Sort,333,92,0.00270540
+Insertion Sort,333,93,0.00324480
+Insertion Sort,333,94,0.00320010
+Insertion Sort,333,95,0.01233170
+Insertion Sort,333,96,0.00291390
+Insertion Sort,333,97,0.00464110
+Insertion Sort,333,98,0.00314480
+Insertion Sort,333,99,0.00307400
+Insertion Sort,333,100,0.00322220
+Insertion Sort,333,101,0.00341640
+Insertion Sort,333,102,0.00474300
+Insertion Sort,333,103,0.00291130
+Insertion Sort,333,104,0.00313520
+Insertion Sort,333,105,0.00328880
+Insertion Sort,333,106,0.00312470
+Insertion Sort,333,107,0.00302070
+Insertion Sort,333,108,0.00311840
+Insertion Sort,333,109,0.00311230
+Insertion Sort,333,110,0.00311210
+Insertion Sort,333,111,0.00379530
+Insertion Sort,333,112,0.00613660
+Insertion Sort,333,113,0.00301830
+Insertion Sort,333,114,0.00327150
+Insertion Sort,333,115,0.00303420
+Insertion Sort,333,116,0.00306640
+Insertion Sort,333,117,0.00315620
+Insertion Sort,333,118,0.00315950
+Insertion Sort,333,119,0.00483990
+Insertion Sort,333,120,0.00313150
+Insertion Sort,333,121,0.00326030
+Insertion Sort,333,122,0.00310750
+Insertion Sort,333,123,0.00480180
+Insertion Sort,333,124,0.00304310
+Insertion Sort,333,125,0.00312520
+Insertion Sort,333,126,0.00344880
+Insertion Sort,333,127,0.00368190
+Insertion Sort,333,128,0.00311230
+Insertion Sort,333,129,0.00960460
+Insertion Sort,333,130,0.00301250
+Insertion Sort,333,131,0.00321120
+Insertion Sort,333,132,0.00360160
+Insertion Sort,333,133,0.00438920
+Insertion Sort,333,134,0.00340620
+Insertion Sort,333,135,0.00364520
+Insertion Sort,333,136,0.00429490
+Insertion Sort,333,137,0.00294660
+Insertion Sort,333,138,0.00317190
+Insertion Sort,333,139,0.00321970
+Insertion Sort,333,140,0.00384610
+Insertion Sort,333,141,0.00355760
+Insertion Sort,333,142,0.00423330
+Insertion Sort,333,143,0.00314280
+Insertion Sort,333,144,0.00292820
+Insertion Sort,333,145,0.00317370
+Insertion Sort,333,146,0.00315450
+Insertion Sort,333,147,0.00437280
+Insertion Sort,333,148,0.00316830
+Insertion Sort,333,149,0.00317570
+Insertion Sort,333,150,0.00325050
+Insertion Sort,333,151,0.00299890
+Insertion Sort,333,152,0.00389560
+Insertion Sort,333,153,0.00392470
+Insertion Sort,333,154,0.00293610
+Insertion Sort,333,155,0.00315260
+Insertion Sort,333,156,0.00498860
+Insertion Sort,333,157,0.00334890
+Insertion Sort,333,158,0.00323380
+Insertion Sort,333,159,0.00305880
+Insertion Sort,333,160,0.00322860
+Insertion Sort,333,161,0.00292800
+Insertion Sort,333,162,0.00355400
+Insertion Sort,333,163,0.00427320
+Insertion Sort,333,164,0.00406270
+Insertion Sort,333,165,0.00345120
+Insertion Sort,333,166,0.00330060
+Insertion Sort,333,167,0.00309290
+Insertion Sort,333,168,0.00281240
+Insertion Sort,333,169,0.00290800
+Insertion Sort,333,170,0.00401320
+Insertion Sort,333,171,0.00313230
+Insertion Sort,333,172,0.00408730
+Insertion Sort,333,173,0.00325840
+Insertion Sort,333,174,0.00304560
+Insertion Sort,333,175,0.00349690
+Insertion Sort,333,176,0.00313810
+Insertion Sort,333,177,0.00309480
+Insertion Sort,333,178,0.00353060
+Insertion Sort,333,179,0.00313940
+Insertion Sort,333,180,0.00421670
+Insertion Sort,333,181,0.00341720
+Insertion Sort,333,182,0.00302370
+Insertion Sort,333,183,0.00314570
+Insertion Sort,333,184,0.00296630
+Insertion Sort,333,185,0.00312000
+Insertion Sort,333,186,0.00427230
+Insertion Sort,333,187,0.00328020
+Insertion Sort,333,188,0.00288780
+Insertion Sort,333,189,0.00310850
+Insertion Sort,333,190,0.00332540
+Insertion Sort,333,191,0.00299880
+Insertion Sort,333,192,0.00402510
+Insertion Sort,333,193,0.00391650
+Insertion Sort,333,194,0.00372810
+Insertion Sort,333,195,0.00331960
+Insertion Sort,333,196,0.00420770
+Insertion Sort,333,197,0.00296780
+Insertion Sort,333,198,0.00298050
+Insertion Sort,333,199,0.00786600
+Insertion Sort,333,200,0.00299490
+Insertion Sort,333,201,0.00376500
+Insertion Sort,333,202,0.00309600
+Insertion Sort,333,203,0.00503550
+Insertion Sort,333,204,0.00501680
+Insertion Sort,333,205,0.00287700
+Insertion Sort,333,206,0.00341690
+Insertion Sort,333,207,0.00286760
+Insertion Sort,333,208,0.00325760
+Insertion Sort,333,209,0.00296780
+Insertion Sort,333,210,0.00310170
+Insertion Sort,333,211,0.00416760
+Insertion Sort,333,212,0.00294850
+Insertion Sort,333,213,0.00426900
+Insertion Sort,333,214,0.00300440
+Insertion Sort,333,215,0.00298410
+Insertion Sort,333,216,0.00357810
+Insertion Sort,333,217,0.00302960
+Insertion Sort,333,218,0.00297380
+Insertion Sort,333,219,0.00320140
+Insertion Sort,333,220,0.00478460
+Insertion Sort,333,221,0.00279670
+Insertion Sort,333,222,0.00391340
+Insertion Sort,333,223,0.00320070
+Insertion Sort,333,224,0.00309700
+Insertion Sort,333,225,0.00307120
+Insertion Sort,333,226,0.00306010
+Insertion Sort,333,227,0.00339410
+Insertion Sort,333,228,0.00335780
+Insertion Sort,333,229,0.00321890
+Insertion Sort,333,230,0.00279280
+Insertion Sort,333,231,0.00325850
+Insertion Sort,333,232,0.00317930
+Insertion Sort,333,233,0.00325510
+Insertion Sort,333,234,0.00370050
+Insertion Sort,333,235,0.00350800
+Insertion Sort,333,236,0.00307850
+Insertion Sort,333,237,0.00350350
+Insertion Sort,333,238,0.00316990
+Insertion Sort,333,239,0.00299220
+Insertion Sort,333,240,0.00339220
+Insertion Sort,333,241,0.00380870
+Insertion Sort,333,242,0.00317180
+Insertion Sort,333,243,0.00295250
+Insertion Sort,333,244,0.00333760
+Insertion Sort,333,245,0.00367950
+Insertion Sort,333,246,0.00323510
+Insertion Sort,333,247,0.00483170
+Insertion Sort,333,248,0.00323830
+Insertion Sort,333,249,0.00295860
+Insertion Sort,333,250,0.00318100
+Insertion Sort,333,251,0.00344050
+Insertion Sort,333,252,0.00295460
+Insertion Sort,333,253,0.00299890
+Insertion Sort,333,254,0.00442880
+Insertion Sort,333,255,0.00332960
+Insertion Sort,333,256,0.00358040
+Insertion Sort,333,257,0.00311150
+Insertion Sort,333,258,0.00306620
+Insertion Sort,333,259,0.00362050
+Insertion Sort,333,260,0.00356620
+Insertion Sort,333,261,0.00460170
+Insertion Sort,333,262,0.00378310
+Insertion Sort,333,263,0.00352030
+Insertion Sort,333,264,0.00356830
+Insertion Sort,333,265,0.00319070
+Insertion Sort,333,266,0.00301870
+Insertion Sort,333,267,0.00299000
+Insertion Sort,333,268,0.00458400
+Insertion Sort,333,269,0.00319820
+Insertion Sort,333,270,0.00550420
+Insertion Sort,333,271,0.00368980
+Insertion Sort,333,272,0.00408120
+Insertion Sort,333,273,0.00290610
+Insertion Sort,333,274,0.00316190
+Insertion Sort,333,275,0.00345910
+Insertion Sort,333,276,0.00348080
+Insertion Sort,333,277,0.00290670
+Insertion Sort,333,278,0.00342260
+Insertion Sort,333,279,0.00316690
+Insertion Sort,333,280,0.00398890
+Insertion Sort,333,281,0.00303080
+Insertion Sort,333,282,0.00303020
+Insertion Sort,333,283,0.00305640
+Insertion Sort,333,284,0.00334520
+Insertion Sort,333,285,0.00306830
+Insertion Sort,333,286,0.00381580
+Insertion Sort,333,287,0.00338380
+Insertion Sort,333,288,0.00309630
+Insertion Sort,333,289,0.00311370
+Insertion Sort,333,290,0.00317720
+Insertion Sort,333,291,0.00308240
+Insertion Sort,333,292,0.00340610
+Insertion Sort,333,293,0.00384340
+Insertion Sort,333,294,0.00305520
+Insertion Sort,333,295,0.00473100
+Insertion Sort,333,296,0.00390210
+Insertion Sort,333,297,0.00336650
+Insertion Sort,333,298,0.00332570
+Insertion Sort,333,299,0.00314970
+Insertion Sort,333,300,0.00324560
+Insertion Sort,333,301,0.00329570
+Insertion Sort,333,302,0.00389690
+Insertion Sort,333,303,0.00305850
+Insertion Sort,333,304,0.00383360
+Insertion Sort,333,305,0.00345900
+Insertion Sort,333,306,0.00352290
+Insertion Sort,333,307,0.00326450
+Insertion Sort,333,308,0.00421030
+Insertion Sort,333,309,0.00313530
+Insertion Sort,333,310,0.00320640
+Insertion Sort,333,311,0.00387910
+Insertion Sort,333,312,0.00310480
+Insertion Sort,333,313,0.00317720
+Insertion Sort,333,314,0.00313370
+Insertion Sort,333,315,0.00382920
+Insertion Sort,333,316,0.00340870
+Insertion Sort,333,317,0.00309050
+Insertion Sort,333,318,0.00361720
+Insertion Sort,333,319,0.00401280
+Insertion Sort,333,320,0.00276390
+Insertion Sort,333,321,0.00319520
+Insertion Sort,333,322,0.00314730
+Insertion Sort,333,323,0.00339500
+Insertion Sort,333,324,0.00282650
+Insertion Sort,333,325,0.00340180
+Insertion Sort,333,326,0.00522890
+Insertion Sort,333,327,0.00294930
+Insertion Sort,333,328,0.00399110
+Insertion Sort,333,329,0.00392820
+Insertion Sort,333,330,0.00333450
+Insertion Sort,333,331,0.00326440
+Insertion Sort,333,332,0.00313100
+Insertion Sort,333,333,0.00360280
+Insertion Sort,333,334,0.00384240
+Insertion Sort,333,335,0.00404550
+Insertion Sort,333,336,0.00304130
+Insertion Sort,333,337,0.00324460
+Insertion Sort,333,338,0.00383140
+Insertion Sort,333,339,0.00308480
+Insertion Sort,333,340,0.00310590
+Insertion Sort,333,341,0.00439080
+Insertion Sort,333,342,0.00316460
+Insertion Sort,333,343,0.00321730
+Insertion Sort,333,344,0.00475430
+Insertion Sort,333,345,0.00385380
+Insertion Sort,333,346,0.00297800
+Insertion Sort,333,347,0.00292320
+Insertion Sort,333,348,0.00379080
+Insertion Sort,333,349,0.00293350
+Insertion Sort,333,350,0.00792620
+Insertion Sort,333,351,0.00318940
+Insertion Sort,333,352,0.00370910
+Insertion Sort,333,353,0.00295660
+Insertion Sort,333,354,0.00285250
+Insertion Sort,333,355,0.00375240
+Insertion Sort,333,356,0.00313730
+Insertion Sort,333,357,0.00398820
+Insertion Sort,333,358,0.00302450
+Insertion Sort,333,359,0.00309470
+Insertion Sort,333,360,0.00288370
+Insertion Sort,333,361,0.00304630
+Insertion Sort,333,362,0.00389910
+Insertion Sort,333,363,0.00479840
+Insertion Sort,333,364,0.00312840
+Insertion Sort,333,365,0.00300690
+Insertion Sort,333,366,0.00414180
+Insertion Sort,333,367,0.00299950
+Insertion Sort,333,368,0.00302700
+Insertion Sort,333,369,0.00413860
+Insertion Sort,333,370,0.00317660
+Insertion Sort,333,371,0.00329710
+Insertion Sort,333,372,0.00400450
+Insertion Sort,333,373,0.00356360
+Insertion Sort,333,374,0.00316600
+Insertion Sort,333,375,0.00322860
+Insertion Sort,333,376,0.00386360
+Insertion Sort,333,377,0.00401450
+Insertion Sort,333,378,0.00337900
+Insertion Sort,333,379,0.00301740
+Insertion Sort,333,380,0.00288450
+Insertion Sort,333,381,0.00407100
+Insertion Sort,333,382,0.00346730
+Insertion Sort,333,383,0.00402650
+Insertion Sort,333,384,0.00305720
+Insertion Sort,333,385,0.00293460
+Insertion Sort,333,386,0.00379450
+Insertion Sort,333,387,0.00328560
+Insertion Sort,333,388,0.00302370
+Insertion Sort,333,389,0.00313880
+Insertion Sort,333,390,0.00306730
+Insertion Sort,333,391,0.00432270
+Insertion Sort,333,392,0.00326140
+Insertion Sort,333,393,0.00313310
+Insertion Sort,333,394,0.00278720
+Insertion Sort,333,395,0.00335050
+Insertion Sort,333,396,0.00292770
+Insertion Sort,333,397,0.00375800
+Insertion Sort,333,398,0.00375040
+Insertion Sort,333,399,0.00302410
+Insertion Sort,333,400,0.00305380
+Insertion Sort,333,401,0.00339810
+Insertion Sort,333,402,0.00337730
+Insertion Sort,333,403,0.00333960
+Insertion Sort,333,404,0.00313890
+Insertion Sort,333,405,0.00449750
+Insertion Sort,333,406,0.00420700
+Insertion Sort,333,407,0.00323420
+Insertion Sort,333,408,0.00294490
+Insertion Sort,333,409,0.00305870
+Insertion Sort,333,410,0.00341850
+Insertion Sort,333,411,0.00286500
+Insertion Sort,333,412,0.00304560
+Insertion Sort,333,413,0.00294870
+Insertion Sort,333,414,0.00436060
+Insertion Sort,333,415,0.00293880
+Insertion Sort,333,416,0.00285240
+Insertion Sort,333,417,0.00294370
+Insertion Sort,333,418,0.00309720
+Insertion Sort,333,419,0.00309410
+Insertion Sort,333,420,0.00747880
+Insertion Sort,333,421,0.00336780
+Insertion Sort,333,422,0.00342980
+Insertion Sort,333,423,0.00321740
+Insertion Sort,333,424,0.00295400
+Insertion Sort,333,425,0.00303290
+Insertion Sort,333,426,0.00311510
+Insertion Sort,333,427,0.00349900
+Insertion Sort,333,428,0.00327990
+Insertion Sort,333,429,0.00443100
+Insertion Sort,333,430,0.00314210
+Insertion Sort,333,431,0.00322680
+Insertion Sort,333,432,0.00347880
+Insertion Sort,333,433,0.00433260
+Insertion Sort,333,434,0.00489450
+Insertion Sort,333,435,0.00860070
+Insertion Sort,333,436,0.00349980
+Insertion Sort,333,437,0.00291980
+Insertion Sort,333,438,0.00293380
+Insertion Sort,333,439,0.00312310
+Insertion Sort,333,440,0.00474200
+Insertion Sort,333,441,0.00320630
+Insertion Sort,333,442,0.00462730
+Insertion Sort,333,443,0.00325740
+Insertion Sort,333,444,0.00345300
+Insertion Sort,333,445,0.00304330
+Insertion Sort,333,446,0.00456050
+Insertion Sort,333,447,0.00317010
+Insertion Sort,333,448,0.00299800
+Insertion Sort,333,449,0.00324200
+Insertion Sort,333,450,0.00310240
+Insertion Sort,333,451,0.00299150
+Insertion Sort,333,452,0.00377240
+Insertion Sort,333,453,0.00620740
+Insertion Sort,333,454,0.00504310
+Insertion Sort,333,455,0.00314160
+Insertion Sort,333,456,0.00318800
+Insertion Sort,333,457,0.00402280
+Insertion Sort,333,458,0.00284930
+Insertion Sort,333,459,0.00299430
+Insertion Sort,333,460,0.00312260
+Insertion Sort,333,461,0.00416290
+Insertion Sort,333,462,0.00440860
+Insertion Sort,333,463,0.00320390
+Insertion Sort,333,464,0.00308340
+Insertion Sort,333,465,0.00289620
+Insertion Sort,333,466,0.00344920
+Insertion Sort,333,467,0.00299610
+Insertion Sort,333,468,0.00356680
+Insertion Sort,333,469,0.00438980
+Insertion Sort,333,470,0.00302360
+Insertion Sort,333,471,0.00311390
+Insertion Sort,333,472,0.00306690
+Insertion Sort,333,473,0.00311210
+Insertion Sort,333,474,0.00317500
+Insertion Sort,333,475,0.00282290
+Insertion Sort,333,476,0.00376440
+Insertion Sort,333,477,0.00331480
+Insertion Sort,333,478,0.00447760
+Insertion Sort,333,479,0.00388570
+Insertion Sort,333,480,0.00407290
+Insertion Sort,333,481,0.00299180
+Insertion Sort,333,482,0.00309210
+Insertion Sort,333,483,0.00392380
+Insertion Sort,333,484,0.00308060
+Insertion Sort,333,485,0.00321540
+Insertion Sort,333,486,0.00362500
+Insertion Sort,333,487,0.00298350
+Insertion Sort,333,488,0.00317210
+Insertion Sort,333,489,0.00331340
+Insertion Sort,333,490,0.00483520
+Insertion Sort,333,491,0.01329700
+Insertion Sort,333,492,0.00387100
+Insertion Sort,333,493,0.00661750
+Insertion Sort,333,494,0.00277480
+Insertion Sort,333,495,0.00330360
+Insertion Sort,333,496,0.00292030
+Insertion Sort,333,497,0.00292070
+Insertion Sort,333,498,0.00310040
+Insertion Sort,333,499,0.00291530
+Insertion Sort,333,500,0.00807470
+Intro Sort,333,1,0.00041100
+Intro Sort,333,2,0.00051010
+Intro Sort,333,3,0.00040310
+Intro Sort,333,4,0.00039510
+Intro Sort,333,5,0.00046430
+Intro Sort,333,6,0.00110770
+Intro Sort,333,7,0.00040240
+Intro Sort,333,8,0.00044660
+Intro Sort,333,9,0.00043880
+Intro Sort,333,10,0.00051740
+Intro Sort,333,11,0.00043170
+Intro Sort,333,12,0.00102510
+Intro Sort,333,13,0.00043960
+Intro Sort,333,14,0.00042800
+Intro Sort,333,15,0.00040720
+Intro Sort,333,16,0.00045830
+Intro Sort,333,17,0.00046290
+Intro Sort,333,18,0.00038640
+Intro Sort,333,19,0.00041350
+Intro Sort,333,20,0.00042320
+Intro Sort,333,21,0.00044970
+Intro Sort,333,22,0.00043240
+Intro Sort,333,23,0.00047150
+Intro Sort,333,24,0.00040740
+Intro Sort,333,25,0.00040240
+Intro Sort,333,26,0.00044560
+Intro Sort,333,27,0.00040200
+Intro Sort,333,28,0.00056760
+Intro Sort,333,29,0.00038660
+Intro Sort,333,30,0.00039240
+Intro Sort,333,31,0.00049290
+Intro Sort,333,32,0.00037700
+Intro Sort,333,33,0.00044090
+Intro Sort,333,34,0.00041640
+Intro Sort,333,35,0.00041270
+Intro Sort,333,36,0.00042880
+Intro Sort,333,37,0.00046380
+Intro Sort,333,38,0.00040780
+Intro Sort,333,39,0.00040220
+Intro Sort,333,40,0.00057560
+Intro Sort,333,41,0.00038930
+Intro Sort,333,42,0.00042970
+Intro Sort,333,43,0.00037670
+Intro Sort,333,44,0.00045250
+Intro Sort,333,45,0.00047100
+Intro Sort,333,46,0.00041890
+Intro Sort,333,47,0.00043010
+Intro Sort,333,48,0.00039200
+Intro Sort,333,49,0.00041990
+Intro Sort,333,50,0.00042190
+Intro Sort,333,51,0.00042310
+Intro Sort,333,52,0.00044980
+Intro Sort,333,53,0.00042270
+Intro Sort,333,54,0.00043020
+Intro Sort,333,55,0.00044230
+Intro Sort,333,56,0.00042980
+Intro Sort,333,57,0.00045420
+Intro Sort,333,58,0.00040830
+Intro Sort,333,59,0.00037410
+Intro Sort,333,60,0.00039790
+Intro Sort,333,61,0.00048940
+Intro Sort,333,62,0.00043190
+Intro Sort,333,63,0.00042760
+Intro Sort,333,64,0.00044570
+Intro Sort,333,65,0.00040420
+Intro Sort,333,66,0.00043650
+Intro Sort,333,67,0.00040750
+Intro Sort,333,68,0.00047660
+Intro Sort,333,69,0.00045430
+Intro Sort,333,70,0.00044230
+Intro Sort,333,71,0.00044620
+Intro Sort,333,72,0.00047220
+Intro Sort,333,73,0.00043880
+Intro Sort,333,74,0.00047220
+Intro Sort,333,75,0.00049140
+Intro Sort,333,76,0.00039580
+Intro Sort,333,77,0.00041690
+Intro Sort,333,78,0.00045520
+Intro Sort,333,79,0.00041620
+Intro Sort,333,80,0.00042210
+Intro Sort,333,81,0.00037540
+Intro Sort,333,82,0.00045030
+Intro Sort,333,83,0.00047020
+Intro Sort,333,84,0.00045660
+Intro Sort,333,85,0.00042720
+Intro Sort,333,86,0.00041300
+Intro Sort,333,87,0.00045680
+Intro Sort,333,88,0.00042230
+Intro Sort,333,89,0.00041520
+Intro Sort,333,90,0.00044930
+Intro Sort,333,91,0.00043860
+Intro Sort,333,92,0.00040830
+Intro Sort,333,93,0.00040460
+Intro Sort,333,94,0.00045690
+Intro Sort,333,95,0.00043850
+Intro Sort,333,96,0.00041830
+Intro Sort,333,97,0.00042220
+Intro Sort,333,98,0.00044900
+Intro Sort,333,99,0.00044160
+Intro Sort,333,100,0.00039520
+Intro Sort,333,101,0.00045360
+Intro Sort,333,102,0.00048220
+Intro Sort,333,103,0.00041520
+Intro Sort,333,104,0.00042620
+Intro Sort,333,105,0.00040640
+Intro Sort,333,106,0.00038500
+Intro Sort,333,107,0.00043380
+Intro Sort,333,108,0.00047280
+Intro Sort,333,109,0.00050320
+Intro Sort,333,110,0.00053390
+Intro Sort,333,111,0.00048970
+Intro Sort,333,112,0.00043710
+Intro Sort,333,113,0.00040490
+Intro Sort,333,114,0.00041480
+Intro Sort,333,115,0.00043010
+Intro Sort,333,116,0.00046810
+Intro Sort,333,117,0.00042940
+Intro Sort,333,118,0.00041430
+Intro Sort,333,119,0.00041430
+Intro Sort,333,120,0.00048270
+Intro Sort,333,121,0.00043980
+Intro Sort,333,122,0.00039620
+Intro Sort,333,123,0.00037940
+Intro Sort,333,124,0.00040450
+Intro Sort,333,125,0.00039970
+Intro Sort,333,126,0.00040210
+Intro Sort,333,127,0.00045350
+Intro Sort,333,128,0.00045870
+Intro Sort,333,129,0.00044030
+Intro Sort,333,130,0.00042960
+Intro Sort,333,131,0.00042560
+Intro Sort,333,132,0.00041830
+Intro Sort,333,133,0.00040730
+Intro Sort,333,134,0.00043150
+Intro Sort,333,135,0.00038650
+Intro Sort,333,136,0.00045380
+Intro Sort,333,137,0.00042300
+Intro Sort,333,138,0.00064410
+Intro Sort,333,139,0.00043620
+Intro Sort,333,140,0.00046660
+Intro Sort,333,141,0.00038970
+Intro Sort,333,142,0.00040940
+Intro Sort,333,143,0.00048780
+Intro Sort,333,144,0.00043430
+Intro Sort,333,145,0.00044070
+Intro Sort,333,146,0.00041800
+Intro Sort,333,147,0.00044710
+Intro Sort,333,148,0.00040930
+Intro Sort,333,149,0.00043310
+Intro Sort,333,150,0.00046000
+Intro Sort,333,151,0.00041990
+Intro Sort,333,152,0.00043560
+Intro Sort,333,153,0.00042810
+Intro Sort,333,154,0.00043640
+Intro Sort,333,155,0.00045630
+Intro Sort,333,156,0.00041820
+Intro Sort,333,157,0.00041260
+Intro Sort,333,158,0.00042490
+Intro Sort,333,159,0.00044230
+Intro Sort,333,160,0.00045900
+Intro Sort,333,161,0.00041970
+Intro Sort,333,162,0.00051370
+Intro Sort,333,163,0.00040160
+Intro Sort,333,164,0.00040550
+Intro Sort,333,165,0.00038210
+Intro Sort,333,166,0.00025780
+Intro Sort,333,167,0.00034450
+Intro Sort,333,168,0.00038380
+Intro Sort,333,169,0.00038740
+Intro Sort,333,170,0.00044480
+Intro Sort,333,171,0.00045090
+Intro Sort,333,172,0.00036540
+Intro Sort,333,173,0.00040670
+Intro Sort,333,174,0.00043700
+Intro Sort,333,175,0.00036010
+Intro Sort,333,176,0.00025090
+Intro Sort,333,177,0.00036180
+Intro Sort,333,178,0.00044240
+Intro Sort,333,179,0.00041380
+Intro Sort,333,180,0.00044620
+Intro Sort,333,181,0.00046780
+Intro Sort,333,182,0.00045150
+Intro Sort,333,183,0.00039740
+Intro Sort,333,184,0.00044740
+Intro Sort,333,185,0.00026490
+Intro Sort,333,186,0.00030280
+Intro Sort,333,187,0.00039130
+Intro Sort,333,188,0.00042480
+Intro Sort,333,189,0.00043920
+Intro Sort,333,190,0.00027250
+Intro Sort,333,191,0.00043940
+Intro Sort,333,192,0.00039060
+Intro Sort,333,193,0.00043110
+Intro Sort,333,194,0.00042350
+Intro Sort,333,195,0.00046970
+Intro Sort,333,196,0.00043140
+Intro Sort,333,197,0.00048520
+Intro Sort,333,198,0.00046760
+Intro Sort,333,199,0.00042110
+Intro Sort,333,200,0.00043590
+Intro Sort,333,201,0.00039370
+Intro Sort,333,202,0.00041980
+Intro Sort,333,203,0.00044880
+Intro Sort,333,204,0.00033510
+Intro Sort,333,205,0.00041690
+Intro Sort,333,206,0.00029760
+Intro Sort,333,207,0.00047820
+Intro Sort,333,208,0.00039910
+Intro Sort,333,209,0.00037640
+Intro Sort,333,210,0.00029740
+Intro Sort,333,211,0.00042720
+Intro Sort,333,212,0.00039850
+Intro Sort,333,213,0.00040240
+Intro Sort,333,214,0.00042480
+Intro Sort,333,215,0.00040100
+Intro Sort,333,216,0.00027660
+Intro Sort,333,217,0.00044220
+Intro Sort,333,218,0.00028380
+Intro Sort,333,219,0.00042950
+Intro Sort,333,220,0.00040670
+Intro Sort,333,221,0.00039120
+Intro Sort,333,222,0.00041250
+Intro Sort,333,223,0.00042220
+Intro Sort,333,224,0.00040270
+Intro Sort,333,225,0.00042400
+Intro Sort,333,226,0.00039640
+Intro Sort,333,227,0.00044870
+Intro Sort,333,228,0.00043580
+Intro Sort,333,229,0.00045340
+Intro Sort,333,230,0.00037300
+Intro Sort,333,231,0.00028660
+Intro Sort,333,232,0.00039020
+Intro Sort,333,233,0.00047160
+Intro Sort,333,234,0.00042580
+Intro Sort,333,235,0.00025670
+Intro Sort,333,236,0.00035970
+Intro Sort,333,237,0.00048770
+Intro Sort,333,238,0.00036980
+Intro Sort,333,239,0.00040510
+Intro Sort,333,240,0.00038460
+Intro Sort,333,241,0.00040510
+Intro Sort,333,242,0.00040500
+Intro Sort,333,243,0.00043290
+Intro Sort,333,244,0.00040850
+Intro Sort,333,245,0.00041960
+Intro Sort,333,246,0.00038260
+Intro Sort,333,247,0.00041630
+Intro Sort,333,248,0.00040760
+Intro Sort,333,249,0.00031120
+Intro Sort,333,250,0.00044500
+Intro Sort,333,251,0.00042620
+Intro Sort,333,252,0.00045740
+Intro Sort,333,253,0.00026130
+Intro Sort,333,254,0.00036360
+Intro Sort,333,255,0.00041380
+Intro Sort,333,256,0.00047460
+Intro Sort,333,257,0.00042980
+Intro Sort,333,258,0.00029870
+Intro Sort,333,259,0.00039950
+Intro Sort,333,260,0.00040400
+Intro Sort,333,261,0.00043480
+Intro Sort,333,262,0.00041820
+Intro Sort,333,263,0.00044380
+Intro Sort,333,264,0.00032770
+Intro Sort,333,265,0.00042350
+Intro Sort,333,266,0.00039190
+Intro Sort,333,267,0.00046310
+Intro Sort,333,268,0.00045460
+Intro Sort,333,269,0.00039810
+Intro Sort,333,270,0.00045600
+Intro Sort,333,271,0.00048670
+Intro Sort,333,272,0.00041620
+Intro Sort,333,273,0.00038940
+Intro Sort,333,274,0.00036160
+Intro Sort,333,275,0.00046640
+Intro Sort,333,276,0.00040700
+Intro Sort,333,277,0.00042410
+Intro Sort,333,278,0.00049010
+Intro Sort,333,279,0.00050110
+Intro Sort,333,280,0.00042170
+Intro Sort,333,281,0.00039630
+Intro Sort,333,282,0.00037760
+Intro Sort,333,283,0.00037730
+Intro Sort,333,284,0.00040560
+Intro Sort,333,285,0.00042920
+Intro Sort,333,286,0.00042670
+Intro Sort,333,287,0.00043420
+Intro Sort,333,288,0.00039100
+Intro Sort,333,289,0.00044050
+Intro Sort,333,290,0.00040920
+Intro Sort,333,291,0.00040400
+Intro Sort,333,292,0.00043640
+Intro Sort,333,293,0.00041770
+Intro Sort,333,294,0.00036790
+Intro Sort,333,295,0.00040130
+Intro Sort,333,296,0.00045370
+Intro Sort,333,297,0.00043680
+Intro Sort,333,298,0.00044820
+Intro Sort,333,299,0.00039990
+Intro Sort,333,300,0.00040120
+Intro Sort,333,301,0.00045480
+Intro Sort,333,302,0.00034550
+Intro Sort,333,303,0.00031880
+Intro Sort,333,304,0.00042420
+Intro Sort,333,305,0.00037520
+Intro Sort,333,306,0.00042790
+Intro Sort,333,307,0.00040950
+Intro Sort,333,308,0.00042370
+Intro Sort,333,309,0.00047420
+Intro Sort,333,310,0.00040890
+Intro Sort,333,311,0.00045160
+Intro Sort,333,312,0.00051000
+Intro Sort,333,313,0.00042650
+Intro Sort,333,314,0.00043910
+Intro Sort,333,315,0.00040590
+Intro Sort,333,316,0.00035490
+Intro Sort,333,317,0.00042420
+Intro Sort,333,318,0.00045360
+Intro Sort,333,319,0.00039040
+Intro Sort,333,320,0.00045320
+Intro Sort,333,321,0.00042530
+Intro Sort,333,322,0.00041420
+Intro Sort,333,323,0.00043860
+Intro Sort,333,324,0.00042540
+Intro Sort,333,325,0.00050690
+Intro Sort,333,326,0.00043820
+Intro Sort,333,327,0.00049490
+Intro Sort,333,328,0.00042620
+Intro Sort,333,329,0.00043470
+Intro Sort,333,330,0.00042300
+Intro Sort,333,331,0.00039600
+Intro Sort,333,332,0.00042520
+Intro Sort,333,333,0.00048070
+Intro Sort,333,334,0.00039100
+Intro Sort,333,335,0.00044370
+Intro Sort,333,336,0.00032930
+Intro Sort,333,337,0.00042420
+Intro Sort,333,338,0.00044080
+Intro Sort,333,339,0.00037040
+Intro Sort,333,340,0.00042000
+Intro Sort,333,341,0.00028470
+Intro Sort,333,342,0.00046980
+Intro Sort,333,343,0.00031010
+Intro Sort,333,344,0.00043170
+Intro Sort,333,345,0.00024670
+Intro Sort,333,346,0.00044990
+Intro Sort,333,347,0.00036280
+Intro Sort,333,348,0.00042070
+Intro Sort,333,349,0.00033580
+Intro Sort,333,350,0.00042410
+Intro Sort,333,351,0.00034320
+Intro Sort,333,352,0.00045320
+Intro Sort,333,353,0.00041650
+Intro Sort,333,354,0.00032460
+Intro Sort,333,355,0.00041480
+Intro Sort,333,356,0.00039380
+Intro Sort,333,357,0.00031960
+Intro Sort,333,358,0.00036150
+Intro Sort,333,359,0.00042020
+Intro Sort,333,360,0.00046660
+Intro Sort,333,361,0.00039740
+Intro Sort,333,362,0.00040040
+Intro Sort,333,363,0.00043540
+Intro Sort,333,364,0.00040560
+Intro Sort,333,365,0.00041050
+Intro Sort,333,366,0.00043770
+Intro Sort,333,367,0.00040650
+Intro Sort,333,368,0.00030090
+Intro Sort,333,369,0.00048940
+Intro Sort,333,370,0.00043450
+Intro Sort,333,371,0.00040750
+Intro Sort,333,372,0.00042430
+Intro Sort,333,373,0.00034960
+Intro Sort,333,374,0.00044910
+Intro Sort,333,375,0.00040660
+Intro Sort,333,376,0.00042880
+Intro Sort,333,377,0.00046800
+Intro Sort,333,378,0.00030880
+Intro Sort,333,379,0.00043430
+Intro Sort,333,380,0.00043710
+Intro Sort,333,381,0.00041190
+Intro Sort,333,382,0.00040100
+Intro Sort,333,383,0.00048070
+Intro Sort,333,384,0.00043960
+Intro Sort,333,385,0.00040110
+Intro Sort,333,386,0.00040230
+Intro Sort,333,387,0.00034330
+Intro Sort,333,388,0.00045350
+Intro Sort,333,389,0.00039430
+Intro Sort,333,390,0.00039630
+Intro Sort,333,391,0.00038480
+Intro Sort,333,392,0.00047640
+Intro Sort,333,393,0.00037380
+Intro Sort,333,394,0.00040170
+Intro Sort,333,395,0.00040880
+Intro Sort,333,396,0.00027230
+Intro Sort,333,397,0.00045830
+Intro Sort,333,398,0.00041560
+Intro Sort,333,399,0.00034740
+Intro Sort,333,400,0.00044400
+Intro Sort,333,401,0.00042070
+Intro Sort,333,402,0.00046660
+Intro Sort,333,403,0.00035750
+Intro Sort,333,404,0.00024380
+Intro Sort,333,405,0.00025850
+Intro Sort,333,406,0.00036580
+Intro Sort,333,407,0.00045910
+Intro Sort,333,408,0.00041210
+Intro Sort,333,409,0.00040470
+Intro Sort,333,410,0.00044050
+Intro Sort,333,411,0.00040790
+Intro Sort,333,412,0.00025690
+Intro Sort,333,413,0.00041430
+Intro Sort,333,414,0.00030960
+Intro Sort,333,415,0.00026260
+Intro Sort,333,416,0.00030720
+Intro Sort,333,417,0.00043060
+Intro Sort,333,418,0.00042680
+Intro Sort,333,419,0.00043680
+Intro Sort,333,420,0.00036720
+Intro Sort,333,421,0.00025100
+Intro Sort,333,422,0.00026670
+Intro Sort,333,423,0.00045220
+Intro Sort,333,424,0.00038640
+Intro Sort,333,425,0.00026640
+Intro Sort,333,426,0.00028190
+Intro Sort,333,427,0.00039580
+Intro Sort,333,428,0.00042200
+Intro Sort,333,429,0.00042950
+Intro Sort,333,430,0.00034310
+Intro Sort,333,431,0.00024950
+Intro Sort,333,432,0.00040380
+Intro Sort,333,433,0.00039630
+Intro Sort,333,434,0.00040510
+Intro Sort,333,435,0.00044130
+Intro Sort,333,436,0.00043590
+Intro Sort,333,437,0.00037690
+Intro Sort,333,438,0.00042300
+Intro Sort,333,439,0.00046900
+Intro Sort,333,440,0.00039990
+Intro Sort,333,441,0.00032190
+Intro Sort,333,442,0.00039410
+Intro Sort,333,443,0.00042870
+Intro Sort,333,444,0.00040730
+Intro Sort,333,445,0.00036090
+Intro Sort,333,446,0.00044710
+Intro Sort,333,447,0.00024140
+Intro Sort,333,448,0.00024800
+Intro Sort,333,449,0.00048350
+Intro Sort,333,450,0.00036280
+Intro Sort,333,451,0.00041770
+Intro Sort,333,452,0.00037970
+Intro Sort,333,453,0.00035960
+Intro Sort,333,454,0.00042160
+Intro Sort,333,455,0.00047430
+Intro Sort,333,456,0.00026510
+Intro Sort,333,457,0.00025170
+Intro Sort,333,458,0.00041920
+Intro Sort,333,459,0.00034590
+Intro Sort,333,460,0.00040400
+Intro Sort,333,461,0.00041040
+Intro Sort,333,462,0.00033730
+Intro Sort,333,463,0.00044220
+Intro Sort,333,464,0.00028780
+Intro Sort,333,465,0.00025450
+Intro Sort,333,466,0.00043050
+Intro Sort,333,467,0.00035090
+Intro Sort,333,468,0.00043870
+Intro Sort,333,469,0.00030400
+Intro Sort,333,470,0.00044810
+Intro Sort,333,471,0.00042230
+Intro Sort,333,472,0.00042940
+Intro Sort,333,473,0.00035650
+Intro Sort,333,474,0.00034950
+Intro Sort,333,475,0.00041190
+Intro Sort,333,476,0.00042620
+Intro Sort,333,477,0.00031490
+Intro Sort,333,478,0.00027170
+Intro Sort,333,479,0.00039600
+Intro Sort,333,480,0.00039240
+Intro Sort,333,481,0.00038900
+Intro Sort,333,482,0.00038000
+Intro Sort,333,483,0.00042000
+Intro Sort,333,484,0.00030420
+Intro Sort,333,485,0.00039760
+Intro Sort,333,486,0.00045520
+Intro Sort,333,487,0.00043630
+Intro Sort,333,488,0.00040000
+Intro Sort,333,489,0.00041660
+Intro Sort,333,490,0.00042630
+Intro Sort,333,491,0.00039850
+Intro Sort,333,492,0.00037720
+Intro Sort,333,493,0.00067420
+Intro Sort,333,494,0.00031480
+Intro Sort,333,495,0.00044200
+Intro Sort,333,496,0.00037880
+Intro Sort,333,497,0.00026680
+Intro Sort,333,498,0.00039450
+Intro Sort,333,499,0.00038560
+Intro Sort,333,500,0.00038670
+LSD Radix Sort,333,1,0.00078580
+LSD Radix Sort,333,2,0.00075230
+LSD Radix Sort,333,3,0.00079870
+LSD Radix Sort,333,4,0.00076080
+LSD Radix Sort,333,5,0.00074390
+LSD Radix Sort,333,6,0.00079460
+LSD Radix Sort,333,7,0.00073040
+LSD Radix Sort,333,8,0.00076940
+LSD Radix Sort,333,9,0.00076390
+LSD Radix Sort,333,10,0.00075990
+LSD Radix Sort,333,11,0.00072710
+LSD Radix Sort,333,12,0.00105900
+LSD Radix Sort,333,13,0.00072740
+LSD Radix Sort,333,14,0.00072620
+LSD Radix Sort,333,15,0.00077320
+LSD Radix Sort,333,16,0.00076520
+LSD Radix Sort,333,17,0.00074010
+LSD Radix Sort,333,18,0.00074440
+LSD Radix Sort,333,19,0.00075330
+LSD Radix Sort,333,20,0.00075960
+LSD Radix Sort,333,21,0.00072680
+LSD Radix Sort,333,22,0.00070740
+LSD Radix Sort,333,23,0.00076340
+LSD Radix Sort,333,24,0.00075660
+LSD Radix Sort,333,25,0.00075920
+LSD Radix Sort,333,26,0.00077060
+LSD Radix Sort,333,27,0.00075430
+LSD Radix Sort,333,28,0.00075500
+LSD Radix Sort,333,29,0.00076510
+LSD Radix Sort,333,30,0.00073000
+LSD Radix Sort,333,31,0.00071090
+LSD Radix Sort,333,32,0.00075800
+LSD Radix Sort,333,33,0.00076330
+LSD Radix Sort,333,34,0.00074440
+LSD Radix Sort,333,35,0.00075080
+LSD Radix Sort,333,36,0.00075510
+LSD Radix Sort,333,37,0.00074560
+LSD Radix Sort,333,38,0.00075870
+LSD Radix Sort,333,39,0.00072810
+LSD Radix Sort,333,40,0.00077980
+LSD Radix Sort,333,41,0.00075630
+LSD Radix Sort,333,42,0.00075660
+LSD Radix Sort,333,43,0.00073770
+LSD Radix Sort,333,44,0.00073310
+LSD Radix Sort,333,45,0.00075270
+LSD Radix Sort,333,46,0.00075280
+LSD Radix Sort,333,47,0.00076510
+LSD Radix Sort,333,48,0.00073400
+LSD Radix Sort,333,49,0.00080180
+LSD Radix Sort,333,50,0.00075380
+LSD Radix Sort,333,51,0.00075570
+LSD Radix Sort,333,52,0.00078940
+LSD Radix Sort,333,53,0.00073950
+LSD Radix Sort,333,54,0.00075810
+LSD Radix Sort,333,55,0.00085950
+LSD Radix Sort,333,56,0.00080000
+LSD Radix Sort,333,57,0.00073240
+LSD Radix Sort,333,58,0.00078510
+LSD Radix Sort,333,59,0.00075890
+LSD Radix Sort,333,60,0.00076200
+LSD Radix Sort,333,61,0.00074220
+LSD Radix Sort,333,62,0.00088210
+LSD Radix Sort,333,63,0.00076220
+LSD Radix Sort,333,64,0.00123750
+LSD Radix Sort,333,65,0.00077400
+LSD Radix Sort,333,66,0.00073220
+LSD Radix Sort,333,67,0.00080070
+LSD Radix Sort,333,68,0.00076050
+LSD Radix Sort,333,69,0.00078100
+LSD Radix Sort,333,70,0.00083320
+LSD Radix Sort,333,71,0.00077720
+LSD Radix Sort,333,72,0.00074040
+LSD Radix Sort,333,73,0.00089210
+LSD Radix Sort,333,74,0.00081290
+LSD Radix Sort,333,75,0.00075000
+LSD Radix Sort,333,76,0.00074620
+LSD Radix Sort,333,77,0.00074800
+LSD Radix Sort,333,78,0.00079940
+LSD Radix Sort,333,79,0.00076280
+LSD Radix Sort,333,80,0.00076390
+LSD Radix Sort,333,81,0.00073200
+LSD Radix Sort,333,82,0.00073650
+LSD Radix Sort,333,83,0.00075320
+LSD Radix Sort,333,84,0.00077470
+LSD Radix Sort,333,85,0.00075670
+LSD Radix Sort,333,86,0.00074600
+LSD Radix Sort,333,87,0.00083420
+LSD Radix Sort,333,88,0.00075720
+LSD Radix Sort,333,89,0.00073020
+LSD Radix Sort,333,90,0.00072960
+LSD Radix Sort,333,91,0.00073570
+LSD Radix Sort,333,92,0.00074700
+LSD Radix Sort,333,93,0.00079670
+LSD Radix Sort,333,94,0.00075220
+LSD Radix Sort,333,95,0.00076210
+LSD Radix Sort,333,96,0.00075750
+LSD Radix Sort,333,97,0.00082890
+LSD Radix Sort,333,98,0.00073000
+LSD Radix Sort,333,99,0.00073610
+LSD Radix Sort,333,100,0.00073340
+LSD Radix Sort,333,101,0.00078560
+LSD Radix Sort,333,102,0.00080090
+LSD Radix Sort,333,103,0.00076090
+LSD Radix Sort,333,104,0.00075110
+LSD Radix Sort,333,105,0.00075880
+LSD Radix Sort,333,106,0.00072820
+LSD Radix Sort,333,107,0.00073740
+LSD Radix Sort,333,108,0.00081770
+LSD Radix Sort,333,109,0.00073040
+LSD Radix Sort,333,110,0.00076710
+LSD Radix Sort,333,111,0.00078810
+LSD Radix Sort,333,112,0.00073510
+LSD Radix Sort,333,113,0.00075630
+LSD Radix Sort,333,114,0.00075040
+LSD Radix Sort,333,115,0.00074620
+LSD Radix Sort,333,116,0.00077440
+LSD Radix Sort,333,117,0.00076040
+LSD Radix Sort,333,118,0.00073050
+LSD Radix Sort,333,119,0.00076790
+LSD Radix Sort,333,120,0.00075190
+LSD Radix Sort,333,121,0.00072950
+LSD Radix Sort,333,122,0.00074790
+LSD Radix Sort,333,123,0.00074740
+LSD Radix Sort,333,124,0.00073860
+LSD Radix Sort,333,125,0.00074480
+LSD Radix Sort,333,126,0.00074130
+LSD Radix Sort,333,127,0.00074480
+LSD Radix Sort,333,128,0.00076480
+LSD Radix Sort,333,129,0.00075400
+LSD Radix Sort,333,130,0.00072640
+LSD Radix Sort,333,131,0.00075090
+LSD Radix Sort,333,132,0.00074440
+LSD Radix Sort,333,133,0.00074340
+LSD Radix Sort,333,134,0.00074880
+LSD Radix Sort,333,135,0.00072320
+LSD Radix Sort,333,136,0.00086290
+LSD Radix Sort,333,137,0.00081780
+LSD Radix Sort,333,138,0.00075470
+LSD Radix Sort,333,139,0.00073160
+LSD Radix Sort,333,140,0.00074710
+LSD Radix Sort,333,141,0.00074080
+LSD Radix Sort,333,142,0.00073560
+LSD Radix Sort,333,143,0.00074680
+LSD Radix Sort,333,144,0.00075350
+LSD Radix Sort,333,145,0.00075490
+LSD Radix Sort,333,146,0.00076560
+LSD Radix Sort,333,147,0.00074230
+LSD Radix Sort,333,148,0.00075540
+LSD Radix Sort,333,149,0.00074030
+LSD Radix Sort,333,150,0.00074260
+LSD Radix Sort,333,151,0.00073850
+LSD Radix Sort,333,152,0.00075120
+LSD Radix Sort,333,153,0.00075320
+LSD Radix Sort,333,154,0.00081620
+LSD Radix Sort,333,155,0.00079400
+LSD Radix Sort,333,156,0.00073720
+LSD Radix Sort,333,157,0.00079180
+LSD Radix Sort,333,158,0.00077000
+LSD Radix Sort,333,159,0.00079270
+LSD Radix Sort,333,160,0.00074890
+LSD Radix Sort,333,161,0.00076600
+LSD Radix Sort,333,162,0.00074610
+LSD Radix Sort,333,163,0.00075310
+LSD Radix Sort,333,164,0.00079180
+LSD Radix Sort,333,165,0.00076030
+LSD Radix Sort,333,166,0.00074950
+LSD Radix Sort,333,167,0.00078430
+LSD Radix Sort,333,168,0.00074390
+LSD Radix Sort,333,169,0.00074540
+LSD Radix Sort,333,170,0.00075810
+LSD Radix Sort,333,171,0.00074140
+LSD Radix Sort,333,172,0.00074890
+LSD Radix Sort,333,173,0.00080540
+LSD Radix Sort,333,174,0.00075880
+LSD Radix Sort,333,175,0.00074900
+LSD Radix Sort,333,176,0.00073720
+LSD Radix Sort,333,177,0.00073440
+LSD Radix Sort,333,178,0.00080430
+LSD Radix Sort,333,179,0.00077730
+LSD Radix Sort,333,180,0.00075990
+LSD Radix Sort,333,181,0.00074810
+LSD Radix Sort,333,182,0.00077260
+LSD Radix Sort,333,183,0.00078550
+LSD Radix Sort,333,184,0.00075770
+LSD Radix Sort,333,185,0.00081820
+LSD Radix Sort,333,186,0.00081690
+LSD Radix Sort,333,187,0.00073720
+LSD Radix Sort,333,188,0.00075510
+LSD Radix Sort,333,189,0.00079760
+LSD Radix Sort,333,190,0.00075820
+LSD Radix Sort,333,191,0.00078580
+LSD Radix Sort,333,192,0.00077000
+LSD Radix Sort,333,193,0.00074220
+LSD Radix Sort,333,194,0.00078390
+LSD Radix Sort,333,195,0.00077980
+LSD Radix Sort,333,196,0.00076260
+LSD Radix Sort,333,197,0.00078010
+LSD Radix Sort,333,198,0.00073830
+LSD Radix Sort,333,199,0.00075870
+LSD Radix Sort,333,200,0.00082770
+LSD Radix Sort,333,201,0.00074300
+LSD Radix Sort,333,202,0.00074400
+LSD Radix Sort,333,203,0.00075980
+LSD Radix Sort,333,204,0.00081100
+LSD Radix Sort,333,205,0.00076760
+LSD Radix Sort,333,206,0.00074150
+LSD Radix Sort,333,207,0.00078720
+LSD Radix Sort,333,208,0.00079700
+LSD Radix Sort,333,209,0.00075100
+LSD Radix Sort,333,210,0.00081900
+LSD Radix Sort,333,211,0.00075960
+LSD Radix Sort,333,212,0.00085610
+LSD Radix Sort,333,213,0.00075450
+LSD Radix Sort,333,214,0.00076000
+LSD Radix Sort,333,215,0.00073320
+LSD Radix Sort,333,216,0.00079000
+LSD Radix Sort,333,217,0.00080420
+LSD Radix Sort,333,218,0.00075480
+LSD Radix Sort,333,219,0.00076180
+LSD Radix Sort,333,220,0.00081210
+LSD Radix Sort,333,221,0.00075370
+LSD Radix Sort,333,222,0.00085660
+LSD Radix Sort,333,223,0.00076510
+LSD Radix Sort,333,224,0.00073670
+LSD Radix Sort,333,225,0.00078800
+LSD Radix Sort,333,226,0.00074870
+LSD Radix Sort,333,227,0.00075810
+LSD Radix Sort,333,228,0.00075200
+LSD Radix Sort,333,229,0.00075850
+LSD Radix Sort,333,230,0.00298270
+LSD Radix Sort,333,231,0.00076040
+LSD Radix Sort,333,232,0.00076000
+LSD Radix Sort,333,233,0.00073790
+LSD Radix Sort,333,234,0.00084190
+LSD Radix Sort,333,235,0.00075310
+LSD Radix Sort,333,236,0.00075580
+LSD Radix Sort,333,237,0.00075470
+LSD Radix Sort,333,238,0.00076060
+LSD Radix Sort,333,239,0.00076750
+LSD Radix Sort,333,240,0.00077760
+LSD Radix Sort,333,241,0.00073170
+LSD Radix Sort,333,242,0.00077670
+LSD Radix Sort,333,243,0.00079190
+LSD Radix Sort,333,244,0.00077210
+LSD Radix Sort,333,245,0.00079750
+LSD Radix Sort,333,246,0.00078640
+LSD Radix Sort,333,247,0.00075740
+LSD Radix Sort,333,248,0.00073350
+LSD Radix Sort,333,249,0.00075940
+LSD Radix Sort,333,250,0.00074840
+LSD Radix Sort,333,251,0.00080440
+LSD Radix Sort,333,252,0.00075510
+LSD Radix Sort,333,253,0.00079160
+LSD Radix Sort,333,254,0.00075650
+LSD Radix Sort,333,255,0.00074960
+LSD Radix Sort,333,256,0.00075400
+LSD Radix Sort,333,257,0.00083220
+LSD Radix Sort,333,258,0.00075130
+LSD Radix Sort,333,259,0.00076040
+LSD Radix Sort,333,260,0.00076000
+LSD Radix Sort,333,261,0.00076710
+LSD Radix Sort,333,262,0.00078050
+LSD Radix Sort,333,263,0.00076150
+LSD Radix Sort,333,264,0.00076290
+LSD Radix Sort,333,265,0.00075830
+LSD Radix Sort,333,266,0.00075670
+LSD Radix Sort,333,267,0.00091040
+LSD Radix Sort,333,268,0.00075230
+LSD Radix Sort,333,269,0.00078150
+LSD Radix Sort,333,270,0.00079410
+LSD Radix Sort,333,271,0.00077460
+LSD Radix Sort,333,272,0.00078660
+LSD Radix Sort,333,273,0.00075900
+LSD Radix Sort,333,274,0.00075620
+LSD Radix Sort,333,275,0.00076750
+LSD Radix Sort,333,276,0.00075420
+LSD Radix Sort,333,277,0.00074560
+LSD Radix Sort,333,278,0.00079310
+LSD Radix Sort,333,279,0.00074710
+LSD Radix Sort,333,280,0.00075920
+LSD Radix Sort,333,281,0.00076210
+LSD Radix Sort,333,282,0.00075870
+LSD Radix Sort,333,283,0.00077600
+LSD Radix Sort,333,284,0.00076250
+LSD Radix Sort,333,285,0.00078150
+LSD Radix Sort,333,286,0.00077730
+LSD Radix Sort,333,287,0.00077200
+LSD Radix Sort,333,288,0.00080920
+LSD Radix Sort,333,289,0.00076060
+LSD Radix Sort,333,290,0.00076180
+LSD Radix Sort,333,291,0.00075680
+LSD Radix Sort,333,292,0.00075350
+LSD Radix Sort,333,293,0.00074780
+LSD Radix Sort,333,294,0.00075960
+LSD Radix Sort,333,295,0.00074310
+LSD Radix Sort,333,296,0.00075830
+LSD Radix Sort,333,297,0.00079810
+LSD Radix Sort,333,298,0.00072160
+LSD Radix Sort,333,299,0.00080350
+LSD Radix Sort,333,300,0.00075590
+LSD Radix Sort,333,301,0.00076600
+LSD Radix Sort,333,302,0.00074810
+LSD Radix Sort,333,303,0.00080980
+LSD Radix Sort,333,304,0.00079380
+LSD Radix Sort,333,305,0.00076930
+LSD Radix Sort,333,306,0.00077370
+LSD Radix Sort,333,307,0.00071900
+LSD Radix Sort,333,308,0.00078880
+LSD Radix Sort,333,309,0.00078840
+LSD Radix Sort,333,310,0.00075150
+LSD Radix Sort,333,311,0.00076340
+LSD Radix Sort,333,312,0.00077550
+LSD Radix Sort,333,313,0.00076710
+LSD Radix Sort,333,314,0.00075750
+LSD Radix Sort,333,315,0.00071800
+LSD Radix Sort,333,316,0.00082740
+LSD Radix Sort,333,317,0.00076350
+LSD Radix Sort,333,318,0.00075970
+LSD Radix Sort,333,319,0.00074780
+LSD Radix Sort,333,320,0.00076420
+LSD Radix Sort,333,321,0.00075550
+LSD Radix Sort,333,322,0.00076360
+LSD Radix Sort,333,323,0.00075280
+LSD Radix Sort,333,324,0.00070980
+LSD Radix Sort,333,325,0.00076020
+LSD Radix Sort,333,326,0.00075800
+LSD Radix Sort,333,327,0.00075390
+LSD Radix Sort,333,328,0.00074830
+LSD Radix Sort,333,329,0.00075770
+LSD Radix Sort,333,330,0.00076480
+LSD Radix Sort,333,331,0.00075310
+LSD Radix Sort,333,332,0.00070560
+LSD Radix Sort,333,333,0.00078240
+LSD Radix Sort,333,334,0.00075640
+LSD Radix Sort,333,335,0.00075960
+LSD Radix Sort,333,336,0.00076260
+LSD Radix Sort,333,337,0.00074530
+LSD Radix Sort,333,338,0.00075980
+LSD Radix Sort,333,339,0.00074770
+LSD Radix Sort,333,340,0.00074940
+LSD Radix Sort,333,341,0.00070830
+LSD Radix Sort,333,342,0.00076840
+LSD Radix Sort,333,343,0.00072310
+LSD Radix Sort,333,344,0.00076480
+LSD Radix Sort,333,345,0.00075280
+LSD Radix Sort,333,346,0.00073950
+LSD Radix Sort,333,347,0.00076060
+LSD Radix Sort,333,348,0.00075160
+LSD Radix Sort,333,349,0.00075060
+LSD Radix Sort,333,350,0.00078650
+LSD Radix Sort,333,351,0.00075420
+LSD Radix Sort,333,352,0.00072630
+LSD Radix Sort,333,353,0.00075250
+LSD Radix Sort,333,354,0.00075590
+LSD Radix Sort,333,355,0.00073790
+LSD Radix Sort,333,356,0.00075300
+LSD Radix Sort,333,357,0.00074550
+LSD Radix Sort,333,358,0.00075290
+LSD Radix Sort,333,359,0.00074780
+LSD Radix Sort,333,360,0.00075110
+LSD Radix Sort,333,361,0.00072220
+LSD Radix Sort,333,362,0.00075460
+LSD Radix Sort,333,363,0.00075160
+LSD Radix Sort,333,364,0.00073950
+LSD Radix Sort,333,365,0.00076230
+LSD Radix Sort,333,366,0.00075110
+LSD Radix Sort,333,367,0.00075340
+LSD Radix Sort,333,368,0.00074700
+LSD Radix Sort,333,369,0.00080940
+LSD Radix Sort,333,370,0.00072870
+LSD Radix Sort,333,371,0.00075740
+LSD Radix Sort,333,372,0.00075060
+LSD Radix Sort,333,373,0.00073380
+LSD Radix Sort,333,374,0.00075060
+LSD Radix Sort,333,375,0.00075210
+LSD Radix Sort,333,376,0.00075810
+LSD Radix Sort,333,377,0.00074580
+LSD Radix Sort,333,378,0.00073180
+LSD Radix Sort,333,379,0.00080790
+LSD Radix Sort,333,380,0.00075480
+LSD Radix Sort,333,381,0.00077360
+LSD Radix Sort,333,382,0.00073000
+LSD Radix Sort,333,383,0.00074960
+LSD Radix Sort,333,384,0.00075660
+LSD Radix Sort,333,385,0.00075290
+LSD Radix Sort,333,386,0.00075580
+LSD Radix Sort,333,387,0.00072280
+LSD Radix Sort,333,388,0.00087580
+LSD Radix Sort,333,389,0.00079090
+LSD Radix Sort,333,390,0.00074040
+LSD Radix Sort,333,391,0.00076990
+LSD Radix Sort,333,392,0.00075820
+LSD Radix Sort,333,393,0.00074700
+LSD Radix Sort,333,394,0.00073300
+LSD Radix Sort,333,395,0.00078880
+LSD Radix Sort,333,396,0.00081060
+LSD Radix Sort,333,397,0.00074070
+LSD Radix Sort,333,398,0.00076560
+LSD Radix Sort,333,399,0.00077330
+LSD Radix Sort,333,400,0.00072330
+LSD Radix Sort,333,401,0.00077890
+LSD Radix Sort,333,402,0.00074500
+LSD Radix Sort,333,403,0.00069740
+LSD Radix Sort,333,404,0.00075610
+LSD Radix Sort,333,405,0.00075000
+LSD Radix Sort,333,406,0.00073960
+LSD Radix Sort,333,407,0.00077820
+LSD Radix Sort,333,408,0.00077020
+LSD Radix Sort,333,409,0.00065840
+LSD Radix Sort,333,410,0.00075140
+LSD Radix Sort,333,411,0.00078230
+LSD Radix Sort,333,412,0.00078150
+LSD Radix Sort,333,413,0.00082970
+LSD Radix Sort,333,414,0.00073500
+LSD Radix Sort,333,415,0.00076270
+LSD Radix Sort,333,416,0.00076060
+LSD Radix Sort,333,417,0.00080940
+LSD Radix Sort,333,418,0.00078190
+LSD Radix Sort,333,419,0.00076060
+LSD Radix Sort,333,420,0.00075750
+LSD Radix Sort,333,421,0.00075650
+LSD Radix Sort,333,422,0.00081990
+LSD Radix Sort,333,423,0.00073400
+LSD Radix Sort,333,424,0.00076760
+LSD Radix Sort,333,425,0.00073450
+LSD Radix Sort,333,426,0.00077180
+LSD Radix Sort,333,427,0.00079970
+LSD Radix Sort,333,428,0.00076680
+LSD Radix Sort,333,429,0.00080320
+LSD Radix Sort,333,430,0.00076070
+LSD Radix Sort,333,431,0.00073290
+LSD Radix Sort,333,432,0.00070990
+LSD Radix Sort,333,433,0.00069410
+LSD Radix Sort,333,434,0.00076630
+LSD Radix Sort,333,435,0.00077920
+LSD Radix Sort,333,436,0.00075720
+LSD Radix Sort,333,437,0.00077060
+LSD Radix Sort,333,438,0.00077650
+LSD Radix Sort,333,439,0.00062960
+LSD Radix Sort,333,440,0.00077530
+LSD Radix Sort,333,441,0.00075180
+LSD Radix Sort,333,442,0.00079600
+LSD Radix Sort,333,443,0.00075070
+LSD Radix Sort,333,444,0.00068520
+LSD Radix Sort,333,445,0.00078940
+LSD Radix Sort,333,446,0.00073850
+LSD Radix Sort,333,447,0.00075530
+LSD Radix Sort,333,448,0.00077230
+LSD Radix Sort,333,449,0.00081780
+LSD Radix Sort,333,450,0.00075260
+LSD Radix Sort,333,451,0.00076570
+LSD Radix Sort,333,452,0.00075550
+LSD Radix Sort,333,453,0.00077900
+LSD Radix Sort,333,454,0.00078250
+LSD Radix Sort,333,455,0.00075560
+LSD Radix Sort,333,456,0.00075180
+LSD Radix Sort,333,457,0.00074920
+LSD Radix Sort,333,458,0.00074560
+LSD Radix Sort,333,459,0.00056400
+LSD Radix Sort,333,460,0.00075980
+LSD Radix Sort,333,461,0.00084560
+LSD Radix Sort,333,462,0.00078090
+LSD Radix Sort,333,463,0.00076010
+LSD Radix Sort,333,464,0.00076980
+LSD Radix Sort,333,465,0.00080230
+LSD Radix Sort,333,466,0.00077030
+LSD Radix Sort,333,467,0.00063780
+LSD Radix Sort,333,468,0.00074500
+LSD Radix Sort,333,469,0.00059930
+LSD Radix Sort,333,470,0.00044630
+LSD Radix Sort,333,471,0.00074180
+LSD Radix Sort,333,472,0.00050100
+LSD Radix Sort,333,473,0.00069710
+LSD Radix Sort,333,474,0.00068580
+LSD Radix Sort,333,475,0.00073400
+LSD Radix Sort,333,476,0.00062660
+LSD Radix Sort,333,477,0.00078180
+LSD Radix Sort,333,478,0.00073610
+LSD Radix Sort,333,479,0.00076060
+LSD Radix Sort,333,480,0.00078600
+LSD Radix Sort,333,481,0.00072210
+LSD Radix Sort,333,482,0.00073990
+LSD Radix Sort,333,483,0.00073020
+LSD Radix Sort,333,484,0.00080290
+LSD Radix Sort,333,485,0.00079800
+LSD Radix Sort,333,486,0.00050790
+LSD Radix Sort,333,487,0.00054660
+LSD Radix Sort,333,488,0.00073190
+LSD Radix Sort,333,489,0.00076300
+LSD Radix Sort,333,490,0.00074870
+LSD Radix Sort,333,491,0.00072750
+LSD Radix Sort,333,492,0.00072430
+LSD Radix Sort,333,493,0.00077380
+LSD Radix Sort,333,494,0.00070590
+LSD Radix Sort,333,495,0.00075510
+LSD Radix Sort,333,496,0.00073380
+LSD Radix Sort,333,497,0.00073040
+LSD Radix Sort,333,498,0.00079420
+LSD Radix Sort,333,499,0.00073550
+LSD Radix Sort,333,500,0.00075740
+Library Sort,333,1,0.00256400
+Library Sort,333,2,0.00157620
+Library Sort,333,3,0.00183910
+Library Sort,333,4,0.00159680
+Library Sort,333,5,0.00143650
+Library Sort,333,6,0.00175480
+Library Sort,333,7,0.00197150
+Library Sort,333,8,0.00236490
+Library Sort,333,9,0.00176060
+Library Sort,333,10,0.00349550
+Library Sort,333,11,0.00347700
+Library Sort,333,12,0.00232580
+Library Sort,333,13,0.00228680
+Library Sort,333,14,0.00173780
+Library Sort,333,15,0.00200580
+Library Sort,333,16,0.00177080
+Library Sort,333,17,0.00347710
+Library Sort,333,18,0.00181650
+Library Sort,333,19,0.00174220
+Library Sort,333,20,0.00190460
+Library Sort,333,21,0.00236590
+Library Sort,333,22,0.00156180
+Library Sort,333,23,0.00152880
+Library Sort,333,24,0.00216500
+Library Sort,333,25,0.00204690
+Library Sort,333,26,0.00309490
+Library Sort,333,27,0.00114860
+Library Sort,333,28,0.00223920
+Library Sort,333,29,0.00157060
+Library Sort,333,30,0.00267380
+Library Sort,333,31,0.00188750
+Library Sort,333,32,0.00219150
+Library Sort,333,33,0.00239500
+Library Sort,333,34,0.00157090
+Library Sort,333,35,0.00321450
+Library Sort,333,36,0.00460910
+Library Sort,333,37,0.00221270
+Library Sort,333,38,0.00219670
+Library Sort,333,39,0.00247790
+Library Sort,333,40,0.00141030
+Library Sort,333,41,0.00265620
+Library Sort,333,42,0.00153250
+Library Sort,333,43,0.00155780
+Library Sort,333,44,0.00162720
+Library Sort,333,45,0.00154120
+Library Sort,333,46,0.00345090
+Library Sort,333,47,0.00239410
+Library Sort,333,48,0.00221790
+Library Sort,333,49,0.00198670
+Library Sort,333,50,0.00180390
+Library Sort,333,51,0.00159900
+Library Sort,333,52,0.00248190
+Library Sort,333,53,0.00201250
+Library Sort,333,54,0.00143040
+Library Sort,333,55,0.00166190
+Library Sort,333,56,0.00401510
+Library Sort,333,57,0.00389390
+Library Sort,333,58,0.00162410
+Library Sort,333,59,0.00188780
+Library Sort,333,60,0.00155940
+Library Sort,333,61,0.00184580
+Library Sort,333,62,0.00211220
+Library Sort,333,63,0.00205250
+Library Sort,333,64,0.00190880
+Library Sort,333,65,0.00193200
+Library Sort,333,66,0.00204480
+Library Sort,333,67,0.00177640
+Library Sort,333,68,0.00146550
+Library Sort,333,69,0.00210420
+Library Sort,333,70,0.00369640
+Library Sort,333,71,0.00153170
+Library Sort,333,72,0.00191290
+Library Sort,333,73,0.00182540
+Library Sort,333,74,0.00148780
+Library Sort,333,75,0.00156770
+Library Sort,333,76,0.00144670
+Library Sort,333,77,0.00167360
+Library Sort,333,78,0.00185500
+Library Sort,333,79,0.00301130
+Library Sort,333,80,0.00277800
+Library Sort,333,81,0.00227340
+Library Sort,333,82,0.00194870
+Library Sort,333,83,0.00219930
+Library Sort,333,84,0.00168650
+Library Sort,333,85,0.00262890
+Library Sort,333,86,0.00181230
+Library Sort,333,87,0.00209960
+Library Sort,333,88,0.00219650
+Library Sort,333,89,0.00276900
+Library Sort,333,90,0.00196960
+Library Sort,333,91,0.00194220
+Library Sort,333,92,0.00339340
+Library Sort,333,93,0.00184230
+Library Sort,333,94,0.00190710
+Library Sort,333,95,0.00180010
+Library Sort,333,96,0.00174850
+Library Sort,333,97,0.00154710
+Library Sort,333,98,0.00241180
+Library Sort,333,99,0.00267790
+Library Sort,333,100,0.00271680
+Library Sort,333,101,0.00183010
+Library Sort,333,102,0.00161870
+Library Sort,333,103,0.00170890
+Library Sort,333,104,0.00181700
+Library Sort,333,105,0.00232410
+Library Sort,333,106,0.00235490
+Library Sort,333,107,0.00154770
+Library Sort,333,108,0.00282030
+Library Sort,333,109,0.00154240
+Library Sort,333,110,0.00322310
+Library Sort,333,111,0.00159770
+Library Sort,333,112,0.00180540
+Library Sort,333,113,0.00365370
+Library Sort,333,114,0.00251810
+Library Sort,333,115,0.00231370
+Library Sort,333,116,0.00203880
+Library Sort,333,117,0.00180770
+Library Sort,333,118,0.00608560
+Library Sort,333,119,0.00303780
+Library Sort,333,120,0.00171970
+Library Sort,333,121,0.00339400
+Library Sort,333,122,0.00189700
+Library Sort,333,123,0.00291910
+Library Sort,333,124,0.00326190
+Library Sort,333,125,0.00188200
+Library Sort,333,126,0.00270600
+Library Sort,333,127,0.00177780
+Library Sort,333,128,0.00266450
+Library Sort,333,129,0.00208450
+Library Sort,333,130,0.00200460
+Library Sort,333,131,0.00163300
+Library Sort,333,132,0.00179390
+Library Sort,333,133,0.00242200
+Library Sort,333,134,0.00192630
+Library Sort,333,135,0.00182890
+Library Sort,333,136,0.00186330
+Library Sort,333,137,0.00212210
+Library Sort,333,138,0.00221870
+Library Sort,333,139,0.00162800
+Library Sort,333,140,0.00145380
+Library Sort,333,141,0.00149490
+Library Sort,333,142,0.00135820
+Library Sort,333,143,0.00351720
+Library Sort,333,144,0.00342970
+Library Sort,333,145,0.00151120
+Library Sort,333,146,0.00250980
+Library Sort,333,147,0.00225500
+Library Sort,333,148,0.00188330
+Library Sort,333,149,0.00153210
+Library Sort,333,150,0.00214510
+Library Sort,333,151,0.00180730
+Library Sort,333,152,0.00146910
+Library Sort,333,153,0.00306070
+Library Sort,333,154,0.00226940
+Library Sort,333,155,0.00194400
+Library Sort,333,156,0.00189430
+Library Sort,333,157,0.00197740
+Library Sort,333,158,0.00164630
+Library Sort,333,159,0.00356290
+Library Sort,333,160,0.00134350
+Library Sort,333,161,0.00347890
+Library Sort,333,162,0.00164130
+Library Sort,333,163,0.00212600
+Library Sort,333,164,0.00351910
+Library Sort,333,165,0.00199240
+Library Sort,333,166,0.00165410
+Library Sort,333,167,0.00173080
+Library Sort,333,168,0.00449350
+Library Sort,333,169,0.00182570
+Library Sort,333,170,0.00289080
+Library Sort,333,171,0.00142540
+Library Sort,333,172,0.00177020
+Library Sort,333,173,0.00272240
+Library Sort,333,174,0.00164760
+Library Sort,333,175,0.00238600
+Library Sort,333,176,0.00147220
+Library Sort,333,177,0.00298370
+Library Sort,333,178,0.00206390
+Library Sort,333,179,0.00212240
+Library Sort,333,180,0.00192210
+Library Sort,333,181,0.00407680
+Library Sort,333,182,0.00140850
+Library Sort,333,183,0.00152570
+Library Sort,333,184,0.00201570
+Library Sort,333,185,0.00223900
+Library Sort,333,186,0.00232220
+Library Sort,333,187,0.00211080
+Library Sort,333,188,0.00346810
+Library Sort,333,189,0.00189340
+Library Sort,333,190,0.00300920
+Library Sort,333,191,0.00262380
+Library Sort,333,192,0.00206370
+Library Sort,333,193,0.00211000
+Library Sort,333,194,0.00202070
+Library Sort,333,195,0.00134530
+Library Sort,333,196,0.00137280
+Library Sort,333,197,0.00184520
+Library Sort,333,198,0.00149570
+Library Sort,333,199,0.00243920
+Library Sort,333,200,0.00196150
+Library Sort,333,201,0.00166880
+Library Sort,333,202,0.00199970
+Library Sort,333,203,0.00251240
+Library Sort,333,204,0.00147080
+Library Sort,333,205,0.00202320
+Library Sort,333,206,0.00139440
+Library Sort,333,207,0.00140840
+Library Sort,333,208,0.00318830
+Library Sort,333,209,0.00208720
+Library Sort,333,210,0.00176540
+Library Sort,333,211,0.00143840
+Library Sort,333,212,0.00209980
+Library Sort,333,213,0.00280910
+Library Sort,333,214,0.00153360
+Library Sort,333,215,0.00236440
+Library Sort,333,216,0.00192740
+Library Sort,333,217,0.00246660
+Library Sort,333,218,0.00232810
+Library Sort,333,219,0.00209370
+Library Sort,333,220,0.00292950
+Library Sort,333,221,0.00301090
+Library Sort,333,222,0.00198840
+Library Sort,333,223,0.00140330
+Library Sort,333,224,0.00228860
+Library Sort,333,225,0.00200810
+Library Sort,333,226,0.00375220
+Library Sort,333,227,0.00293180
+Library Sort,333,228,0.00336970
+Library Sort,333,229,0.00203010
+Library Sort,333,230,0.00162310
+Library Sort,333,231,0.00189740
+Library Sort,333,232,0.00175840
+Library Sort,333,233,0.00389230
+Library Sort,333,234,0.00350560
+Library Sort,333,235,0.00156650
+Library Sort,333,236,0.00180320
+Library Sort,333,237,0.00216470
+Library Sort,333,238,0.00166880
+Library Sort,333,239,0.00158200
+Library Sort,333,240,0.00210980
+Library Sort,333,241,0.00225040
+Library Sort,333,242,0.00314480
+Library Sort,333,243,0.00175830
+Library Sort,333,244,0.00209710
+Library Sort,333,245,0.00190670
+Library Sort,333,246,0.00197500
+Library Sort,333,247,0.00281920
+Library Sort,333,248,0.00189230
+Library Sort,333,249,0.00236040
+Library Sort,333,250,0.00197180
+Library Sort,333,251,0.00242110
+Library Sort,333,252,0.00452840
+Library Sort,333,253,0.00231700
+Library Sort,333,254,0.00155240
+Library Sort,333,255,0.00238190
+Library Sort,333,256,0.00171590
+Library Sort,333,257,0.00234950
+Library Sort,333,258,0.00402890
+Library Sort,333,259,0.00176600
+Library Sort,333,260,0.00241360
+Library Sort,333,261,0.00213010
+Library Sort,333,262,0.00346380
+Library Sort,333,263,0.00160530
+Library Sort,333,264,0.00177090
+Library Sort,333,265,0.00215090
+Library Sort,333,266,0.00264390
+Library Sort,333,267,0.00166680
+Library Sort,333,268,0.00473550
+Library Sort,333,269,0.00149390
+Library Sort,333,270,0.00183960
+Library Sort,333,271,0.00609440
+Library Sort,333,272,0.00194030
+Library Sort,333,273,0.00283620
+Library Sort,333,274,0.00152590
+Library Sort,333,275,0.00205120
+Library Sort,333,276,0.00135050
+Library Sort,333,277,0.00287940
+Library Sort,333,278,0.00170800
+Library Sort,333,279,0.00145200
+Library Sort,333,280,0.00208730
+Library Sort,333,281,0.00188840
+Library Sort,333,282,0.00213280
+Library Sort,333,283,0.00126100
+Library Sort,333,284,0.00239340
+Library Sort,333,285,0.00416390
+Library Sort,333,286,0.00204030
+Library Sort,333,287,0.00313200
+Library Sort,333,288,0.00180000
+Library Sort,333,289,0.00263270
+Library Sort,333,290,0.00196550
+Library Sort,333,291,0.00130430
+Library Sort,333,292,0.00260760
+Library Sort,333,293,0.00325570
+Library Sort,333,294,0.00171480
+Library Sort,333,295,0.00198580
+Library Sort,333,296,0.00258090
+Library Sort,333,297,0.00180980
+Library Sort,333,298,0.00142890
+Library Sort,333,299,0.00212960
+Library Sort,333,300,0.00324050
+Library Sort,333,301,0.00231800
+Library Sort,333,302,0.00647660
+Library Sort,333,303,0.00216160
+Library Sort,333,304,0.00257490
+Library Sort,333,305,0.00147610
+Library Sort,333,306,0.00222860
+Library Sort,333,307,0.00199080
+Library Sort,333,308,0.00213360
+Library Sort,333,309,0.00338490
+Library Sort,333,310,0.00181920
+Library Sort,333,311,0.00165630
+Library Sort,333,312,0.00183590
+Library Sort,333,313,0.00381140
+Library Sort,333,314,0.00194380
+Library Sort,333,315,0.00156620
+Library Sort,333,316,0.00137670
+Library Sort,333,317,0.00186840
+Library Sort,333,318,0.00189300
+Library Sort,333,319,0.00552770
+Library Sort,333,320,0.00299280
+Library Sort,333,321,0.00326200
+Library Sort,333,322,0.00212730
+Library Sort,333,323,0.00163930
+Library Sort,333,324,0.00170030
+Library Sort,333,325,0.00116770
+Library Sort,333,326,0.00223730
+Library Sort,333,327,0.00157530
+Library Sort,333,328,0.00291400
+Library Sort,333,329,0.00169830
+Library Sort,333,330,0.00179970
+Library Sort,333,331,0.00258880
+Library Sort,333,332,0.00391750
+Library Sort,333,333,0.00168140
+Library Sort,333,334,0.00215030
+Library Sort,333,335,0.00165780
+Library Sort,333,336,0.00220490
+Library Sort,333,337,0.00316330
+Library Sort,333,338,0.00298270
+Library Sort,333,339,0.00210910
+Library Sort,333,340,0.00232500
+Library Sort,333,341,0.00165730
+Library Sort,333,342,0.00233920
+Library Sort,333,343,0.00296990
+Library Sort,333,344,0.00199120
+Library Sort,333,345,0.00404960
+Library Sort,333,346,0.00657180
+Library Sort,333,347,0.00231960
+Library Sort,333,348,0.00230410
+Library Sort,333,349,0.00423630
+Library Sort,333,350,0.00168340
+Library Sort,333,351,0.00183820
+Library Sort,333,352,0.00444300
+Library Sort,333,353,0.00238730
+Library Sort,333,354,0.00194110
+Library Sort,333,355,0.00192040
+Library Sort,333,356,0.00189270
+Library Sort,333,357,0.00168740
+Library Sort,333,358,0.00323830
+Library Sort,333,359,0.00305470
+Library Sort,333,360,0.00149020
+Library Sort,333,361,0.00174490
+Library Sort,333,362,0.00523350
+Library Sort,333,363,0.00185980
+Library Sort,333,364,0.00221680
+Library Sort,333,365,0.00254310
+Library Sort,333,366,0.00192740
+Library Sort,333,367,0.00414360
+Library Sort,333,368,0.00347440
+Library Sort,333,369,0.00249620
+Library Sort,333,370,0.00468910
+Library Sort,333,371,0.00285480
+Library Sort,333,372,0.00166210
+Library Sort,333,373,0.00198210
+Library Sort,333,374,0.00200960
+Library Sort,333,375,0.00328640
+Library Sort,333,376,0.00129780
+Library Sort,333,377,0.00432640
+Library Sort,333,378,0.00361270
+Library Sort,333,379,0.00235180
+Library Sort,333,380,0.00144320
+Library Sort,333,381,0.00291370
+Library Sort,333,382,0.00211940
+Library Sort,333,383,0.00216040
+Library Sort,333,384,0.00484270
+Library Sort,333,385,0.00154750
+Library Sort,333,386,0.00131140
+Library Sort,333,387,0.00137280
+Library Sort,333,388,0.00191340
+Library Sort,333,389,0.00305730
+Library Sort,333,390,0.00313680
+Library Sort,333,391,0.00226740
+Library Sort,333,392,0.00271920
+Library Sort,333,393,0.00201120
+Library Sort,333,394,0.00151020
+Library Sort,333,395,0.00156160
+Library Sort,333,396,0.00112760
+Library Sort,333,397,0.00158190
+Library Sort,333,398,0.00211440
+Library Sort,333,399,0.00172860
+Library Sort,333,400,0.00118520
+Library Sort,333,401,0.00163100
+Library Sort,333,402,0.00182230
+Library Sort,333,403,0.00173860
+Library Sort,333,404,0.00178120
+Library Sort,333,405,0.00213760
+Library Sort,333,406,0.00172000
+Library Sort,333,407,0.00181450
+Library Sort,333,408,0.00381780
+Library Sort,333,409,0.00133240
+Library Sort,333,410,0.00213990
+Library Sort,333,411,0.00242220
+Library Sort,333,412,0.00184940
+Library Sort,333,413,0.00211720
+Library Sort,333,414,0.00395980
+Library Sort,333,415,0.00231610
+Library Sort,333,416,0.00728190
+Library Sort,333,417,0.00263500
+Library Sort,333,418,0.00336710
+Library Sort,333,419,0.00245640
+Library Sort,333,420,0.00232290
+Library Sort,333,421,0.00250620
+Library Sort,333,422,0.00216190
+Library Sort,333,423,0.00188740
+Library Sort,333,424,0.00178710
+Library Sort,333,425,0.00365860
+Library Sort,333,426,0.00101810
+Library Sort,333,427,0.00280930
+Library Sort,333,428,0.00209190
+Library Sort,333,429,0.00253850
+Library Sort,333,430,0.00191430
+Library Sort,333,431,0.00157440
+Library Sort,333,432,0.00304510
+Library Sort,333,433,0.00191230
+Library Sort,333,434,0.00244520
+Library Sort,333,435,0.00171830
+Library Sort,333,436,0.00247900
+Library Sort,333,437,0.00118090
+Library Sort,333,438,0.00217690
+Library Sort,333,439,0.00336690
+Library Sort,333,440,0.00306840
+Library Sort,333,441,0.00177630
+Library Sort,333,442,0.00175920
+Library Sort,333,443,0.00183080
+Library Sort,333,444,0.00209730
+Library Sort,333,445,0.00321250
+Library Sort,333,446,0.00325510
+Library Sort,333,447,0.00276810
+Library Sort,333,448,0.00373090
+Library Sort,333,449,0.00212340
+Library Sort,333,450,0.00410370
+Library Sort,333,451,0.00147730
+Library Sort,333,452,0.00139550
+Library Sort,333,453,0.00375310
+Library Sort,333,454,0.00161070
+Library Sort,333,455,0.00222000
+Library Sort,333,456,0.00232780
+Library Sort,333,457,0.00209260
+Library Sort,333,458,0.00301810
+Library Sort,333,459,0.00259090
+Library Sort,333,460,0.00341290
+Library Sort,333,461,0.00291300
+Library Sort,333,462,0.00150850
+Library Sort,333,463,0.00149500
+Library Sort,333,464,0.00277280
+Library Sort,333,465,0.00379760
+Library Sort,333,466,0.00189780
+Library Sort,333,467,0.00402580
+Library Sort,333,468,0.00336820
+Library Sort,333,469,0.00193270
+Library Sort,333,470,0.00176170
+Library Sort,333,471,0.00251120
+Library Sort,333,472,0.00219460
+Library Sort,333,473,0.00298660
+Library Sort,333,474,0.00210660
+Library Sort,333,475,0.00205470
+Library Sort,333,476,0.00371830
+Library Sort,333,477,0.00346170
+Library Sort,333,478,0.00233450
+Library Sort,333,479,0.00122760
+Library Sort,333,480,0.00183490
+Library Sort,333,481,0.00178690
+Library Sort,333,482,0.00225530
+Library Sort,333,483,0.00188480
+Library Sort,333,484,0.00190380
+Library Sort,333,485,0.00185730
+Library Sort,333,486,0.00657330
+Library Sort,333,487,0.00243630
+Library Sort,333,488,0.00232130
+Library Sort,333,489,0.00391430
+Library Sort,333,490,0.00366260
+Library Sort,333,491,0.00218940
+Library Sort,333,492,0.00377360
+Library Sort,333,493,0.00223140
+Library Sort,333,494,0.00292050
+Library Sort,333,495,0.00155260
+Library Sort,333,496,0.00159920
+Library Sort,333,497,0.00159450
+Library Sort,333,498,0.00224520
+Library Sort,333,499,0.00197320
+Library Sort,333,500,0.00213250
+MSD Radix Sort,333,1,0.00072670
+MSD Radix Sort,333,2,0.00054750
+MSD Radix Sort,333,3,0.00068610
+MSD Radix Sort,333,4,0.00054470
+MSD Radix Sort,333,5,0.00059480
+MSD Radix Sort,333,6,0.00041880
+MSD Radix Sort,333,7,0.00057290
+MSD Radix Sort,333,8,0.00060800
+MSD Radix Sort,333,9,0.00061010
+MSD Radix Sort,333,10,0.00061030
+MSD Radix Sort,333,11,0.00055420
+MSD Radix Sort,333,12,0.00056000
+MSD Radix Sort,333,13,0.00060320
+MSD Radix Sort,333,14,0.00033450
+MSD Radix Sort,333,15,0.00059570
+MSD Radix Sort,333,16,0.00058200
+MSD Radix Sort,333,17,0.00041520
+MSD Radix Sort,333,18,0.00064160
+MSD Radix Sort,333,19,0.00061420
+MSD Radix Sort,333,20,0.00042840
+MSD Radix Sort,333,21,0.00056510
+MSD Radix Sort,333,22,0.00063150
+MSD Radix Sort,333,23,0.00034730
+MSD Radix Sort,333,24,0.00062350
+MSD Radix Sort,333,25,0.00061370
+MSD Radix Sort,333,26,0.00060840
+MSD Radix Sort,333,27,0.00066930
+MSD Radix Sort,333,28,0.00041730
+MSD Radix Sort,333,29,0.00058280
+MSD Radix Sort,333,30,0.00058800
+MSD Radix Sort,333,31,0.00060030
+MSD Radix Sort,333,32,0.00056710
+MSD Radix Sort,333,33,0.00057950
+MSD Radix Sort,333,34,0.00035220
+MSD Radix Sort,333,35,0.00063360
+MSD Radix Sort,333,36,0.00035410
+MSD Radix Sort,333,37,0.00057710
+MSD Radix Sort,333,38,0.00035380
+MSD Radix Sort,333,39,0.00058500
+MSD Radix Sort,333,40,0.00063220
+MSD Radix Sort,333,41,0.00065370
+MSD Radix Sort,333,42,0.00063810
+MSD Radix Sort,333,43,0.00065440
+MSD Radix Sort,333,44,0.00053830
+MSD Radix Sort,333,45,0.00062650
+MSD Radix Sort,333,46,0.00033050
+MSD Radix Sort,333,47,0.00057700
+MSD Radix Sort,333,48,0.00063820
+MSD Radix Sort,333,49,0.00059110
+MSD Radix Sort,333,50,0.00063760
+MSD Radix Sort,333,51,0.00056900
+MSD Radix Sort,333,52,0.00057210
+MSD Radix Sort,333,53,0.00064130
+MSD Radix Sort,333,54,0.00038700
+MSD Radix Sort,333,55,0.00058080
+MSD Radix Sort,333,56,0.00067250
+MSD Radix Sort,333,57,0.00061090
+MSD Radix Sort,333,58,0.00062480
+MSD Radix Sort,333,59,0.00043470
+MSD Radix Sort,333,60,0.00042340
+MSD Radix Sort,333,61,0.00061790
+MSD Radix Sort,333,62,0.00060210
+MSD Radix Sort,333,63,0.00065530
+MSD Radix Sort,333,64,0.00059900
+MSD Radix Sort,333,65,0.00061430
+MSD Radix Sort,333,66,0.00037670
+MSD Radix Sort,333,67,0.00056760
+MSD Radix Sort,333,68,0.00042420
+MSD Radix Sort,333,69,0.00059390
+MSD Radix Sort,333,70,0.00034860
+MSD Radix Sort,333,71,0.00058860
+MSD Radix Sort,333,72,0.00062300
+MSD Radix Sort,333,73,0.00040510
+MSD Radix Sort,333,74,0.00056940
+MSD Radix Sort,333,75,0.00066820
+MSD Radix Sort,333,76,0.00067840
+MSD Radix Sort,333,77,0.00058300
+MSD Radix Sort,333,78,0.00043770
+MSD Radix Sort,333,79,0.00058190
+MSD Radix Sort,333,80,0.00064860
+MSD Radix Sort,333,81,0.00043390
+MSD Radix Sort,333,82,0.00059000
+MSD Radix Sort,333,83,0.00056710
+MSD Radix Sort,333,84,0.00057090
+MSD Radix Sort,333,85,0.00063930
+MSD Radix Sort,333,86,0.00056830
+MSD Radix Sort,333,87,0.00059680
+MSD Radix Sort,333,88,0.00064450
+MSD Radix Sort,333,89,0.00059310
+MSD Radix Sort,333,90,0.00056550
+MSD Radix Sort,333,91,0.00062320
+MSD Radix Sort,333,92,0.00058330
+MSD Radix Sort,333,93,0.00060250
+MSD Radix Sort,333,94,0.00062440
+MSD Radix Sort,333,95,0.00044780
+MSD Radix Sort,333,96,0.00066480
+MSD Radix Sort,333,97,0.00048800
+MSD Radix Sort,333,98,0.00057990
+MSD Radix Sort,333,99,0.00062120
+MSD Radix Sort,333,100,0.00061370
+MSD Radix Sort,333,101,0.00056350
+MSD Radix Sort,333,102,0.00064950
+MSD Radix Sort,333,103,0.00043530
+MSD Radix Sort,333,104,0.00057330
+MSD Radix Sort,333,105,0.00055190
+MSD Radix Sort,333,106,0.00055670
+MSD Radix Sort,333,107,0.00067110
+MSD Radix Sort,333,108,0.00036540
+MSD Radix Sort,333,109,0.00062150
+MSD Radix Sort,333,110,0.00066360
+MSD Radix Sort,333,111,0.00066130
+MSD Radix Sort,333,112,0.00067590
+MSD Radix Sort,333,113,0.00061560
+MSD Radix Sort,333,114,0.00056540
+MSD Radix Sort,333,115,0.00058040
+MSD Radix Sort,333,116,0.00058020
+MSD Radix Sort,333,117,0.00062160
+MSD Radix Sort,333,118,0.00064660
+MSD Radix Sort,333,119,0.00059840
+MSD Radix Sort,333,120,0.00062360
+MSD Radix Sort,333,121,0.00060580
+MSD Radix Sort,333,122,0.00067410
+MSD Radix Sort,333,123,0.00070930
+MSD Radix Sort,333,124,0.00052300
+MSD Radix Sort,333,125,0.00061520
+MSD Radix Sort,333,126,0.00059010
+MSD Radix Sort,333,127,0.00051500
+MSD Radix Sort,333,128,0.00044370
+MSD Radix Sort,333,129,0.00049850
+MSD Radix Sort,333,130,0.00056950
+MSD Radix Sort,333,131,0.00054470
+MSD Radix Sort,333,132,0.00047830
+MSD Radix Sort,333,133,0.00042530
+MSD Radix Sort,333,134,0.00055100
+MSD Radix Sort,333,135,0.00061700
+MSD Radix Sort,333,136,0.00062730
+MSD Radix Sort,333,137,0.00059150
+MSD Radix Sort,333,138,0.00061990
+MSD Radix Sort,333,139,0.00063560
+MSD Radix Sort,333,140,0.00047220
+MSD Radix Sort,333,141,0.00054610
+MSD Radix Sort,333,142,0.00055720
+MSD Radix Sort,333,143,0.00042320
+MSD Radix Sort,333,144,0.00064360
+MSD Radix Sort,333,145,0.00057840
+MSD Radix Sort,333,146,0.00057520
+MSD Radix Sort,333,147,0.00067710
+MSD Radix Sort,333,148,0.00060450
+MSD Radix Sort,333,149,0.00066880
+MSD Radix Sort,333,150,0.00057740
+MSD Radix Sort,333,151,0.00060440
+MSD Radix Sort,333,152,0.00058520
+MSD Radix Sort,333,153,0.00062180
+MSD Radix Sort,333,154,0.00064720
+MSD Radix Sort,333,155,0.00066440
+MSD Radix Sort,333,156,0.00058290
+MSD Radix Sort,333,157,0.00058050
+MSD Radix Sort,333,158,0.00064700
+MSD Radix Sort,333,159,0.00061770
+MSD Radix Sort,333,160,0.00040630
+MSD Radix Sort,333,161,0.00054380
+MSD Radix Sort,333,162,0.00058480
+MSD Radix Sort,333,163,0.00055130
+MSD Radix Sort,333,164,0.00061340
+MSD Radix Sort,333,165,0.00059740
+MSD Radix Sort,333,166,0.00062130
+MSD Radix Sort,333,167,0.00065160
+MSD Radix Sort,333,168,0.00067170
+MSD Radix Sort,333,169,0.00064800
+MSD Radix Sort,333,170,0.00065990
+MSD Radix Sort,333,171,0.00063950
+MSD Radix Sort,333,172,0.00064530
+MSD Radix Sort,333,173,0.00058020
+MSD Radix Sort,333,174,0.00062940
+MSD Radix Sort,333,175,0.00048670
+MSD Radix Sort,333,176,0.00055830
+MSD Radix Sort,333,177,0.00068320
+MSD Radix Sort,333,178,0.00056620
+MSD Radix Sort,333,179,0.00057420
+MSD Radix Sort,333,180,0.00058060
+MSD Radix Sort,333,181,0.00041710
+MSD Radix Sort,333,182,0.00058730
+MSD Radix Sort,333,183,0.00070310
+MSD Radix Sort,333,184,0.00055890
+MSD Radix Sort,333,185,0.00033590
+MSD Radix Sort,333,186,0.00053920
+MSD Radix Sort,333,187,0.00070660
+MSD Radix Sort,333,188,0.00058850
+MSD Radix Sort,333,189,0.00057040
+MSD Radix Sort,333,190,0.00056190
+MSD Radix Sort,333,191,0.00061910
+MSD Radix Sort,333,192,0.00061730
+MSD Radix Sort,333,193,0.00039790
+MSD Radix Sort,333,194,0.00058200
+MSD Radix Sort,333,195,0.00068380
+MSD Radix Sort,333,196,0.00056090
+MSD Radix Sort,333,197,0.00069720
+MSD Radix Sort,333,198,0.00059080
+MSD Radix Sort,333,199,0.00057970
+MSD Radix Sort,333,200,0.00058830
+MSD Radix Sort,333,201,0.00051610
+MSD Radix Sort,333,202,0.00064960
+MSD Radix Sort,333,203,0.00037520
+MSD Radix Sort,333,204,0.00048510
+MSD Radix Sort,333,205,0.00062810
+MSD Radix Sort,333,206,0.00059820
+MSD Radix Sort,333,207,0.00061440
+MSD Radix Sort,333,208,0.00059240
+MSD Radix Sort,333,209,0.00066130
+MSD Radix Sort,333,210,0.00057870
+MSD Radix Sort,333,211,0.00063440
+MSD Radix Sort,333,212,0.00057810
+MSD Radix Sort,333,213,0.00066310
+MSD Radix Sort,333,214,0.00048960
+MSD Radix Sort,333,215,0.00059400
+MSD Radix Sort,333,216,0.00051540
+MSD Radix Sort,333,217,0.00055400
+MSD Radix Sort,333,218,0.00063220
+MSD Radix Sort,333,219,0.00061710
+MSD Radix Sort,333,220,0.00057170
+MSD Radix Sort,333,221,0.00058910
+MSD Radix Sort,333,222,0.00058570
+MSD Radix Sort,333,223,0.00067120
+MSD Radix Sort,333,224,0.00065650
+MSD Radix Sort,333,225,0.00056170
+MSD Radix Sort,333,226,0.00067200
+MSD Radix Sort,333,227,0.00060120
+MSD Radix Sort,333,228,0.00054760
+MSD Radix Sort,333,229,0.00042500
+MSD Radix Sort,333,230,0.00036790
+MSD Radix Sort,333,231,0.00066350
+MSD Radix Sort,333,232,0.00059930
+MSD Radix Sort,333,233,0.00048520
+MSD Radix Sort,333,234,0.00052840
+MSD Radix Sort,333,235,0.00059170
+MSD Radix Sort,333,236,0.00057840
+MSD Radix Sort,333,237,0.00054560
+MSD Radix Sort,333,238,0.00063260
+MSD Radix Sort,333,239,0.00044980
+MSD Radix Sort,333,240,0.00064500
+MSD Radix Sort,333,241,0.00059830
+MSD Radix Sort,333,242,0.00059390
+MSD Radix Sort,333,243,0.00064120
+MSD Radix Sort,333,244,0.00057570
+MSD Radix Sort,333,245,0.00058910
+MSD Radix Sort,333,246,0.00064610
+MSD Radix Sort,333,247,0.00059210
+MSD Radix Sort,333,248,0.00043020
+MSD Radix Sort,333,249,0.00064610
+MSD Radix Sort,333,250,0.00036230
+MSD Radix Sort,333,251,0.00056980
+MSD Radix Sort,333,252,0.00058460
+MSD Radix Sort,333,253,0.00040370
+MSD Radix Sort,333,254,0.00057110
+MSD Radix Sort,333,255,0.00061500
+MSD Radix Sort,333,256,0.00057880
+MSD Radix Sort,333,257,0.00062960
+MSD Radix Sort,333,258,0.00064590
+MSD Radix Sort,333,259,0.00058870
+MSD Radix Sort,333,260,0.00053900
+MSD Radix Sort,333,261,0.00057020
+MSD Radix Sort,333,262,0.00040940
+MSD Radix Sort,333,263,0.00059920
+MSD Radix Sort,333,264,0.00063570
+MSD Radix Sort,333,265,0.00056060
+MSD Radix Sort,333,266,0.00057460
+MSD Radix Sort,333,267,0.00068760
+MSD Radix Sort,333,268,0.00059040
+MSD Radix Sort,333,269,0.00046330
+MSD Radix Sort,333,270,0.00042990
+MSD Radix Sort,333,271,0.00062820
+MSD Radix Sort,333,272,0.00057650
+MSD Radix Sort,333,273,0.00048640
+MSD Radix Sort,333,274,0.00063520
+MSD Radix Sort,333,275,0.00055540
+MSD Radix Sort,333,276,0.00057640
+MSD Radix Sort,333,277,0.00065930
+MSD Radix Sort,333,278,0.00036100
+MSD Radix Sort,333,279,0.00057220
+MSD Radix Sort,333,280,0.00044200
+MSD Radix Sort,333,281,0.00056800
+MSD Radix Sort,333,282,0.00062470
+MSD Radix Sort,333,283,0.00060650
+MSD Radix Sort,333,284,0.00054840
+MSD Radix Sort,333,285,0.00056820
+MSD Radix Sort,333,286,0.00061890
+MSD Radix Sort,333,287,0.00060340
+MSD Radix Sort,333,288,0.00055660
+MSD Radix Sort,333,289,0.00050040
+MSD Radix Sort,333,290,0.00056260
+MSD Radix Sort,333,291,0.00048480
+MSD Radix Sort,333,292,0.00034190
+MSD Radix Sort,333,293,0.00063260
+MSD Radix Sort,333,294,0.00054840
+MSD Radix Sort,333,295,0.00044930
+MSD Radix Sort,333,296,0.00057110
+MSD Radix Sort,333,297,0.00034290
+MSD Radix Sort,333,298,0.00048510
+MSD Radix Sort,333,299,0.00060390
+MSD Radix Sort,333,300,0.00065510
+MSD Radix Sort,333,301,0.00060910
+MSD Radix Sort,333,302,0.00060980
+MSD Radix Sort,333,303,0.00055720
+MSD Radix Sort,333,304,0.00041780
+MSD Radix Sort,333,305,0.00068350
+MSD Radix Sort,333,306,0.00045960
+MSD Radix Sort,333,307,0.00059360
+MSD Radix Sort,333,308,0.00055900
+MSD Radix Sort,333,309,0.00051430
+MSD Radix Sort,333,310,0.00057530
+MSD Radix Sort,333,311,0.00056970
+MSD Radix Sort,333,312,0.00058150
+MSD Radix Sort,333,313,0.00060230
+MSD Radix Sort,333,314,0.00050150
+MSD Radix Sort,333,315,0.00055290
+MSD Radix Sort,333,316,0.00037750
+MSD Radix Sort,333,317,0.00040450
+MSD Radix Sort,333,318,0.00058720
+MSD Radix Sort,333,319,0.00057700
+MSD Radix Sort,333,320,0.00057660
+MSD Radix Sort,333,321,0.00060570
+MSD Radix Sort,333,322,0.00043190
+MSD Radix Sort,333,323,0.00057900
+MSD Radix Sort,333,324,0.00061120
+MSD Radix Sort,333,325,0.00058890
+MSD Radix Sort,333,326,0.00051510
+MSD Radix Sort,333,327,0.00057020
+MSD Radix Sort,333,328,0.00037520
+MSD Radix Sort,333,329,0.00060830
+MSD Radix Sort,333,330,0.00058480
+MSD Radix Sort,333,331,0.00046610
+MSD Radix Sort,333,332,0.00061930
+MSD Radix Sort,333,333,0.00063360
+MSD Radix Sort,333,334,0.00062390
+MSD Radix Sort,333,335,0.00059190
+MSD Radix Sort,333,336,0.00059100
+MSD Radix Sort,333,337,0.00040770
+MSD Radix Sort,333,338,0.00056160
+MSD Radix Sort,333,339,0.00060590
+MSD Radix Sort,333,340,0.00047570
+MSD Radix Sort,333,341,0.00051340
+MSD Radix Sort,333,342,0.00041720
+MSD Radix Sort,333,343,0.00057350
+MSD Radix Sort,333,344,0.00058000
+MSD Radix Sort,333,345,0.00056340
+MSD Radix Sort,333,346,0.00038410
+MSD Radix Sort,333,347,0.00058560
+MSD Radix Sort,333,348,0.00060660
+MSD Radix Sort,333,349,0.00058800
+MSD Radix Sort,333,350,0.00058400
+MSD Radix Sort,333,351,0.00052180
+MSD Radix Sort,333,352,0.00058120
+MSD Radix Sort,333,353,0.00061300
+MSD Radix Sort,333,354,0.00060460
+MSD Radix Sort,333,355,0.00060010
+MSD Radix Sort,333,356,0.00057800
+MSD Radix Sort,333,357,0.00038540
+MSD Radix Sort,333,358,0.00044230
+MSD Radix Sort,333,359,0.00060940
+MSD Radix Sort,333,360,0.00061640
+MSD Radix Sort,333,361,0.00061060
+MSD Radix Sort,333,362,0.00066840
+MSD Radix Sort,333,363,0.00070760
+MSD Radix Sort,333,364,0.00048700
+MSD Radix Sort,333,365,0.00063510
+MSD Radix Sort,333,366,0.00058380
+MSD Radix Sort,333,367,0.00065230
+MSD Radix Sort,333,368,0.00059220
+MSD Radix Sort,333,369,0.00055830
+MSD Radix Sort,333,370,0.00055570
+MSD Radix Sort,333,371,0.00054330
+MSD Radix Sort,333,372,0.00062570
+MSD Radix Sort,333,373,0.00062580
+MSD Radix Sort,333,374,0.00059700
+MSD Radix Sort,333,375,0.00056810
+MSD Radix Sort,333,376,0.00058250
+MSD Radix Sort,333,377,0.00059570
+MSD Radix Sort,333,378,0.00060530
+MSD Radix Sort,333,379,0.00057210
+MSD Radix Sort,333,380,0.00061730
+MSD Radix Sort,333,381,0.00064200
+MSD Radix Sort,333,382,0.00055240
+MSD Radix Sort,333,383,0.00063730
+MSD Radix Sort,333,384,0.00057540
+MSD Radix Sort,333,385,0.00055320
+MSD Radix Sort,333,386,0.00058910
+MSD Radix Sort,333,387,0.00058330
+MSD Radix Sort,333,388,0.00060100
+MSD Radix Sort,333,389,0.00056830
+MSD Radix Sort,333,390,0.00065830
+MSD Radix Sort,333,391,0.00059090
+MSD Radix Sort,333,392,0.00060580
+MSD Radix Sort,333,393,0.00066240
+MSD Radix Sort,333,394,0.00068290
+MSD Radix Sort,333,395,0.00056060
+MSD Radix Sort,333,396,0.00059310
+MSD Radix Sort,333,397,0.00061070
+MSD Radix Sort,333,398,0.00063780
+MSD Radix Sort,333,399,0.00056810
+MSD Radix Sort,333,400,0.00037770
+MSD Radix Sort,333,401,0.00056890
+MSD Radix Sort,333,402,0.00064540
+MSD Radix Sort,333,403,0.00060090
+MSD Radix Sort,333,404,0.00035950
+MSD Radix Sort,333,405,0.00049220
+MSD Radix Sort,333,406,0.00069800
+MSD Radix Sort,333,407,0.00049190
+MSD Radix Sort,333,408,0.00059410
+MSD Radix Sort,333,409,0.00058270
+MSD Radix Sort,333,410,0.00056650
+MSD Radix Sort,333,411,0.00054220
+MSD Radix Sort,333,412,0.00062320
+MSD Radix Sort,333,413,0.00057380
+MSD Radix Sort,333,414,0.00059650
+MSD Radix Sort,333,415,0.00039370
+MSD Radix Sort,333,416,0.00060550
+MSD Radix Sort,333,417,0.00054980
+MSD Radix Sort,333,418,0.00057780
+MSD Radix Sort,333,419,0.00063900
+MSD Radix Sort,333,420,0.00033820
+MSD Radix Sort,333,421,0.00066640
+MSD Radix Sort,333,422,0.00051940
+MSD Radix Sort,333,423,0.00055860
+MSD Radix Sort,333,424,0.00057740
+MSD Radix Sort,333,425,0.00061480
+MSD Radix Sort,333,426,0.00062980
+MSD Radix Sort,333,427,0.00061500
+MSD Radix Sort,333,428,0.00062830
+MSD Radix Sort,333,429,0.00042470
+MSD Radix Sort,333,430,0.00035510
+MSD Radix Sort,333,431,0.00054910
+MSD Radix Sort,333,432,0.00065550
+MSD Radix Sort,333,433,0.00052640
+MSD Radix Sort,333,434,0.00061010
+MSD Radix Sort,333,435,0.00062310
+MSD Radix Sort,333,436,0.00056170
+MSD Radix Sort,333,437,0.00057940
+MSD Radix Sort,333,438,0.00059290
+MSD Radix Sort,333,439,0.00070000
+MSD Radix Sort,333,440,0.00057660
+MSD Radix Sort,333,441,0.00054990
+MSD Radix Sort,333,442,0.00052530
+MSD Radix Sort,333,443,0.00061150
+MSD Radix Sort,333,444,0.00058960
+MSD Radix Sort,333,445,0.00064010
+MSD Radix Sort,333,446,0.00056760
+MSD Radix Sort,333,447,0.00055150
+MSD Radix Sort,333,448,0.00063290
+MSD Radix Sort,333,449,0.00058330
+MSD Radix Sort,333,450,0.00056620
+MSD Radix Sort,333,451,0.00062640
+MSD Radix Sort,333,452,0.00062370
+MSD Radix Sort,333,453,0.00055290
+MSD Radix Sort,333,454,0.00064080
+MSD Radix Sort,333,455,0.00063130
+MSD Radix Sort,333,456,0.00067680
+MSD Radix Sort,333,457,0.00058790
+MSD Radix Sort,333,458,0.00057150
+MSD Radix Sort,333,459,0.00062970
+MSD Radix Sort,333,460,0.00058480
+MSD Radix Sort,333,461,0.00055380
+MSD Radix Sort,333,462,0.00046250
+MSD Radix Sort,333,463,0.00060300
+MSD Radix Sort,333,464,0.00053250
+MSD Radix Sort,333,465,0.00055730
+MSD Radix Sort,333,466,0.00054020
+MSD Radix Sort,333,467,0.00052280
+MSD Radix Sort,333,468,0.00059510
+MSD Radix Sort,333,469,0.00058760
+MSD Radix Sort,333,470,0.00044280
+MSD Radix Sort,333,471,0.00058780
+MSD Radix Sort,333,472,0.00037260
+MSD Radix Sort,333,473,0.00047240
+MSD Radix Sort,333,474,0.00059140
+MSD Radix Sort,333,475,0.00056120
+MSD Radix Sort,333,476,0.00035710
+MSD Radix Sort,333,477,0.00059710
+MSD Radix Sort,333,478,0.00057490
+MSD Radix Sort,333,479,0.00046810
+MSD Radix Sort,333,480,0.00058860
+MSD Radix Sort,333,481,0.00060960
+MSD Radix Sort,333,482,0.00042150
+MSD Radix Sort,333,483,0.00055660
+MSD Radix Sort,333,484,0.00064790
+MSD Radix Sort,333,485,0.00062920
+MSD Radix Sort,333,486,0.00060250
+MSD Radix Sort,333,487,0.00059560
+MSD Radix Sort,333,488,0.00062470
+MSD Radix Sort,333,489,0.00057830
+MSD Radix Sort,333,490,0.00066450
+MSD Radix Sort,333,491,0.00051360
+MSD Radix Sort,333,492,0.00058780
+MSD Radix Sort,333,493,0.00059260
+MSD Radix Sort,333,494,0.00069390
+MSD Radix Sort,333,495,0.00064590
+MSD Radix Sort,333,496,0.00065960
+MSD Radix Sort,333,497,0.00056440
+MSD Radix Sort,333,498,0.00065020
+MSD Radix Sort,333,499,0.00061720
+MSD Radix Sort,333,500,0.00061230
+MSD Radix Sort In-Place,333,1,0.00069740
+MSD Radix Sort In-Place,333,2,0.00061820
+MSD Radix Sort In-Place,333,3,0.00057660
+MSD Radix Sort In-Place,333,4,0.00063630
+MSD Radix Sort In-Place,333,5,0.00048080
+MSD Radix Sort In-Place,333,6,0.00066960
+MSD Radix Sort In-Place,333,7,0.00066280
+MSD Radix Sort In-Place,333,8,0.00066870
+MSD Radix Sort In-Place,333,9,0.00063020
+MSD Radix Sort In-Place,333,10,0.00060770
+MSD Radix Sort In-Place,333,11,0.00046970
+MSD Radix Sort In-Place,333,12,0.00042100
+MSD Radix Sort In-Place,333,13,0.00061460
+MSD Radix Sort In-Place,333,14,0.00039050
+MSD Radix Sort In-Place,333,15,0.00060210
+MSD Radix Sort In-Place,333,16,0.00056650
+MSD Radix Sort In-Place,333,17,0.00063190
+MSD Radix Sort In-Place,333,18,0.00063210
+MSD Radix Sort In-Place,333,19,0.00047270
+MSD Radix Sort In-Place,333,20,0.00061740
+MSD Radix Sort In-Place,333,21,0.00063640
+MSD Radix Sort In-Place,333,22,0.00067110
+MSD Radix Sort In-Place,333,23,0.00049460
+MSD Radix Sort In-Place,333,24,0.00039710
+MSD Radix Sort In-Place,333,25,0.00050900
+MSD Radix Sort In-Place,333,26,0.00060700
+MSD Radix Sort In-Place,333,27,0.00036680
+MSD Radix Sort In-Place,333,28,0.00061410
+MSD Radix Sort In-Place,333,29,0.00060800
+MSD Radix Sort In-Place,333,30,0.00064320
+MSD Radix Sort In-Place,333,31,0.00036910
+MSD Radix Sort In-Place,333,32,0.00064190
+MSD Radix Sort In-Place,333,33,0.00065330
+MSD Radix Sort In-Place,333,34,0.00063570
+MSD Radix Sort In-Place,333,35,0.00064990
+MSD Radix Sort In-Place,333,36,0.00061440
+MSD Radix Sort In-Place,333,37,0.00038590
+MSD Radix Sort In-Place,333,38,0.00063280
+MSD Radix Sort In-Place,333,39,0.00063430
+MSD Radix Sort In-Place,333,40,0.00066040
+MSD Radix Sort In-Place,333,41,0.00063770
+MSD Radix Sort In-Place,333,42,0.00065380
+MSD Radix Sort In-Place,333,43,0.00065710
+MSD Radix Sort In-Place,333,44,0.00055820
+MSD Radix Sort In-Place,333,45,0.00070690
+MSD Radix Sort In-Place,333,46,0.00065630
+MSD Radix Sort In-Place,333,47,0.00042060
+MSD Radix Sort In-Place,333,48,0.00065360
+MSD Radix Sort In-Place,333,49,0.00060310
+MSD Radix Sort In-Place,333,50,0.00047770
+MSD Radix Sort In-Place,333,51,0.00045540
+MSD Radix Sort In-Place,333,52,0.00058090
+MSD Radix Sort In-Place,333,53,0.00065270
+MSD Radix Sort In-Place,333,54,0.00046870
+MSD Radix Sort In-Place,333,55,0.00076230
+MSD Radix Sort In-Place,333,56,0.00060020
+MSD Radix Sort In-Place,333,57,0.00038510
+MSD Radix Sort In-Place,333,58,0.00039850
+MSD Radix Sort In-Place,333,59,0.00069180
+MSD Radix Sort In-Place,333,60,0.00047370
+MSD Radix Sort In-Place,333,61,0.00067400
+MSD Radix Sort In-Place,333,62,0.00060460
+MSD Radix Sort In-Place,333,63,0.00054450
+MSD Radix Sort In-Place,333,64,0.00064410
+MSD Radix Sort In-Place,333,65,0.00061050
+MSD Radix Sort In-Place,333,66,0.00064010
+MSD Radix Sort In-Place,333,67,0.00037410
+MSD Radix Sort In-Place,333,68,0.00065490
+MSD Radix Sort In-Place,333,69,0.00054090
+MSD Radix Sort In-Place,333,70,0.00050960
+MSD Radix Sort In-Place,333,71,0.00065390
+MSD Radix Sort In-Place,333,72,0.00037900
+MSD Radix Sort In-Place,333,73,0.00063180
+MSD Radix Sort In-Place,333,74,0.00058140
+MSD Radix Sort In-Place,333,75,0.00036300
+MSD Radix Sort In-Place,333,76,0.00062800
+MSD Radix Sort In-Place,333,77,0.00067290
+MSD Radix Sort In-Place,333,78,0.00057300
+MSD Radix Sort In-Place,333,79,0.00062980
+MSD Radix Sort In-Place,333,80,0.00043760
+MSD Radix Sort In-Place,333,81,0.00063670
+MSD Radix Sort In-Place,333,82,0.00040040
+MSD Radix Sort In-Place,333,83,0.00037220
+MSD Radix Sort In-Place,333,84,0.00041320
+MSD Radix Sort In-Place,333,85,0.00063680
+MSD Radix Sort In-Place,333,86,0.00065050
+MSD Radix Sort In-Place,333,87,0.00054390
+MSD Radix Sort In-Place,333,88,0.00037110
+MSD Radix Sort In-Place,333,89,0.00059470
+MSD Radix Sort In-Place,333,90,0.00060220
+MSD Radix Sort In-Place,333,91,0.00061340
+MSD Radix Sort In-Place,333,92,0.00039700
+MSD Radix Sort In-Place,333,93,0.00064370
+MSD Radix Sort In-Place,333,94,0.00060930
+MSD Radix Sort In-Place,333,95,0.00061650
+MSD Radix Sort In-Place,333,96,0.00059770
+MSD Radix Sort In-Place,333,97,0.00039530
+MSD Radix Sort In-Place,333,98,0.00036780
+MSD Radix Sort In-Place,333,99,0.00044690
+MSD Radix Sort In-Place,333,100,0.00060270
+MSD Radix Sort In-Place,333,101,0.00053210
+MSD Radix Sort In-Place,333,102,0.00036510
+MSD Radix Sort In-Place,333,103,0.00060890
+MSD Radix Sort In-Place,333,104,0.00064920
+MSD Radix Sort In-Place,333,105,0.00061060
+MSD Radix Sort In-Place,333,106,0.00059810
+MSD Radix Sort In-Place,333,107,0.00057100
+MSD Radix Sort In-Place,333,108,0.00059530
+MSD Radix Sort In-Place,333,109,0.00063590
+MSD Radix Sort In-Place,333,110,0.00062760
+MSD Radix Sort In-Place,333,111,0.00038430
+MSD Radix Sort In-Place,333,112,0.00061300
+MSD Radix Sort In-Place,333,113,0.00060800
+MSD Radix Sort In-Place,333,114,0.00058710
+MSD Radix Sort In-Place,333,115,0.00069350
+MSD Radix Sort In-Place,333,116,0.00046470
+MSD Radix Sort In-Place,333,117,0.00039520
+MSD Radix Sort In-Place,333,118,0.00063230
+MSD Radix Sort In-Place,333,119,0.00039110
+MSD Radix Sort In-Place,333,120,0.00056300
+MSD Radix Sort In-Place,333,121,0.00059770
+MSD Radix Sort In-Place,333,122,0.00066960
+MSD Radix Sort In-Place,333,123,0.00061940
+MSD Radix Sort In-Place,333,124,0.00047600
+MSD Radix Sort In-Place,333,125,0.00061660
+MSD Radix Sort In-Place,333,126,0.00056750
+MSD Radix Sort In-Place,333,127,0.00061240
+MSD Radix Sort In-Place,333,128,0.00058900
+MSD Radix Sort In-Place,333,129,0.00067600
+MSD Radix Sort In-Place,333,130,0.00068670
+MSD Radix Sort In-Place,333,131,0.00060570
+MSD Radix Sort In-Place,333,132,0.00063560
+MSD Radix Sort In-Place,333,133,0.00055410
+MSD Radix Sort In-Place,333,134,0.00038580
+MSD Radix Sort In-Place,333,135,0.00058520
+MSD Radix Sort In-Place,333,136,0.00061950
+MSD Radix Sort In-Place,333,137,0.00039860
+MSD Radix Sort In-Place,333,138,0.00062180
+MSD Radix Sort In-Place,333,139,0.00036800
+MSD Radix Sort In-Place,333,140,0.00069610
+MSD Radix Sort In-Place,333,141,0.00065580
+MSD Radix Sort In-Place,333,142,0.00064120
+MSD Radix Sort In-Place,333,143,0.00062450
+MSD Radix Sort In-Place,333,144,0.00036840
+MSD Radix Sort In-Place,333,145,0.00037120
+MSD Radix Sort In-Place,333,146,0.00058860
+MSD Radix Sort In-Place,333,147,0.00061960
+MSD Radix Sort In-Place,333,148,0.00063270
+MSD Radix Sort In-Place,333,149,0.00059900
+MSD Radix Sort In-Place,333,150,0.00037930
+MSD Radix Sort In-Place,333,151,0.00058720
+MSD Radix Sort In-Place,333,152,0.00058940
+MSD Radix Sort In-Place,333,153,0.00066590
+MSD Radix Sort In-Place,333,154,0.00061780
+MSD Radix Sort In-Place,333,155,0.00061620
+MSD Radix Sort In-Place,333,156,0.00061780
+MSD Radix Sort In-Place,333,157,0.00065410
+MSD Radix Sort In-Place,333,158,0.00067420
+MSD Radix Sort In-Place,333,159,0.00068190
+MSD Radix Sort In-Place,333,160,0.00036450
+MSD Radix Sort In-Place,333,161,0.00063980
+MSD Radix Sort In-Place,333,162,0.00066000
+MSD Radix Sort In-Place,333,163,0.00053980
+MSD Radix Sort In-Place,333,164,0.00058290
+MSD Radix Sort In-Place,333,165,0.00069250
+MSD Radix Sort In-Place,333,166,0.00062000
+MSD Radix Sort In-Place,333,167,0.00051670
+MSD Radix Sort In-Place,333,168,0.00040670
+MSD Radix Sort In-Place,333,169,0.00038880
+MSD Radix Sort In-Place,333,170,0.00043980
+MSD Radix Sort In-Place,333,171,0.00059450
+MSD Radix Sort In-Place,333,172,0.00039760
+MSD Radix Sort In-Place,333,173,0.00036720
+MSD Radix Sort In-Place,333,174,0.00058870
+MSD Radix Sort In-Place,333,175,0.00046740
+MSD Radix Sort In-Place,333,176,0.00068310
+MSD Radix Sort In-Place,333,177,0.00064480
+MSD Radix Sort In-Place,333,178,0.00042700
+MSD Radix Sort In-Place,333,179,0.00061480
+MSD Radix Sort In-Place,333,180,0.00058040
+MSD Radix Sort In-Place,333,181,0.00043550
+MSD Radix Sort In-Place,333,182,0.00058840
+MSD Radix Sort In-Place,333,183,0.00040350
+MSD Radix Sort In-Place,333,184,0.00045550
+MSD Radix Sort In-Place,333,185,0.00037460
+MSD Radix Sort In-Place,333,186,0.00048630
+MSD Radix Sort In-Place,333,187,0.00049790
+MSD Radix Sort In-Place,333,188,0.00069800
+MSD Radix Sort In-Place,333,189,0.00065930
+MSD Radix Sort In-Place,333,190,0.00062730
+MSD Radix Sort In-Place,333,191,0.00065100
+MSD Radix Sort In-Place,333,192,0.00063630
+MSD Radix Sort In-Place,333,193,0.00064410
+MSD Radix Sort In-Place,333,194,0.00063180
+MSD Radix Sort In-Place,333,195,0.00059580
+MSD Radix Sort In-Place,333,196,0.00067260
+MSD Radix Sort In-Place,333,197,0.00062820
+MSD Radix Sort In-Place,333,198,0.00061730
+MSD Radix Sort In-Place,333,199,0.00051300
+MSD Radix Sort In-Place,333,200,0.00064810
+MSD Radix Sort In-Place,333,201,0.00063930
+MSD Radix Sort In-Place,333,202,0.00067330
+MSD Radix Sort In-Place,333,203,0.00066400
+MSD Radix Sort In-Place,333,204,0.00064990
+MSD Radix Sort In-Place,333,205,0.00067730
+MSD Radix Sort In-Place,333,206,0.00064040
+MSD Radix Sort In-Place,333,207,0.00058190
+MSD Radix Sort In-Place,333,208,0.00071300
+MSD Radix Sort In-Place,333,209,0.00041800
+MSD Radix Sort In-Place,333,210,0.00037170
+MSD Radix Sort In-Place,333,211,0.00064140
+MSD Radix Sort In-Place,333,212,0.00061190
+MSD Radix Sort In-Place,333,213,0.00061300
+MSD Radix Sort In-Place,333,214,0.00043910
+MSD Radix Sort In-Place,333,215,0.00064850
+MSD Radix Sort In-Place,333,216,0.00061800
+MSD Radix Sort In-Place,333,217,0.00059450
+MSD Radix Sort In-Place,333,218,0.00042670
+MSD Radix Sort In-Place,333,219,0.00063530
+MSD Radix Sort In-Place,333,220,0.00039600
+MSD Radix Sort In-Place,333,221,0.00061830
+MSD Radix Sort In-Place,333,222,0.00063420
+MSD Radix Sort In-Place,333,223,0.00046220
+MSD Radix Sort In-Place,333,224,0.00062300
+MSD Radix Sort In-Place,333,225,0.00060830
+MSD Radix Sort In-Place,333,226,0.00061620
+MSD Radix Sort In-Place,333,227,0.00062670
+MSD Radix Sort In-Place,333,228,0.00069520
+MSD Radix Sort In-Place,333,229,0.00060680
+MSD Radix Sort In-Place,333,230,0.00061990
+MSD Radix Sort In-Place,333,231,0.00059400
+MSD Radix Sort In-Place,333,232,0.00063250
+MSD Radix Sort In-Place,333,233,0.00040690
+MSD Radix Sort In-Place,333,234,0.00064560
+MSD Radix Sort In-Place,333,235,0.00068720
+MSD Radix Sort In-Place,333,236,0.00063510
+MSD Radix Sort In-Place,333,237,0.00059250
+MSD Radix Sort In-Place,333,238,0.00054100
+MSD Radix Sort In-Place,333,239,0.00047960
+MSD Radix Sort In-Place,333,240,0.00037040
+MSD Radix Sort In-Place,333,241,0.00039520
+MSD Radix Sort In-Place,333,242,0.00064620
+MSD Radix Sort In-Place,333,243,0.00059740
+MSD Radix Sort In-Place,333,244,0.00067450
+MSD Radix Sort In-Place,333,245,0.00061180
+MSD Radix Sort In-Place,333,246,0.00041650
+MSD Radix Sort In-Place,333,247,0.00050520
+MSD Radix Sort In-Place,333,248,0.00035170
+MSD Radix Sort In-Place,333,249,0.00060560
+MSD Radix Sort In-Place,333,250,0.00035960
+MSD Radix Sort In-Place,333,251,0.00047300
+MSD Radix Sort In-Place,333,252,0.00037740
+MSD Radix Sort In-Place,333,253,0.00061280
+MSD Radix Sort In-Place,333,254,0.00059710
+MSD Radix Sort In-Place,333,255,0.00054920
+MSD Radix Sort In-Place,333,256,0.00042230
+MSD Radix Sort In-Place,333,257,0.00061770
+MSD Radix Sort In-Place,333,258,0.00055630
+MSD Radix Sort In-Place,333,259,0.00066780
+MSD Radix Sort In-Place,333,260,0.00050080
+MSD Radix Sort In-Place,333,261,0.00055040
+MSD Radix Sort In-Place,333,262,0.00059090
+MSD Radix Sort In-Place,333,263,0.00041730
+MSD Radix Sort In-Place,333,264,0.00062420
+MSD Radix Sort In-Place,333,265,0.00060810
+MSD Radix Sort In-Place,333,266,0.00057110
+MSD Radix Sort In-Place,333,267,0.00038720
+MSD Radix Sort In-Place,333,268,0.00061900
+MSD Radix Sort In-Place,333,269,0.00060930
+MSD Radix Sort In-Place,333,270,0.00059940
+MSD Radix Sort In-Place,333,271,0.00039370
+MSD Radix Sort In-Place,333,272,0.00068740
+MSD Radix Sort In-Place,333,273,0.00038290
+MSD Radix Sort In-Place,333,274,0.00060730
+MSD Radix Sort In-Place,333,275,0.00058560
+MSD Radix Sort In-Place,333,276,0.00043560
+MSD Radix Sort In-Place,333,277,0.00063030
+MSD Radix Sort In-Place,333,278,0.00047220
+MSD Radix Sort In-Place,333,279,0.00060240
+MSD Radix Sort In-Place,333,280,0.00063410
+MSD Radix Sort In-Place,333,281,0.00057770
+MSD Radix Sort In-Place,333,282,0.00060000
+MSD Radix Sort In-Place,333,283,0.00061610
+MSD Radix Sort In-Place,333,284,0.00042090
+MSD Radix Sort In-Place,333,285,0.00063970
+MSD Radix Sort In-Place,333,286,0.00063320
+MSD Radix Sort In-Place,333,287,0.00064250
+MSD Radix Sort In-Place,333,288,0.00046960
+MSD Radix Sort In-Place,333,289,0.00068500
+MSD Radix Sort In-Place,333,290,0.00062920
+MSD Radix Sort In-Place,333,291,0.00067780
+MSD Radix Sort In-Place,333,292,0.00068060
+MSD Radix Sort In-Place,333,293,0.00059660
+MSD Radix Sort In-Place,333,294,0.00057380
+MSD Radix Sort In-Place,333,295,0.00037990
+MSD Radix Sort In-Place,333,296,0.00058510
+MSD Radix Sort In-Place,333,297,0.00062140
+MSD Radix Sort In-Place,333,298,0.00072870
+MSD Radix Sort In-Place,333,299,0.00062270
+MSD Radix Sort In-Place,333,300,0.00036170
+MSD Radix Sort In-Place,333,301,0.00058870
+MSD Radix Sort In-Place,333,302,0.00063650
+MSD Radix Sort In-Place,333,303,0.00037240
+MSD Radix Sort In-Place,333,304,0.00062330
+MSD Radix Sort In-Place,333,305,0.00062000
+MSD Radix Sort In-Place,333,306,0.00046940
+MSD Radix Sort In-Place,333,307,0.00067620
+MSD Radix Sort In-Place,333,308,0.00067890
+MSD Radix Sort In-Place,333,309,0.00063160
+MSD Radix Sort In-Place,333,310,0.00047760
+MSD Radix Sort In-Place,333,311,0.00060260
+MSD Radix Sort In-Place,333,312,0.00059480
+MSD Radix Sort In-Place,333,313,0.00068010
+MSD Radix Sort In-Place,333,314,0.00068670
+MSD Radix Sort In-Place,333,315,0.00039700
+MSD Radix Sort In-Place,333,316,0.00061410
+MSD Radix Sort In-Place,333,317,0.00056490
+MSD Radix Sort In-Place,333,318,0.00060270
+MSD Radix Sort In-Place,333,319,0.00054860
+MSD Radix Sort In-Place,333,320,0.00062110
+MSD Radix Sort In-Place,333,321,0.00066630
+MSD Radix Sort In-Place,333,322,0.00042290
+MSD Radix Sort In-Place,333,323,0.00058080
+MSD Radix Sort In-Place,333,324,0.00069180
+MSD Radix Sort In-Place,333,325,0.00061800
+MSD Radix Sort In-Place,333,326,0.00065170
+MSD Radix Sort In-Place,333,327,0.00068540
+MSD Radix Sort In-Place,333,328,0.00066190
+MSD Radix Sort In-Place,333,329,0.00066470
+MSD Radix Sort In-Place,333,330,0.00067020
+MSD Radix Sort In-Place,333,331,0.00061930
+MSD Radix Sort In-Place,333,332,0.00066580
+MSD Radix Sort In-Place,333,333,0.00051650
+MSD Radix Sort In-Place,333,334,0.00071320
+MSD Radix Sort In-Place,333,335,0.00058910
+MSD Radix Sort In-Place,333,336,0.00065250
+MSD Radix Sort In-Place,333,337,0.00067650
+MSD Radix Sort In-Place,333,338,0.00064260
+MSD Radix Sort In-Place,333,339,0.00063510
+MSD Radix Sort In-Place,333,340,0.00064680
+MSD Radix Sort In-Place,333,341,0.00039450
+MSD Radix Sort In-Place,333,342,0.00060780
+MSD Radix Sort In-Place,333,343,0.00072320
+MSD Radix Sort In-Place,333,344,0.00065030
+MSD Radix Sort In-Place,333,345,0.00055030
+MSD Radix Sort In-Place,333,346,0.00059710
+MSD Radix Sort In-Place,333,347,0.00060270
+MSD Radix Sort In-Place,333,348,0.00060850
+MSD Radix Sort In-Place,333,349,0.00072250
+MSD Radix Sort In-Place,333,350,0.00060140
+MSD Radix Sort In-Place,333,351,0.00064000
+MSD Radix Sort In-Place,333,352,0.00049540
+MSD Radix Sort In-Place,333,353,0.00036560
+MSD Radix Sort In-Place,333,354,0.00059770
+MSD Radix Sort In-Place,333,355,0.00053180
+MSD Radix Sort In-Place,333,356,0.00052930
+MSD Radix Sort In-Place,333,357,0.00068810
+MSD Radix Sort In-Place,333,358,0.00053250
+MSD Radix Sort In-Place,333,359,0.00060620
+MSD Radix Sort In-Place,333,360,0.00045190
+MSD Radix Sort In-Place,333,361,0.00059010
+MSD Radix Sort In-Place,333,362,0.00068160
+MSD Radix Sort In-Place,333,363,0.00062340
+MSD Radix Sort In-Place,333,364,0.00046260
+MSD Radix Sort In-Place,333,365,0.00066500
+MSD Radix Sort In-Place,333,366,0.00059200
+MSD Radix Sort In-Place,333,367,0.00041070
+MSD Radix Sort In-Place,333,368,0.00061650
+MSD Radix Sort In-Place,333,369,0.00054660
+MSD Radix Sort In-Place,333,370,0.00065010
+MSD Radix Sort In-Place,333,371,0.00037770
+MSD Radix Sort In-Place,333,372,0.00057430
+MSD Radix Sort In-Place,333,373,0.00060940
+MSD Radix Sort In-Place,333,374,0.00059880
+MSD Radix Sort In-Place,333,375,0.00060350
+MSD Radix Sort In-Place,333,376,0.00065080
+MSD Radix Sort In-Place,333,377,0.00065030
+MSD Radix Sort In-Place,333,378,0.00060520
+MSD Radix Sort In-Place,333,379,0.00057490
+MSD Radix Sort In-Place,333,380,0.00068600
+MSD Radix Sort In-Place,333,381,0.00064000
+MSD Radix Sort In-Place,333,382,0.00054550
+MSD Radix Sort In-Place,333,383,0.00068900
+MSD Radix Sort In-Place,333,384,0.00043960
+MSD Radix Sort In-Place,333,385,0.00062140
+MSD Radix Sort In-Place,333,386,0.00060140
+MSD Radix Sort In-Place,333,387,0.00076220
+MSD Radix Sort In-Place,333,388,0.00065130
+MSD Radix Sort In-Place,333,389,0.00069780
+MSD Radix Sort In-Place,333,390,0.00063670
+MSD Radix Sort In-Place,333,391,0.00060080
+MSD Radix Sort In-Place,333,392,0.00066400
+MSD Radix Sort In-Place,333,393,0.00061570
+MSD Radix Sort In-Place,333,394,0.00065570
+MSD Radix Sort In-Place,333,395,0.00061570
+MSD Radix Sort In-Place,333,396,0.00036800
+MSD Radix Sort In-Place,333,397,0.00055680
+MSD Radix Sort In-Place,333,398,0.00053280
+MSD Radix Sort In-Place,333,399,0.00060170
+MSD Radix Sort In-Place,333,400,0.00060270
+MSD Radix Sort In-Place,333,401,0.00068060
+MSD Radix Sort In-Place,333,402,0.00059980
+MSD Radix Sort In-Place,333,403,0.00053890
+MSD Radix Sort In-Place,333,404,0.00072790
+MSD Radix Sort In-Place,333,405,0.00063090
+MSD Radix Sort In-Place,333,406,0.00059290
+MSD Radix Sort In-Place,333,407,0.00044430
+MSD Radix Sort In-Place,333,408,0.00035360
+MSD Radix Sort In-Place,333,409,0.00063960
+MSD Radix Sort In-Place,333,410,0.00064130
+MSD Radix Sort In-Place,333,411,0.00060020
+MSD Radix Sort In-Place,333,412,0.00054350
+MSD Radix Sort In-Place,333,413,0.00066350
+MSD Radix Sort In-Place,333,414,0.00066260
+MSD Radix Sort In-Place,333,415,0.00064680
+MSD Radix Sort In-Place,333,416,0.00061550
+MSD Radix Sort In-Place,333,417,0.00061010
+MSD Radix Sort In-Place,333,418,0.00067980
+MSD Radix Sort In-Place,333,419,0.00067910
+MSD Radix Sort In-Place,333,420,0.00061370
+MSD Radix Sort In-Place,333,421,0.00053420
+MSD Radix Sort In-Place,333,422,0.00062340
+MSD Radix Sort In-Place,333,423,0.00061220
+MSD Radix Sort In-Place,333,424,0.00063830
+MSD Radix Sort In-Place,333,425,0.00037940
+MSD Radix Sort In-Place,333,426,0.00060330
+MSD Radix Sort In-Place,333,427,0.00061520
+MSD Radix Sort In-Place,333,428,0.00047680
+MSD Radix Sort In-Place,333,429,0.00061520
+MSD Radix Sort In-Place,333,430,0.00062530
+MSD Radix Sort In-Place,333,431,0.00049900
+MSD Radix Sort In-Place,333,432,0.00064430
+MSD Radix Sort In-Place,333,433,0.00062690
+MSD Radix Sort In-Place,333,434,0.00061820
+MSD Radix Sort In-Place,333,435,0.00053720
+MSD Radix Sort In-Place,333,436,0.00052410
+MSD Radix Sort In-Place,333,437,0.00059450
+MSD Radix Sort In-Place,333,438,0.00045530
+MSD Radix Sort In-Place,333,439,0.00067240
+MSD Radix Sort In-Place,333,440,0.00067070
+MSD Radix Sort In-Place,333,441,0.00059020
+MSD Radix Sort In-Place,333,442,0.00057680
+MSD Radix Sort In-Place,333,443,0.00070840
+MSD Radix Sort In-Place,333,444,0.00038400
+MSD Radix Sort In-Place,333,445,0.00064570
+MSD Radix Sort In-Place,333,446,0.00050840
+MSD Radix Sort In-Place,333,447,0.00058040
+MSD Radix Sort In-Place,333,448,0.00073340
+MSD Radix Sort In-Place,333,449,0.00059440
+MSD Radix Sort In-Place,333,450,0.00067100
+MSD Radix Sort In-Place,333,451,0.00063490
+MSD Radix Sort In-Place,333,452,0.00046340
+MSD Radix Sort In-Place,333,453,0.00065780
+MSD Radix Sort In-Place,333,454,0.00061640
+MSD Radix Sort In-Place,333,455,0.00055370
+MSD Radix Sort In-Place,333,456,0.00060320
+MSD Radix Sort In-Place,333,457,0.00066250
+MSD Radix Sort In-Place,333,458,0.00061930
+MSD Radix Sort In-Place,333,459,0.00059890
+MSD Radix Sort In-Place,333,460,0.00061840
+MSD Radix Sort In-Place,333,461,0.00063390
+MSD Radix Sort In-Place,333,462,0.00036920
+MSD Radix Sort In-Place,333,463,0.00072660
+MSD Radix Sort In-Place,333,464,0.00055010
+MSD Radix Sort In-Place,333,465,0.00039170
+MSD Radix Sort In-Place,333,466,0.00063580
+MSD Radix Sort In-Place,333,467,0.00060970
+MSD Radix Sort In-Place,333,468,0.00061290
+MSD Radix Sort In-Place,333,469,0.00051880
+MSD Radix Sort In-Place,333,470,0.00060710
+MSD Radix Sort In-Place,333,471,0.00062940
+MSD Radix Sort In-Place,333,472,0.00075100
+MSD Radix Sort In-Place,333,473,0.00060600
+MSD Radix Sort In-Place,333,474,0.00052470
+MSD Radix Sort In-Place,333,475,0.00060430
+MSD Radix Sort In-Place,333,476,0.00061460
+MSD Radix Sort In-Place,333,477,0.00058890
+MSD Radix Sort In-Place,333,478,0.00048090
+MSD Radix Sort In-Place,333,479,0.00069370
+MSD Radix Sort In-Place,333,480,0.00062060
+MSD Radix Sort In-Place,333,481,0.00063160
+MSD Radix Sort In-Place,333,482,0.00067390
+MSD Radix Sort In-Place,333,483,0.00068500
+MSD Radix Sort In-Place,333,484,0.00064870
+MSD Radix Sort In-Place,333,485,0.00052130
+MSD Radix Sort In-Place,333,486,0.00060650
+MSD Radix Sort In-Place,333,487,0.00041950
+MSD Radix Sort In-Place,333,488,0.00066890
+MSD Radix Sort In-Place,333,489,0.00066670
+MSD Radix Sort In-Place,333,490,0.00070500
+MSD Radix Sort In-Place,333,491,0.00065530
+MSD Radix Sort In-Place,333,492,0.00050200
+MSD Radix Sort In-Place,333,493,0.00065380
+MSD Radix Sort In-Place,333,494,0.00067960
+MSD Radix Sort In-Place,333,495,0.00055250
+MSD Radix Sort In-Place,333,496,0.00062440
+MSD Radix Sort In-Place,333,497,0.00061000
+MSD Radix Sort In-Place,333,498,0.00066180
+MSD Radix Sort In-Place,333,499,0.00070350
+MSD Radix Sort In-Place,333,500,0.00067990
+Merge Insertion Sort,333,1,0.00046780
+Merge Insertion Sort,333,2,0.00047830
+Merge Insertion Sort,333,3,0.00053200
+Merge Insertion Sort,333,4,0.00053410
+Merge Insertion Sort,333,5,0.00044810
+Merge Insertion Sort,333,6,0.00046210
+Merge Insertion Sort,333,7,0.00052000
+Merge Insertion Sort,333,8,0.00048620
+Merge Insertion Sort,333,9,0.00050860
+Merge Insertion Sort,333,10,0.00046110
+Merge Insertion Sort,333,11,0.00047090
+Merge Insertion Sort,333,12,0.00045950
+Merge Insertion Sort,333,13,0.00046870
+Merge Insertion Sort,333,14,0.00046550
+Merge Insertion Sort,333,15,0.00040990
+Merge Insertion Sort,333,16,0.00047580
+Merge Insertion Sort,333,17,0.00046710
+Merge Insertion Sort,333,18,0.00035750
+Merge Insertion Sort,333,19,0.00040210
+Merge Insertion Sort,333,20,0.00046790
+Merge Insertion Sort,333,21,0.00046630
+Merge Insertion Sort,333,22,0.00047180
+Merge Insertion Sort,333,23,0.00050450
+Merge Insertion Sort,333,24,0.00046660
+Merge Insertion Sort,333,25,0.00053260
+Merge Insertion Sort,333,26,0.00050780
+Merge Insertion Sort,333,27,0.00028990
+Merge Insertion Sort,333,28,0.00049210
+Merge Insertion Sort,333,29,0.00032100
+Merge Insertion Sort,333,30,0.00048530
+Merge Insertion Sort,333,31,0.00030020
+Merge Insertion Sort,333,32,0.00033840
+Merge Insertion Sort,333,33,0.00046270
+Merge Insertion Sort,333,34,0.00045830
+Merge Insertion Sort,333,35,0.00044340
+Merge Insertion Sort,333,36,0.00046690
+Merge Insertion Sort,333,37,0.00052100
+Merge Insertion Sort,333,38,0.00047300
+Merge Insertion Sort,333,39,0.00031040
+Merge Insertion Sort,333,40,0.00041200
+Merge Insertion Sort,333,41,0.00038320
+Merge Insertion Sort,333,42,0.00049080
+Merge Insertion Sort,333,43,0.00041790
+Merge Insertion Sort,333,44,0.00046640
+Merge Insertion Sort,333,45,0.00034600
+Merge Insertion Sort,333,46,0.00042600
+Merge Insertion Sort,333,47,0.00046840
+Merge Insertion Sort,333,48,0.00036250
+Merge Insertion Sort,333,49,0.00049360
+Merge Insertion Sort,333,50,0.00030510
+Merge Insertion Sort,333,51,0.00046180
+Merge Insertion Sort,333,52,0.00048240
+Merge Insertion Sort,333,53,0.00049730
+Merge Insertion Sort,333,54,0.00048950
+Merge Insertion Sort,333,55,0.00045140
+Merge Insertion Sort,333,56,0.00031060
+Merge Insertion Sort,333,57,0.00046680
+Merge Insertion Sort,333,58,0.00033680
+Merge Insertion Sort,333,59,0.00045390
+Merge Insertion Sort,333,60,0.00050630
+Merge Insertion Sort,333,61,0.00030810
+Merge Insertion Sort,333,62,0.00047900
+Merge Insertion Sort,333,63,0.00044450
+Merge Insertion Sort,333,64,0.00045180
+Merge Insertion Sort,333,65,0.00048220
+Merge Insertion Sort,333,66,0.00047610
+Merge Insertion Sort,333,67,0.00046470
+Merge Insertion Sort,333,68,0.00045610
+Merge Insertion Sort,333,69,0.00052910
+Merge Insertion Sort,333,70,0.00047740
+Merge Insertion Sort,333,71,0.00047220
+Merge Insertion Sort,333,72,0.00038370
+Merge Insertion Sort,333,73,0.00034490
+Merge Insertion Sort,333,74,0.00028350
+Merge Insertion Sort,333,75,0.00048220
+Merge Insertion Sort,333,76,0.00034490
+Merge Insertion Sort,333,77,0.00046500
+Merge Insertion Sort,333,78,0.00047450
+Merge Insertion Sort,333,79,0.00050650
+Merge Insertion Sort,333,80,0.00048440
+Merge Insertion Sort,333,81,0.00037710
+Merge Insertion Sort,333,82,0.00046510
+Merge Insertion Sort,333,83,0.00045530
+Merge Insertion Sort,333,84,0.00036340
+Merge Insertion Sort,333,85,0.00047100
+Merge Insertion Sort,333,86,0.00034480
+Merge Insertion Sort,333,87,0.00045800
+Merge Insertion Sort,333,88,0.00049530
+Merge Insertion Sort,333,89,0.00047380
+Merge Insertion Sort,333,90,0.00052340
+Merge Insertion Sort,333,91,0.00046060
+Merge Insertion Sort,333,92,0.00048740
+Merge Insertion Sort,333,93,0.00050630
+Merge Insertion Sort,333,94,0.00046780
+Merge Insertion Sort,333,95,0.00046420
+Merge Insertion Sort,333,96,0.00047540
+Merge Insertion Sort,333,97,0.00032070
+Merge Insertion Sort,333,98,0.00047880
+Merge Insertion Sort,333,99,0.00047910
+Merge Insertion Sort,333,100,0.00047470
+Merge Insertion Sort,333,101,0.00045550
+Merge Insertion Sort,333,102,0.00028820
+Merge Insertion Sort,333,103,0.00038300
+Merge Insertion Sort,333,104,0.00046900
+Merge Insertion Sort,333,105,0.00047250
+Merge Insertion Sort,333,106,0.00046920
+Merge Insertion Sort,333,107,0.00031290
+Merge Insertion Sort,333,108,0.00046510
+Merge Insertion Sort,333,109,0.00050670
+Merge Insertion Sort,333,110,0.00039350
+Merge Insertion Sort,333,111,0.00045600
+Merge Insertion Sort,333,112,0.00047490
+Merge Insertion Sort,333,113,0.00051250
+Merge Insertion Sort,333,114,0.00041640
+Merge Insertion Sort,333,115,0.00046350
+Merge Insertion Sort,333,116,0.00048640
+Merge Insertion Sort,333,117,0.00033420
+Merge Insertion Sort,333,118,0.00032870
+Merge Insertion Sort,333,119,0.00046840
+Merge Insertion Sort,333,120,0.00029960
+Merge Insertion Sort,333,121,0.00049790
+Merge Insertion Sort,333,122,0.00046610
+Merge Insertion Sort,333,123,0.00044410
+Merge Insertion Sort,333,124,0.00046660
+Merge Insertion Sort,333,125,0.00039740
+Merge Insertion Sort,333,126,0.00028740
+Merge Insertion Sort,333,127,0.00028550
+Merge Insertion Sort,333,128,0.00043420
+Merge Insertion Sort,333,129,0.00039760
+Merge Insertion Sort,333,130,0.00048530
+Merge Insertion Sort,333,131,0.00048290
+Merge Insertion Sort,333,132,0.00049120
+Merge Insertion Sort,333,133,0.00047540
+Merge Insertion Sort,333,134,0.00043260
+Merge Insertion Sort,333,135,0.00036810
+Merge Insertion Sort,333,136,0.00039950
+Merge Insertion Sort,333,137,0.00028680
+Merge Insertion Sort,333,138,0.00040480
+Merge Insertion Sort,333,139,0.00051560
+Merge Insertion Sort,333,140,0.00047100
+Merge Insertion Sort,333,141,0.00048200
+Merge Insertion Sort,333,142,0.00047600
+Merge Insertion Sort,333,143,0.00049700
+Merge Insertion Sort,333,144,0.00047680
+Merge Insertion Sort,333,145,0.00039340
+Merge Insertion Sort,333,146,0.00046800
+Merge Insertion Sort,333,147,0.00037090
+Merge Insertion Sort,333,148,0.00048150
+Merge Insertion Sort,333,149,0.00048310
+Merge Insertion Sort,333,150,0.00050720
+Merge Insertion Sort,333,151,0.00052190
+Merge Insertion Sort,333,152,0.00046050
+Merge Insertion Sort,333,153,0.00048790
+Merge Insertion Sort,333,154,0.00049150
+Merge Insertion Sort,333,155,0.00043800
+Merge Insertion Sort,333,156,0.00052670
+Merge Insertion Sort,333,157,0.00030050
+Merge Insertion Sort,333,158,0.00048640
+Merge Insertion Sort,333,159,0.00048460
+Merge Insertion Sort,333,160,0.00048930
+Merge Insertion Sort,333,161,0.00046580
+Merge Insertion Sort,333,162,0.00050880
+Merge Insertion Sort,333,163,0.00046770
+Merge Insertion Sort,333,164,0.00048880
+Merge Insertion Sort,333,165,0.00036610
+Merge Insertion Sort,333,166,0.00050230
+Merge Insertion Sort,333,167,0.00037920
+Merge Insertion Sort,333,168,0.00045520
+Merge Insertion Sort,333,169,0.00046320
+Merge Insertion Sort,333,170,0.00051730
+Merge Insertion Sort,333,171,0.00052340
+Merge Insertion Sort,333,172,0.00049850
+Merge Insertion Sort,333,173,0.00045360
+Merge Insertion Sort,333,174,0.00053360
+Merge Insertion Sort,333,175,0.00045300
+Merge Insertion Sort,333,176,0.00048800
+Merge Insertion Sort,333,177,0.00054320
+Merge Insertion Sort,333,178,0.00048410
+Merge Insertion Sort,333,179,0.00052530
+Merge Insertion Sort,333,180,0.00037340
+Merge Insertion Sort,333,181,0.00053080
+Merge Insertion Sort,333,182,0.00040180
+Merge Insertion Sort,333,183,0.00049490
+Merge Insertion Sort,333,184,0.00050590
+Merge Insertion Sort,333,185,0.00051060
+Merge Insertion Sort,333,186,0.00047870
+Merge Insertion Sort,333,187,0.00054490
+Merge Insertion Sort,333,188,0.00046180
+Merge Insertion Sort,333,189,0.00046830
+Merge Insertion Sort,333,190,0.00050250
+Merge Insertion Sort,333,191,0.00050450
+Merge Insertion Sort,333,192,0.00046250
+Merge Insertion Sort,333,193,0.00048910
+Merge Insertion Sort,333,194,0.00046100
+Merge Insertion Sort,333,195,0.00047680
+Merge Insertion Sort,333,196,0.00031770
+Merge Insertion Sort,333,197,0.00047370
+Merge Insertion Sort,333,198,0.00036400
+Merge Insertion Sort,333,199,0.00036700
+Merge Insertion Sort,333,200,0.00034830
+Merge Insertion Sort,333,201,0.00046420
+Merge Insertion Sort,333,202,0.00050120
+Merge Insertion Sort,333,203,0.00048800
+Merge Insertion Sort,333,204,0.00045320
+Merge Insertion Sort,333,205,0.00047570
+Merge Insertion Sort,333,206,0.00028420
+Merge Insertion Sort,333,207,0.00054500
+Merge Insertion Sort,333,208,0.00040250
+Merge Insertion Sort,333,209,0.00048860
+Merge Insertion Sort,333,210,0.00049340
+Merge Insertion Sort,333,211,0.00047310
+Merge Insertion Sort,333,212,0.00046690
+Merge Insertion Sort,333,213,0.00039220
+Merge Insertion Sort,333,214,0.00047970
+Merge Insertion Sort,333,215,0.00047110
+Merge Insertion Sort,333,216,0.00046920
+Merge Insertion Sort,333,217,0.00030160
+Merge Insertion Sort,333,218,0.00049800
+Merge Insertion Sort,333,219,0.00047040
+Merge Insertion Sort,333,220,0.00037330
+Merge Insertion Sort,333,221,0.00046930
+Merge Insertion Sort,333,222,0.00045970
+Merge Insertion Sort,333,223,0.00045020
+Merge Insertion Sort,333,224,0.00030650
+Merge Insertion Sort,333,225,0.00048250
+Merge Insertion Sort,333,226,0.00053080
+Merge Insertion Sort,333,227,0.00045550
+Merge Insertion Sort,333,228,0.00048720
+Merge Insertion Sort,333,229,0.00044340
+Merge Insertion Sort,333,230,0.00047700
+Merge Insertion Sort,333,231,0.00034700
+Merge Insertion Sort,333,232,0.00046420
+Merge Insertion Sort,333,233,0.00029660
+Merge Insertion Sort,333,234,0.00048120
+Merge Insertion Sort,333,235,0.00029930
+Merge Insertion Sort,333,236,0.00045530
+Merge Insertion Sort,333,237,0.00029940
+Merge Insertion Sort,333,238,0.00028990
+Merge Insertion Sort,333,239,0.00045630
+Merge Insertion Sort,333,240,0.00047670
+Merge Insertion Sort,333,241,0.00047800
+Merge Insertion Sort,333,242,0.00048230
+Merge Insertion Sort,333,243,0.00043090
+Merge Insertion Sort,333,244,0.00048580
+Merge Insertion Sort,333,245,0.00052440
+Merge Insertion Sort,333,246,0.00052520
+Merge Insertion Sort,333,247,0.00055020
+Merge Insertion Sort,333,248,0.00047440
+Merge Insertion Sort,333,249,0.00048540
+Merge Insertion Sort,333,250,0.00041090
+Merge Insertion Sort,333,251,0.00052750
+Merge Insertion Sort,333,252,0.00049930
+Merge Insertion Sort,333,253,0.00046660
+Merge Insertion Sort,333,254,0.00050160
+Merge Insertion Sort,333,255,0.00037210
+Merge Insertion Sort,333,256,0.00046630
+Merge Insertion Sort,333,257,0.00036030
+Merge Insertion Sort,333,258,0.00046440
+Merge Insertion Sort,333,259,0.00046720
+Merge Insertion Sort,333,260,0.00040450
+Merge Insertion Sort,333,261,0.00031980
+Merge Insertion Sort,333,262,0.00051460
+Merge Insertion Sort,333,263,0.00044600
+Merge Insertion Sort,333,264,0.00046520
+Merge Insertion Sort,333,265,0.00045630
+Merge Insertion Sort,333,266,0.00049530
+Merge Insertion Sort,333,267,0.00045610
+Merge Insertion Sort,333,268,0.00045600
+Merge Insertion Sort,333,269,0.00048870
+Merge Insertion Sort,333,270,0.00046540
+Merge Insertion Sort,333,271,0.00042910
+Merge Insertion Sort,333,272,0.00046220
+Merge Insertion Sort,333,273,0.00049490
+Merge Insertion Sort,333,274,0.00045930
+Merge Insertion Sort,333,275,0.00046960
+Merge Insertion Sort,333,276,0.00041180
+Merge Insertion Sort,333,277,0.00046120
+Merge Insertion Sort,333,278,0.00048550
+Merge Insertion Sort,333,279,0.00046900
+Merge Insertion Sort,333,280,0.00045900
+Merge Insertion Sort,333,281,0.00038260
+Merge Insertion Sort,333,282,0.00047440
+Merge Insertion Sort,333,283,0.00041070
+Merge Insertion Sort,333,284,0.00046110
+Merge Insertion Sort,333,285,0.00045460
+Merge Insertion Sort,333,286,0.00040300
+Merge Insertion Sort,333,287,0.00048520
+Merge Insertion Sort,333,288,0.00046740
+Merge Insertion Sort,333,289,0.00045720
+Merge Insertion Sort,333,290,0.00046850
+Merge Insertion Sort,333,291,0.00048650
+Merge Insertion Sort,333,292,0.00051580
+Merge Insertion Sort,333,293,0.00040540
+Merge Insertion Sort,333,294,0.00045540
+Merge Insertion Sort,333,295,0.00049010
+Merge Insertion Sort,333,296,0.00050940
+Merge Insertion Sort,333,297,0.00050580
+Merge Insertion Sort,333,298,0.00048760
+Merge Insertion Sort,333,299,0.00052330
+Merge Insertion Sort,333,300,0.00053640
+Merge Insertion Sort,333,301,0.00053300
+Merge Insertion Sort,333,302,0.00049640
+Merge Insertion Sort,333,303,0.00051160
+Merge Insertion Sort,333,304,0.00049890
+Merge Insertion Sort,333,305,0.00044210
+Merge Insertion Sort,333,306,0.00053910
+Merge Insertion Sort,333,307,0.00041580
+Merge Insertion Sort,333,308,0.00050970
+Merge Insertion Sort,333,309,0.00051360
+Merge Insertion Sort,333,310,0.00049880
+Merge Insertion Sort,333,311,0.00045700
+Merge Insertion Sort,333,312,0.00046140
+Merge Insertion Sort,333,313,0.00040940
+Merge Insertion Sort,333,314,0.00047930
+Merge Insertion Sort,333,315,0.00046290
+Merge Insertion Sort,333,316,0.00050230
+Merge Insertion Sort,333,317,0.00049970
+Merge Insertion Sort,333,318,0.00050680
+Merge Insertion Sort,333,319,0.00048630
+Merge Insertion Sort,333,320,0.00044550
+Merge Insertion Sort,333,321,0.00046270
+Merge Insertion Sort,333,322,0.00031500
+Merge Insertion Sort,333,323,0.00046990
+Merge Insertion Sort,333,324,0.00034520
+Merge Insertion Sort,333,325,0.00050530
+Merge Insertion Sort,333,326,0.00049720
+Merge Insertion Sort,333,327,0.00041990
+Merge Insertion Sort,333,328,0.00046200
+Merge Insertion Sort,333,329,0.00028680
+Merge Insertion Sort,333,330,0.00049510
+Merge Insertion Sort,333,331,0.00032420
+Merge Insertion Sort,333,332,0.00043850
+Merge Insertion Sort,333,333,0.00044660
+Merge Insertion Sort,333,334,0.00044340
+Merge Insertion Sort,333,335,0.00047130
+Merge Insertion Sort,333,336,0.00045820
+Merge Insertion Sort,333,337,0.00030560
+Merge Insertion Sort,333,338,0.00050970
+Merge Insertion Sort,333,339,0.00048890
+Merge Insertion Sort,333,340,0.00046980
+Merge Insertion Sort,333,341,0.00049420
+Merge Insertion Sort,333,342,0.00030830
+Merge Insertion Sort,333,343,0.00041930
+Merge Insertion Sort,333,344,0.00049720
+Merge Insertion Sort,333,345,0.00049530
+Merge Insertion Sort,333,346,0.00049810
+Merge Insertion Sort,333,347,0.00030740
+Merge Insertion Sort,333,348,0.00039800
+Merge Insertion Sort,333,349,0.00048610
+Merge Insertion Sort,333,350,0.00046790
+Merge Insertion Sort,333,351,0.00049150
+Merge Insertion Sort,333,352,0.00052080
+Merge Insertion Sort,333,353,0.00049250
+Merge Insertion Sort,333,354,0.00034530
+Merge Insertion Sort,333,355,0.00050280
+Merge Insertion Sort,333,356,0.00046980
+Merge Insertion Sort,333,357,0.00042660
+Merge Insertion Sort,333,358,0.00049380
+Merge Insertion Sort,333,359,0.00045780
+Merge Insertion Sort,333,360,0.00040150
+Merge Insertion Sort,333,361,0.00049470
+Merge Insertion Sort,333,362,0.00050020
+Merge Insertion Sort,333,363,0.00046050
+Merge Insertion Sort,333,364,0.00072230
+Merge Insertion Sort,333,365,0.00075470
+Merge Insertion Sort,333,366,0.00061240
+Merge Insertion Sort,333,367,0.00049130
+Merge Insertion Sort,333,368,0.00048790
+Merge Insertion Sort,333,369,0.00051890
+Merge Insertion Sort,333,370,0.00050380
+Merge Insertion Sort,333,371,0.00050800
+Merge Insertion Sort,333,372,0.00051590
+Merge Insertion Sort,333,373,0.00051400
+Merge Insertion Sort,333,374,0.00049740
+Merge Insertion Sort,333,375,0.00051740
+Merge Insertion Sort,333,376,0.00048970
+Merge Insertion Sort,333,377,0.00051170
+Merge Insertion Sort,333,378,0.00052310
+Merge Insertion Sort,333,379,0.00046350
+Merge Insertion Sort,333,380,0.00054170
+Merge Insertion Sort,333,381,0.00050460
+Merge Insertion Sort,333,382,0.00052010
+Merge Insertion Sort,333,383,0.00050110
+Merge Insertion Sort,333,384,0.00048030
+Merge Insertion Sort,333,385,0.00048250
+Merge Insertion Sort,333,386,0.00046410
+Merge Insertion Sort,333,387,0.00046820
+Merge Insertion Sort,333,388,0.00054130
+Merge Insertion Sort,333,389,0.00041790
+Merge Insertion Sort,333,390,0.00049030
+Merge Insertion Sort,333,391,0.00039710
+Merge Insertion Sort,333,392,0.00052750
+Merge Insertion Sort,333,393,0.00046300
+Merge Insertion Sort,333,394,0.00049160
+Merge Insertion Sort,333,395,0.00047780
+Merge Insertion Sort,333,396,0.00051580
+Merge Insertion Sort,333,397,0.00051840
+Merge Insertion Sort,333,398,0.00052850
+Merge Insertion Sort,333,399,0.00049980
+Merge Insertion Sort,333,400,0.00047370
+Merge Insertion Sort,333,401,0.00045920
+Merge Insertion Sort,333,402,0.00049170
+Merge Insertion Sort,333,403,0.00042510
+Merge Insertion Sort,333,404,0.00049710
+Merge Insertion Sort,333,405,0.00046270
+Merge Insertion Sort,333,406,0.00049340
+Merge Insertion Sort,333,407,0.00047770
+Merge Insertion Sort,333,408,0.00050440
+Merge Insertion Sort,333,409,0.00045770
+Merge Insertion Sort,333,410,0.00044330
+Merge Insertion Sort,333,411,0.00051670
+Merge Insertion Sort,333,412,0.00050250
+Merge Insertion Sort,333,413,0.00043810
+Merge Insertion Sort,333,414,0.00040200
+Merge Insertion Sort,333,415,0.00047490
+Merge Insertion Sort,333,416,0.00049390
+Merge Insertion Sort,333,417,0.00049620
+Merge Insertion Sort,333,418,0.00047780
+Merge Insertion Sort,333,419,0.00049270
+Merge Insertion Sort,333,420,0.00050800
+Merge Insertion Sort,333,421,0.00050010
+Merge Insertion Sort,333,422,0.00047050
+Merge Insertion Sort,333,423,0.00054610
+Merge Insertion Sort,333,424,0.00045020
+Merge Insertion Sort,333,425,0.00048220
+Merge Insertion Sort,333,426,0.00051030
+Merge Insertion Sort,333,427,0.00050760
+Merge Insertion Sort,333,428,0.00055850
+Merge Insertion Sort,333,429,0.00055020
+Merge Insertion Sort,333,430,0.00050950
+Merge Insertion Sort,333,431,0.00053650
+Merge Insertion Sort,333,432,0.00053030
+Merge Insertion Sort,333,433,0.00050580
+Merge Insertion Sort,333,434,0.00047030
+Merge Insertion Sort,333,435,0.00050230
+Merge Insertion Sort,333,436,0.00043400
+Merge Insertion Sort,333,437,0.00050360
+Merge Insertion Sort,333,438,0.00044190
+Merge Insertion Sort,333,439,0.00044940
+Merge Insertion Sort,333,440,0.00051630
+Merge Insertion Sort,333,441,0.00042100
+Merge Insertion Sort,333,442,0.00048840
+Merge Insertion Sort,333,443,0.00048390
+Merge Insertion Sort,333,444,0.00041970
+Merge Insertion Sort,333,445,0.00051950
+Merge Insertion Sort,333,446,0.00048150
+Merge Insertion Sort,333,447,0.00047860
+Merge Insertion Sort,333,448,0.00049590
+Merge Insertion Sort,333,449,0.00051340
+Merge Insertion Sort,333,450,0.00048990
+Merge Insertion Sort,333,451,0.00049900
+Merge Insertion Sort,333,452,0.00050670
+Merge Insertion Sort,333,453,0.00051300
+Merge Insertion Sort,333,454,0.00047780
+Merge Insertion Sort,333,455,0.00043780
+Merge Insertion Sort,333,456,0.00050860
+Merge Insertion Sort,333,457,0.00046670
+Merge Insertion Sort,333,458,0.00046320
+Merge Insertion Sort,333,459,0.00055730
+Merge Insertion Sort,333,460,0.00047210
+Merge Insertion Sort,333,461,0.00040880
+Merge Insertion Sort,333,462,0.00046420
+Merge Insertion Sort,333,463,0.00040740
+Merge Insertion Sort,333,464,0.00043100
+Merge Insertion Sort,333,465,0.00055180
+Merge Insertion Sort,333,466,0.00046980
+Merge Insertion Sort,333,467,0.00042790
+Merge Insertion Sort,333,468,0.00040020
+Merge Insertion Sort,333,469,0.00052050
+Merge Insertion Sort,333,470,0.00044710
+Merge Insertion Sort,333,471,0.00051000
+Merge Insertion Sort,333,472,0.00042540
+Merge Insertion Sort,333,473,0.00048700
+Merge Insertion Sort,333,474,0.00036910
+Merge Insertion Sort,333,475,0.00046760
+Merge Insertion Sort,333,476,0.00046260
+Merge Insertion Sort,333,477,0.00053860
+Merge Insertion Sort,333,478,0.00028620
+Merge Insertion Sort,333,479,0.00042770
+Merge Insertion Sort,333,480,0.00047940
+Merge Insertion Sort,333,481,0.00045470
+Merge Insertion Sort,333,482,0.00045140
+Merge Insertion Sort,333,483,0.00050390
+Merge Insertion Sort,333,484,0.00041990
+Merge Insertion Sort,333,485,0.00050470
+Merge Insertion Sort,333,486,0.00047600
+Merge Insertion Sort,333,487,0.00050400
+Merge Insertion Sort,333,488,0.00051340
+Merge Insertion Sort,333,489,0.00046880
+Merge Insertion Sort,333,490,0.00047030
+Merge Insertion Sort,333,491,0.00044000
+Merge Insertion Sort,333,492,0.00051010
+Merge Insertion Sort,333,493,0.00049660
+Merge Insertion Sort,333,494,0.00049150
+Merge Insertion Sort,333,495,0.00042500
+Merge Insertion Sort,333,496,0.00047130
+Merge Insertion Sort,333,497,0.00047550
+Merge Insertion Sort,333,498,0.00047460
+Merge Insertion Sort,333,499,0.00049300
+Merge Insertion Sort,333,500,0.00050470
+Merge Sort,333,1,0.00082750
+Merge Sort,333,2,0.00088910
+Merge Sort,333,3,0.00080190
+Merge Sort,333,4,0.00082240
+Merge Sort,333,5,0.00083550
+Merge Sort,333,6,0.00086640
+Merge Sort,333,7,0.00088480
+Merge Sort,333,8,0.00076690
+Merge Sort,333,9,0.00086860
+Merge Sort,333,10,0.00081250
+Merge Sort,333,11,0.00086090
+Merge Sort,333,12,0.00084060
+Merge Sort,333,13,0.00090090
+Merge Sort,333,14,0.00086240
+Merge Sort,333,15,0.00086770
+Merge Sort,333,16,0.00086140
+Merge Sort,333,17,0.00084830
+Merge Sort,333,18,0.00087410
+Merge Sort,333,19,0.00081240
+Merge Sort,333,20,0.00081200
+Merge Sort,333,21,0.00089240
+Merge Sort,333,22,0.00086910
+Merge Sort,333,23,0.00084790
+Merge Sort,333,24,0.00088540
+Merge Sort,333,25,0.00083330
+Merge Sort,333,26,0.00086360
+Merge Sort,333,27,0.00088930
+Merge Sort,333,28,0.00084600
+Merge Sort,333,29,0.00086720
+Merge Sort,333,30,0.00088790
+Merge Sort,333,31,0.00088650
+Merge Sort,333,32,0.00090660
+Merge Sort,333,33,0.00084770
+Merge Sort,333,34,0.00085410
+Merge Sort,333,35,0.00086320
+Merge Sort,333,36,0.00087780
+Merge Sort,333,37,0.00083980
+Merge Sort,333,38,0.00080970
+Merge Sort,333,39,0.00089000
+Merge Sort,333,40,0.00081070
+Merge Sort,333,41,0.00090330
+Merge Sort,333,42,0.00089020
+Merge Sort,333,43,0.00084150
+Merge Sort,333,44,0.00083080
+Merge Sort,333,45,0.00082580
+Merge Sort,333,46,0.00082500
+Merge Sort,333,47,0.00084010
+Merge Sort,333,48,0.00091110
+Merge Sort,333,49,0.00081690
+Merge Sort,333,50,0.00081730
+Merge Sort,333,51,0.00087420
+Merge Sort,333,52,0.00091240
+Merge Sort,333,53,0.00084380
+Merge Sort,333,54,0.00087770
+Merge Sort,333,55,0.00088130
+Merge Sort,333,56,0.00082080
+Merge Sort,333,57,0.00087540
+Merge Sort,333,58,0.00074690
+Merge Sort,333,59,0.00086320
+Merge Sort,333,60,0.00088620
+Merge Sort,333,61,0.00085760
+Merge Sort,333,62,0.00085730
+Merge Sort,333,63,0.00087250
+Merge Sort,333,64,0.00085280
+Merge Sort,333,65,0.00084530
+Merge Sort,333,66,0.00088200
+Merge Sort,333,67,0.00091670
+Merge Sort,333,68,0.00086240
+Merge Sort,333,69,0.00086220
+Merge Sort,333,70,0.00086890
+Merge Sort,333,71,0.00086020
+Merge Sort,333,72,0.00085570
+Merge Sort,333,73,0.00085090
+Merge Sort,333,74,0.00085350
+Merge Sort,333,75,0.00091180
+Merge Sort,333,76,0.00085610
+Merge Sort,333,77,0.00085480
+Merge Sort,333,78,0.00084290
+Merge Sort,333,79,0.00089510
+Merge Sort,333,80,0.00086780
+Merge Sort,333,81,0.00084530
+Merge Sort,333,82,0.00085270
+Merge Sort,333,83,0.00089120
+Merge Sort,333,84,0.00085490
+Merge Sort,333,85,0.00086790
+Merge Sort,333,86,0.00085260
+Merge Sort,333,87,0.00085760
+Merge Sort,333,88,0.00085460
+Merge Sort,333,89,0.00090730
+Merge Sort,333,90,0.00084870
+Merge Sort,333,91,0.00084500
+Merge Sort,333,92,0.00086500
+Merge Sort,333,93,0.00090650
+Merge Sort,333,94,0.00085290
+Merge Sort,333,95,0.00085080
+Merge Sort,333,96,0.00087050
+Merge Sort,333,97,0.00085390
+Merge Sort,333,98,0.00085380
+Merge Sort,333,99,0.00085180
+Merge Sort,333,100,0.00084190
+Merge Sort,333,101,0.00086420
+Merge Sort,333,102,0.00088730
+Merge Sort,333,103,0.00085420
+Merge Sort,333,104,0.00088210
+Merge Sort,333,105,0.00087680
+Merge Sort,333,106,0.00086720
+Merge Sort,333,107,0.00085780
+Merge Sort,333,108,0.00084390
+Merge Sort,333,109,0.00086300
+Merge Sort,333,110,0.00085400
+Merge Sort,333,111,0.00092620
+Merge Sort,333,112,0.00086860
+Merge Sort,333,113,0.00085510
+Merge Sort,333,114,0.00085570
+Merge Sort,333,115,0.00085160
+Merge Sort,333,116,0.00084830
+Merge Sort,333,117,0.00086550
+Merge Sort,333,118,0.00085880
+Merge Sort,333,119,0.00087030
+Merge Sort,333,120,0.00091010
+Merge Sort,333,121,0.00085030
+Merge Sort,333,122,0.00085370
+Merge Sort,333,123,0.00085420
+Merge Sort,333,124,0.00085320
+Merge Sort,333,125,0.00084940
+Merge Sort,333,126,0.00092390
+Merge Sort,333,127,0.00086250
+Merge Sort,333,128,0.00092010
+Merge Sort,333,129,0.00085020
+Merge Sort,333,130,0.00085790
+Merge Sort,333,131,0.00084770
+Merge Sort,333,132,0.00085010
+Merge Sort,333,133,0.00082370
+Merge Sort,333,134,0.00084720
+Merge Sort,333,135,0.00093440
+Merge Sort,333,136,0.00086370
+Merge Sort,333,137,0.00094630
+Merge Sort,333,138,0.00084760
+Merge Sort,333,139,0.00086080
+Merge Sort,333,140,0.00084760
+Merge Sort,333,141,0.00084810
+Merge Sort,333,142,0.00084620
+Merge Sort,333,143,0.00085330
+Merge Sort,333,144,0.00093260
+Merge Sort,333,145,0.00088650
+Merge Sort,333,146,0.00085360
+Merge Sort,333,147,0.00096880
+Merge Sort,333,148,0.00090040
+Merge Sort,333,149,0.00085210
+Merge Sort,333,150,0.00085150
+Merge Sort,333,151,0.00084510
+Merge Sort,333,152,0.00085130
+Merge Sort,333,153,0.00087060
+Merge Sort,333,154,0.00087930
+Merge Sort,333,155,0.00089990
+Merge Sort,333,156,0.00086150
+Merge Sort,333,157,0.00094030
+Merge Sort,333,158,0.00102160
+Merge Sort,333,159,0.00084670
+Merge Sort,333,160,0.00084180
+Merge Sort,333,161,0.00084760
+Merge Sort,333,162,0.00086310
+Merge Sort,333,163,0.00091280
+Merge Sort,333,164,0.00090640
+Merge Sort,333,165,0.00085740
+Merge Sort,333,166,0.00084580
+Merge Sort,333,167,0.00102840
+Merge Sort,333,168,0.00084850
+Merge Sort,333,169,0.00081890
+Merge Sort,333,170,0.00091850
+Merge Sort,333,171,0.00086170
+Merge Sort,333,172,0.00088280
+Merge Sort,333,173,0.00085640
+Merge Sort,333,174,0.00084880
+Merge Sort,333,175,0.00084850
+Merge Sort,333,176,0.00085400
+Merge Sort,333,177,0.00081890
+Merge Sort,333,178,0.00092440
+Merge Sort,333,179,0.00095960
+Merge Sort,333,180,0.00085640
+Merge Sort,333,181,0.00087620
+Merge Sort,333,182,0.00089120
+Merge Sort,333,183,0.00087730
+Merge Sort,333,184,0.00084930
+Merge Sort,333,185,0.00081810
+Merge Sort,333,186,0.00084320
+Merge Sort,333,187,0.00093690
+Merge Sort,333,188,0.00087100
+Merge Sort,333,189,0.00084820
+Merge Sort,333,190,0.00086330
+Merge Sort,333,191,0.00089650
+Merge Sort,333,192,0.00084950
+Merge Sort,333,193,0.00081940
+Merge Sort,333,194,0.00084960
+Merge Sort,333,195,0.00084630
+Merge Sort,333,196,0.00094230
+Merge Sort,333,197,0.00087430
+Merge Sort,333,198,0.00095620
+Merge Sort,333,199,0.00086230
+Merge Sort,333,200,0.00085820
+Merge Sort,333,201,0.00085030
+Merge Sort,333,202,0.00082090
+Merge Sort,333,203,0.00085040
+Merge Sort,333,204,0.00084140
+Merge Sort,333,205,0.00086970
+Merge Sort,333,206,0.00094330
+Merge Sort,333,207,0.00087980
+Merge Sort,333,208,0.00086800
+Merge Sort,333,209,0.00085510
+Merge Sort,333,210,0.00086450
+Merge Sort,333,211,0.00085210
+Merge Sort,333,212,0.00084550
+Merge Sort,333,213,0.00084180
+Merge Sort,333,214,0.00087650
+Merge Sort,333,215,0.00095090
+Merge Sort,333,216,0.00089340
+Merge Sort,333,217,0.00088680
+Merge Sort,333,218,0.00085550
+Merge Sort,333,219,0.00086530
+Merge Sort,333,220,0.00084990
+Merge Sort,333,221,0.00102940
+Merge Sort,333,222,0.00090590
+Merge Sort,333,223,0.00086650
+Merge Sort,333,224,0.00086940
+Merge Sort,333,225,0.00091310
+Merge Sort,333,226,0.00085800
+Merge Sort,333,227,0.00085570
+Merge Sort,333,228,0.00086060
+Merge Sort,333,229,0.00084710
+Merge Sort,333,230,0.00090490
+Merge Sort,333,231,0.00105020
+Merge Sort,333,232,0.00086700
+Merge Sort,333,233,0.00086440
+Merge Sort,333,234,0.00090590
+Merge Sort,333,235,0.00085930
+Merge Sort,333,236,0.00085350
+Merge Sort,333,237,0.00085950
+Merge Sort,333,238,0.00085050
+Merge Sort,333,239,0.00088560
+Merge Sort,333,240,0.00096570
+Merge Sort,333,241,0.00086400
+Merge Sort,333,242,0.00087200
+Merge Sort,333,243,0.00086820
+Merge Sort,333,244,0.00091430
+Merge Sort,333,245,0.00085540
+Merge Sort,333,246,0.00086320
+Merge Sort,333,247,0.00084940
+Merge Sort,333,248,0.00089410
+Merge Sort,333,249,0.00086320
+Merge Sort,333,250,0.00093340
+Merge Sort,333,251,0.00086460
+Merge Sort,333,252,0.00087180
+Merge Sort,333,253,0.00085430
+Merge Sort,333,254,0.00088370
+Merge Sort,333,255,0.00086110
+Merge Sort,333,256,0.00084760
+Merge Sort,333,257,0.00085990
+Merge Sort,333,258,0.00086120
+Merge Sort,333,259,0.00092450
+Merge Sort,333,260,0.00093580
+Merge Sort,333,261,0.00086000
+Merge Sort,333,262,0.00085430
+Merge Sort,333,263,0.00091370
+Merge Sort,333,264,0.00081620
+Merge Sort,333,265,0.00084710
+Merge Sort,333,266,0.00089320
+Merge Sort,333,267,0.00088300
+Merge Sort,333,268,0.00091610
+Merge Sort,333,269,0.00086880
+Merge Sort,333,270,0.00085420
+Merge Sort,333,271,0.00085850
+Merge Sort,333,272,0.00094210
+Merge Sort,333,273,0.00094170
+Merge Sort,333,274,0.00087070
+Merge Sort,333,275,0.00085210
+Merge Sort,333,276,0.00087210
+Merge Sort,333,277,0.00086550
+Merge Sort,333,278,0.00087570
+Merge Sort,333,279,0.00088060
+Merge Sort,333,280,0.00088290
+Merge Sort,333,281,0.00093040
+Merge Sort,333,282,0.00085700
+Merge Sort,333,283,0.00100310
+Merge Sort,333,284,0.00084030
+Merge Sort,333,285,0.00092060
+Merge Sort,333,286,0.00086320
+Merge Sort,333,287,0.00087210
+Merge Sort,333,288,0.00090280
+Merge Sort,333,289,0.00086590
+Merge Sort,333,290,0.00092360
+Merge Sort,333,291,0.00082580
+Merge Sort,333,292,0.00090940
+Merge Sort,333,293,0.00087750
+Merge Sort,333,294,0.00098350
+Merge Sort,333,295,0.00088820
+Merge Sort,333,296,0.00087830
+Merge Sort,333,297,0.00086650
+Merge Sort,333,298,0.00089030
+Merge Sort,333,299,0.00076540
+Merge Sort,333,300,0.00086680
+Merge Sort,333,301,0.00086760
+Merge Sort,333,302,0.00081650
+Merge Sort,333,303,0.00087820
+Merge Sort,333,304,0.00091460
+Merge Sort,333,305,0.00089640
+Merge Sort,333,306,0.00086820
+Merge Sort,333,307,0.00086310
+Merge Sort,333,308,0.00080730
+Merge Sort,333,309,0.00086230
+Merge Sort,333,310,0.00092670
+Merge Sort,333,311,0.00086030
+Merge Sort,333,312,0.00087890
+Merge Sort,333,313,0.00088970
+Merge Sort,333,314,0.00087920
+Merge Sort,333,315,0.00085370
+Merge Sort,333,316,0.00087840
+Merge Sort,333,317,0.00077520
+Merge Sort,333,318,0.00081160
+Merge Sort,333,319,0.00087790
+Merge Sort,333,320,0.00082040
+Merge Sort,333,321,0.00087180
+Merge Sort,333,322,0.00074840
+Merge Sort,333,323,0.00084040
+Merge Sort,333,324,0.00096370
+Merge Sort,333,325,0.00080330
+Merge Sort,333,326,0.00091950
+Merge Sort,333,327,0.00083580
+Merge Sort,333,328,0.00087050
+Merge Sort,333,329,0.00090110
+Merge Sort,333,330,0.00092510
+Merge Sort,333,331,0.00082480
+Merge Sort,333,332,0.00081180
+Merge Sort,333,333,0.00088500
+Merge Sort,333,334,0.00071520
+Merge Sort,333,335,0.00070700
+Merge Sort,333,336,0.00087830
+Merge Sort,333,337,0.00089380
+Merge Sort,333,338,0.00086330
+Merge Sort,333,339,0.00088080
+Merge Sort,333,340,0.00087630
+Merge Sort,333,341,0.00088350
+Merge Sort,333,342,0.00094730
+Merge Sort,333,343,0.00090870
+Merge Sort,333,344,0.00088920
+Merge Sort,333,345,0.00090000
+Merge Sort,333,346,0.00084360
+Merge Sort,333,347,0.00097950
+Merge Sort,333,348,0.00083250
+Merge Sort,333,349,0.00086260
+Merge Sort,333,350,0.00088640
+Merge Sort,333,351,0.00087720
+Merge Sort,333,352,0.00090000
+Merge Sort,333,353,0.00080220
+Merge Sort,333,354,0.00086540
+Merge Sort,333,355,0.00094330
+Merge Sort,333,356,0.00090270
+Merge Sort,333,357,0.00092340
+Merge Sort,333,358,0.00082140
+Merge Sort,333,359,0.00083530
+Merge Sort,333,360,0.00086190
+Merge Sort,333,361,0.00086570
+Merge Sort,333,362,0.00084470
+Merge Sort,333,363,0.00095080
+Merge Sort,333,364,0.00092820
+Merge Sort,333,365,0.00088390
+Merge Sort,333,366,0.00093540
+Merge Sort,333,367,0.00089910
+Merge Sort,333,368,0.00091600
+Merge Sort,333,369,0.00090040
+Merge Sort,333,370,0.00085670
+Merge Sort,333,371,0.00089730
+Merge Sort,333,372,0.00087190
+Merge Sort,333,373,0.00089970
+Merge Sort,333,374,0.00089080
+Merge Sort,333,375,0.00092470
+Merge Sort,333,376,0.00079440
+Merge Sort,333,377,0.00087950
+Merge Sort,333,378,0.00088640
+Merge Sort,333,379,0.00081140
+Merge Sort,333,380,0.00090620
+Merge Sort,333,381,0.00091250
+Merge Sort,333,382,0.00085220
+Merge Sort,333,383,0.00085680
+Merge Sort,333,384,0.00094840
+Merge Sort,333,385,0.00090280
+Merge Sort,333,386,0.00078810
+Merge Sort,333,387,0.00085390
+Merge Sort,333,388,0.00092130
+Merge Sort,333,389,0.00085960
+Merge Sort,333,390,0.00085480
+Merge Sort,333,391,0.00083580
+Merge Sort,333,392,0.00090780
+Merge Sort,333,393,0.00087870
+Merge Sort,333,394,0.00090970
+Merge Sort,333,395,0.00090610
+Merge Sort,333,396,0.00084240
+Merge Sort,333,397,0.00085300
+Merge Sort,333,398,0.00089280
+Merge Sort,333,399,0.00088630
+Merge Sort,333,400,0.00087510
+Merge Sort,333,401,0.00088630
+Merge Sort,333,402,0.00092610
+Merge Sort,333,403,0.00089390
+Merge Sort,333,404,0.00091890
+Merge Sort,333,405,0.00089960
+Merge Sort,333,406,0.00088900
+Merge Sort,333,407,0.00081560
+Merge Sort,333,408,0.00086660
+Merge Sort,333,409,0.00098410
+Merge Sort,333,410,0.00080350
+Merge Sort,333,411,0.00088390
+Merge Sort,333,412,0.00085860
+Merge Sort,333,413,0.00088910
+Merge Sort,333,414,0.00094980
+Merge Sort,333,415,0.00094170
+Merge Sort,333,416,0.00093180
+Merge Sort,333,417,0.00089500
+Merge Sort,333,418,0.00087580
+Merge Sort,333,419,0.00088660
+Merge Sort,333,420,0.00089460
+Merge Sort,333,421,0.00088080
+Merge Sort,333,422,0.00091700
+Merge Sort,333,423,0.00073130
+Merge Sort,333,424,0.00085330
+Merge Sort,333,425,0.00085730
+Merge Sort,333,426,0.00080940
+Merge Sort,333,427,0.00086530
+Merge Sort,333,428,0.00066150
+Merge Sort,333,429,0.00092150
+Merge Sort,333,430,0.00092560
+Merge Sort,333,431,0.00074880
+Merge Sort,333,432,0.00080990
+Merge Sort,333,433,0.00090720
+Merge Sort,333,434,0.00064430
+Merge Sort,333,435,0.00089570
+Merge Sort,333,436,0.00080590
+Merge Sort,333,437,0.00087080
+Merge Sort,333,438,0.00084490
+Merge Sort,333,439,0.00084180
+Merge Sort,333,440,0.00090290
+Merge Sort,333,441,0.00081710
+Merge Sort,333,442,0.00081240
+Merge Sort,333,443,0.00049810
+Merge Sort,333,444,0.00059220
+Merge Sort,333,445,0.00080810
+Merge Sort,333,446,0.00088170
+Merge Sort,333,447,0.00088140
+Merge Sort,333,448,0.00081390
+Merge Sort,333,449,0.00086220
+Merge Sort,333,450,0.00086760
+Merge Sort,333,451,0.00087150
+Merge Sort,333,452,0.00081320
+Merge Sort,333,453,0.00082020
+Merge Sort,333,454,0.00071670
+Merge Sort,333,455,0.00081440
+Merge Sort,333,456,0.00080930
+Merge Sort,333,457,0.00055790
+Merge Sort,333,458,0.00084870
+Merge Sort,333,459,0.00084300
+Merge Sort,333,460,0.00081270
+Merge Sort,333,461,0.00080640
+Merge Sort,333,462,0.00084080
+Merge Sort,333,463,0.00090480
+Merge Sort,333,464,0.00086690
+Merge Sort,333,465,0.00083630
+Merge Sort,333,466,0.00084150
+Merge Sort,333,467,0.00081040
+Merge Sort,333,468,0.00088870
+Merge Sort,333,469,0.00080290
+Merge Sort,333,470,0.00083240
+Merge Sort,333,471,0.00088850
+Merge Sort,333,472,0.00083930
+Merge Sort,333,473,0.00080830
+Merge Sort,333,474,0.00088740
+Merge Sort,333,475,0.00088390
+Merge Sort,333,476,0.00084690
+Merge Sort,333,477,0.00061630
+Merge Sort,333,478,0.00062460
+Merge Sort,333,479,0.00087220
+Merge Sort,333,480,0.00082970
+Merge Sort,333,481,0.00085020
+Merge Sort,333,482,0.00079210
+Merge Sort,333,483,0.00081930
+Merge Sort,333,484,0.00081980
+Merge Sort,333,485,0.00073840
+Merge Sort,333,486,0.00056460
+Merge Sort,333,487,0.00084220
+Merge Sort,333,488,0.00072280
+Merge Sort,333,489,0.00051850
+Merge Sort,333,490,0.00084350
+Merge Sort,333,491,0.00048650
+Merge Sort,333,492,0.00081710
+Merge Sort,333,493,0.00081940
+Merge Sort,333,494,0.00052320
+Merge Sort,333,495,0.00049440
+Merge Sort,333,496,0.00078650
+Merge Sort,333,497,0.00058660
+Merge Sort,333,498,0.00075880
+Merge Sort,333,499,0.00080070
+Merge Sort,333,500,0.00081410
+Merge Sort In-Place,333,1,0.00099300
+Merge Sort In-Place,333,2,0.00083500
+Merge Sort In-Place,333,3,0.00096880
+Merge Sort In-Place,333,4,0.00060810
+Merge Sort In-Place,333,5,0.00062690
+Merge Sort In-Place,333,6,0.00104940
+Merge Sort In-Place,333,7,0.00097790
+Merge Sort In-Place,333,8,0.00093920
+Merge Sort In-Place,333,9,0.00099580
+Merge Sort In-Place,333,10,0.00096650
+Merge Sort In-Place,333,11,0.00102250
+Merge Sort In-Place,333,12,0.00104060
+Merge Sort In-Place,333,13,0.00084660
+Merge Sort In-Place,333,14,0.00090200
+Merge Sort In-Place,333,15,0.00096760
+Merge Sort In-Place,333,16,0.00099350
+Merge Sort In-Place,333,17,0.00096070
+Merge Sort In-Place,333,18,0.00097850
+Merge Sort In-Place,333,19,0.00100490
+Merge Sort In-Place,333,20,0.00097860
+Merge Sort In-Place,333,21,0.00096770
+Merge Sort In-Place,333,22,0.00093100
+Merge Sort In-Place,333,23,0.00096930
+Merge Sort In-Place,333,24,0.00079340
+Merge Sort In-Place,333,25,0.00082050
+Merge Sort In-Place,333,26,0.00094780
+Merge Sort In-Place,333,27,0.00096520
+Merge Sort In-Place,333,28,0.00097980
+Merge Sort In-Place,333,29,0.00097230
+Merge Sort In-Place,333,30,0.00103330
+Merge Sort In-Place,333,31,0.00103610
+Merge Sort In-Place,333,32,0.00103110
+Merge Sort In-Place,333,33,0.00107410
+Merge Sort In-Place,333,34,0.00096360
+Merge Sort In-Place,333,35,0.00105300
+Merge Sort In-Place,333,36,0.00097500
+Merge Sort In-Place,333,37,0.00080280
+Merge Sort In-Place,333,38,0.00090580
+Merge Sort In-Place,333,39,0.00103750
+Merge Sort In-Place,333,40,0.00102090
+Merge Sort In-Place,333,41,0.00109750
+Merge Sort In-Place,333,42,0.00101800
+Merge Sort In-Place,333,43,0.00098170
+Merge Sort In-Place,333,44,0.00093880
+Merge Sort In-Place,333,45,0.00105710
+Merge Sort In-Place,333,46,0.00096320
+Merge Sort In-Place,333,47,0.00100180
+Merge Sort In-Place,333,48,0.00092770
+Merge Sort In-Place,333,49,0.00101610
+Merge Sort In-Place,333,50,0.00094380
+Merge Sort In-Place,333,51,0.00104820
+Merge Sort In-Place,333,52,0.00101120
+Merge Sort In-Place,333,53,0.00103600
+Merge Sort In-Place,333,54,0.00092040
+Merge Sort In-Place,333,55,0.00101500
+Merge Sort In-Place,333,56,0.00098030
+Merge Sort In-Place,333,57,0.00101110
+Merge Sort In-Place,333,58,0.00100690
+Merge Sort In-Place,333,59,0.00109120
+Merge Sort In-Place,333,60,0.00103170
+Merge Sort In-Place,333,61,0.00096480
+Merge Sort In-Place,333,62,0.00109620
+Merge Sort In-Place,333,63,0.00103450
+Merge Sort In-Place,333,64,0.00102530
+Merge Sort In-Place,333,65,0.00100730
+Merge Sort In-Place,333,66,0.00104710
+Merge Sort In-Place,333,67,0.00102390
+Merge Sort In-Place,333,68,0.00099100
+Merge Sort In-Place,333,69,0.00105920
+Merge Sort In-Place,333,70,0.00091690
+Merge Sort In-Place,333,71,0.00100640
+Merge Sort In-Place,333,72,0.00100150
+Merge Sort In-Place,333,73,0.00097190
+Merge Sort In-Place,333,74,0.00101410
+Merge Sort In-Place,333,75,0.00101150
+Merge Sort In-Place,333,76,0.00077580
+Merge Sort In-Place,333,77,0.00097810
+Merge Sort In-Place,333,78,0.00106460
+Merge Sort In-Place,333,79,0.00102250
+Merge Sort In-Place,333,80,0.00105060
+Merge Sort In-Place,333,81,0.00093710
+Merge Sort In-Place,333,82,0.00102760
+Merge Sort In-Place,333,83,0.00105630
+Merge Sort In-Place,333,84,0.00110090
+Merge Sort In-Place,333,85,0.00091560
+Merge Sort In-Place,333,86,0.00107450
+Merge Sort In-Place,333,87,0.00103200
+Merge Sort In-Place,333,88,0.00097000
+Merge Sort In-Place,333,89,0.00093030
+Merge Sort In-Place,333,90,0.00103760
+Merge Sort In-Place,333,91,0.00103080
+Merge Sort In-Place,333,92,0.00098250
+Merge Sort In-Place,333,93,0.00104050
+Merge Sort In-Place,333,94,0.00111990
+Merge Sort In-Place,333,95,0.00106850
+Merge Sort In-Place,333,96,0.00096750
+Merge Sort In-Place,333,97,0.00098180
+Merge Sort In-Place,333,98,0.00101670
+Merge Sort In-Place,333,99,0.00103200
+Merge Sort In-Place,333,100,0.00105230
+Merge Sort In-Place,333,101,0.00101160
+Merge Sort In-Place,333,102,0.00104800
+Merge Sort In-Place,333,103,0.00079330
+Merge Sort In-Place,333,104,0.00100830
+Merge Sort In-Place,333,105,0.00103270
+Merge Sort In-Place,333,106,0.00092170
+Merge Sort In-Place,333,107,0.00096970
+Merge Sort In-Place,333,108,0.00098770
+Merge Sort In-Place,333,109,0.00061360
+Merge Sort In-Place,333,110,0.00073690
+Merge Sort In-Place,333,111,0.00100780
+Merge Sort In-Place,333,112,0.00100710
+Merge Sort In-Place,333,113,0.00100850
+Merge Sort In-Place,333,114,0.00106970
+Merge Sort In-Place,333,115,0.00089820
+Merge Sort In-Place,333,116,0.00101350
+Merge Sort In-Place,333,117,0.00090800
+Merge Sort In-Place,333,118,0.00078060
+Merge Sort In-Place,333,119,0.00090750
+Merge Sort In-Place,333,120,0.00094380
+Merge Sort In-Place,333,121,0.00097080
+Merge Sort In-Place,333,122,0.00087770
+Merge Sort In-Place,333,123,0.00076000
+Merge Sort In-Place,333,124,0.00095860
+Merge Sort In-Place,333,125,0.00063680
+Merge Sort In-Place,333,126,0.00097210
+Merge Sort In-Place,333,127,0.00086070
+Merge Sort In-Place,333,128,0.00104190
+Merge Sort In-Place,333,129,0.00092250
+Merge Sort In-Place,333,130,0.00104880
+Merge Sort In-Place,333,131,0.00099350
+Merge Sort In-Place,333,132,0.00067400
+Merge Sort In-Place,333,133,0.00096880
+Merge Sort In-Place,333,134,0.00094700
+Merge Sort In-Place,333,135,0.00098840
+Merge Sort In-Place,333,136,0.00084060
+Merge Sort In-Place,333,137,0.00096380
+Merge Sort In-Place,333,138,0.00098090
+Merge Sort In-Place,333,139,0.00094840
+Merge Sort In-Place,333,140,0.00078160
+Merge Sort In-Place,333,141,0.00106550
+Merge Sort In-Place,333,142,0.00102140
+Merge Sort In-Place,333,143,0.00099850
+Merge Sort In-Place,333,144,0.00097630
+Merge Sort In-Place,333,145,0.00109310
+Merge Sort In-Place,333,146,0.00101640
+Merge Sort In-Place,333,147,0.00099860
+Merge Sort In-Place,333,148,0.00100710
+Merge Sort In-Place,333,149,0.00103950
+Merge Sort In-Place,333,150,0.00104360
+Merge Sort In-Place,333,151,0.00100670
+Merge Sort In-Place,333,152,0.00111780
+Merge Sort In-Place,333,153,0.00108030
+Merge Sort In-Place,333,154,0.00106460
+Merge Sort In-Place,333,155,0.00097130
+Merge Sort In-Place,333,156,0.00104440
+Merge Sort In-Place,333,157,0.00101830
+Merge Sort In-Place,333,158,0.00098350
+Merge Sort In-Place,333,159,0.00090550
+Merge Sort In-Place,333,160,0.00106320
+Merge Sort In-Place,333,161,0.00102420
+Merge Sort In-Place,333,162,0.00102670
+Merge Sort In-Place,333,163,0.00100670
+Merge Sort In-Place,333,164,0.00100690
+Merge Sort In-Place,333,165,0.00105440
+Merge Sort In-Place,333,166,0.00097930
+Merge Sort In-Place,333,167,0.00104210
+Merge Sort In-Place,333,168,0.00103930
+Merge Sort In-Place,333,169,0.00106130
+Merge Sort In-Place,333,170,0.00098710
+Merge Sort In-Place,333,171,0.00101580
+Merge Sort In-Place,333,172,0.00102590
+Merge Sort In-Place,333,173,0.00095640
+Merge Sort In-Place,333,174,0.00095300
+Merge Sort In-Place,333,175,0.00102620
+Merge Sort In-Place,333,176,0.00098530
+Merge Sort In-Place,333,177,0.00084040
+Merge Sort In-Place,333,178,0.00097590
+Merge Sort In-Place,333,179,0.00095330
+Merge Sort In-Place,333,180,0.00093150
+Merge Sort In-Place,333,181,0.00063390
+Merge Sort In-Place,333,182,0.00099990
+Merge Sort In-Place,333,183,0.00095800
+Merge Sort In-Place,333,184,0.00096090
+Merge Sort In-Place,333,185,0.00103860
+Merge Sort In-Place,333,186,0.00067520
+Merge Sort In-Place,333,187,0.00095950
+Merge Sort In-Place,333,188,0.00095540
+Merge Sort In-Place,333,189,0.00100720
+Merge Sort In-Place,333,190,0.00097610
+Merge Sort In-Place,333,191,0.00097160
+Merge Sort In-Place,333,192,0.00081680
+Merge Sort In-Place,333,193,0.00103810
+Merge Sort In-Place,333,194,0.00085820
+Merge Sort In-Place,333,195,0.00093450
+Merge Sort In-Place,333,196,0.00099850
+Merge Sort In-Place,333,197,0.00067820
+Merge Sort In-Place,333,198,0.00086070
+Merge Sort In-Place,333,199,0.00095890
+Merge Sort In-Place,333,200,0.00095430
+Merge Sort In-Place,333,201,0.00096440
+Merge Sort In-Place,333,202,0.00103330
+Merge Sort In-Place,333,203,0.00104540
+Merge Sort In-Place,333,204,0.00089490
+Merge Sort In-Place,333,205,0.00096160
+Merge Sort In-Place,333,206,0.00066440
+Merge Sort In-Place,333,207,0.00096660
+Merge Sort In-Place,333,208,0.00100620
+Merge Sort In-Place,333,209,0.00057740
+Merge Sort In-Place,333,210,0.00096310
+Merge Sort In-Place,333,211,0.00087720
+Merge Sort In-Place,333,212,0.00099140
+Merge Sort In-Place,333,213,0.00087160
+Merge Sort In-Place,333,214,0.00094780
+Merge Sort In-Place,333,215,0.00096130
+Merge Sort In-Place,333,216,0.00095560
+Merge Sort In-Place,333,217,0.00096250
+Merge Sort In-Place,333,218,0.00100950
+Merge Sort In-Place,333,219,0.00074720
+Merge Sort In-Place,333,220,0.00083420
+Merge Sort In-Place,333,221,0.00106190
+Merge Sort In-Place,333,222,0.00086120
+Merge Sort In-Place,333,223,0.00104000
+Merge Sort In-Place,333,224,0.00093510
+Merge Sort In-Place,333,225,0.00105050
+Merge Sort In-Place,333,226,0.00096300
+Merge Sort In-Place,333,227,0.00100310
+Merge Sort In-Place,333,228,0.00094470
+Merge Sort In-Place,333,229,0.00104810
+Merge Sort In-Place,333,230,0.00103110
+Merge Sort In-Place,333,231,0.00101710
+Merge Sort In-Place,333,232,0.00100690
+Merge Sort In-Place,333,233,0.00088230
+Merge Sort In-Place,333,234,0.00107970
+Merge Sort In-Place,333,235,0.00099580
+Merge Sort In-Place,333,236,0.00099410
+Merge Sort In-Place,333,237,0.00106440
+Merge Sort In-Place,333,238,0.00100970
+Merge Sort In-Place,333,239,0.00103920
+Merge Sort In-Place,333,240,0.00104820
+Merge Sort In-Place,333,241,0.00077520
+Merge Sort In-Place,333,242,0.00100790
+Merge Sort In-Place,333,243,0.00097060
+Merge Sort In-Place,333,244,0.00101020
+Merge Sort In-Place,333,245,0.00096660
+Merge Sort In-Place,333,246,0.00070330
+Merge Sort In-Place,333,247,0.00095990
+Merge Sort In-Place,333,248,0.00099340
+Merge Sort In-Place,333,249,0.00067090
+Merge Sort In-Place,333,250,0.00108430
+Merge Sort In-Place,333,251,0.00093220
+Merge Sort In-Place,333,252,0.00096860
+Merge Sort In-Place,333,253,0.00093380
+Merge Sort In-Place,333,254,0.00091560
+Merge Sort In-Place,333,255,0.00097250
+Merge Sort In-Place,333,256,0.00104220
+Merge Sort In-Place,333,257,0.00073100
+Merge Sort In-Place,333,258,0.00095100
+Merge Sort In-Place,333,259,0.00101180
+Merge Sort In-Place,333,260,0.00107320
+Merge Sort In-Place,333,261,0.00103250
+Merge Sort In-Place,333,262,0.00081620
+Merge Sort In-Place,333,263,0.00088210
+Merge Sort In-Place,333,264,0.00100350
+Merge Sort In-Place,333,265,0.00102500
+Merge Sort In-Place,333,266,0.00101890
+Merge Sort In-Place,333,267,0.00104940
+Merge Sort In-Place,333,268,0.00107960
+Merge Sort In-Place,333,269,0.00078570
+Merge Sort In-Place,333,270,0.00071220
+Merge Sort In-Place,333,271,0.00101870
+Merge Sort In-Place,333,272,0.00070610
+Merge Sort In-Place,333,273,0.00102080
+Merge Sort In-Place,333,274,0.00103620
+Merge Sort In-Place,333,275,0.00096520
+Merge Sort In-Place,333,276,0.00057540
+Merge Sort In-Place,333,277,0.00099280
+Merge Sort In-Place,333,278,0.00089000
+Merge Sort In-Place,333,279,0.00070530
+Merge Sort In-Place,333,280,0.00101000
+Merge Sort In-Place,333,281,0.00097710
+Merge Sort In-Place,333,282,0.00076950
+Merge Sort In-Place,333,283,0.00107680
+Merge Sort In-Place,333,284,0.00105550
+Merge Sort In-Place,333,285,0.00078260
+Merge Sort In-Place,333,286,0.00103700
+Merge Sort In-Place,333,287,0.00101170
+Merge Sort In-Place,333,288,0.00096300
+Merge Sort In-Place,333,289,0.00100670
+Merge Sort In-Place,333,290,0.00102500
+Merge Sort In-Place,333,291,0.00105860
+Merge Sort In-Place,333,292,0.00098820
+Merge Sort In-Place,333,293,0.00076380
+Merge Sort In-Place,333,294,0.00075030
+Merge Sort In-Place,333,295,0.00093470
+Merge Sort In-Place,333,296,0.00101970
+Merge Sort In-Place,333,297,0.00101920
+Merge Sort In-Place,333,298,0.00063050
+Merge Sort In-Place,333,299,0.00094200
+Merge Sort In-Place,333,300,0.00092240
+Merge Sort In-Place,333,301,0.00096030
+Merge Sort In-Place,333,302,0.00098810
+Merge Sort In-Place,333,303,0.00074960
+Merge Sort In-Place,333,304,0.00094750
+Merge Sort In-Place,333,305,0.00065070
+Merge Sort In-Place,333,306,0.00095960
+Merge Sort In-Place,333,307,0.00096800
+Merge Sort In-Place,333,308,0.00091290
+Merge Sort In-Place,333,309,0.00096480
+Merge Sort In-Place,333,310,0.00095360
+Merge Sort In-Place,333,311,0.00105330
+Merge Sort In-Place,333,312,0.00077130
+Merge Sort In-Place,333,313,0.00100130
+Merge Sort In-Place,333,314,0.00101900
+Merge Sort In-Place,333,315,0.00099980
+Merge Sort In-Place,333,316,0.00096730
+Merge Sort In-Place,333,317,0.00102240
+Merge Sort In-Place,333,318,0.00102900
+Merge Sort In-Place,333,319,0.00079360
+Merge Sort In-Place,333,320,0.00099810
+Merge Sort In-Place,333,321,0.00105470
+Merge Sort In-Place,333,322,0.00096480
+Merge Sort In-Place,333,323,0.00081700
+Merge Sort In-Place,333,324,0.00094700
+Merge Sort In-Place,333,325,0.00102600
+Merge Sort In-Place,333,326,0.00102170
+Merge Sort In-Place,333,327,0.00098980
+Merge Sort In-Place,333,328,0.00093080
+Merge Sort In-Place,333,329,0.00097680
+Merge Sort In-Place,333,330,0.00101790
+Merge Sort In-Place,333,331,0.00106050
+Merge Sort In-Place,333,332,0.00101740
+Merge Sort In-Place,333,333,0.00101080
+Merge Sort In-Place,333,334,0.00093170
+Merge Sort In-Place,333,335,0.00096810
+Merge Sort In-Place,333,336,0.00100120
+Merge Sort In-Place,333,337,0.00096290
+Merge Sort In-Place,333,338,0.00101250
+Merge Sort In-Place,333,339,0.00097800
+Merge Sort In-Place,333,340,0.00094590
+Merge Sort In-Place,333,341,0.00098550
+Merge Sort In-Place,333,342,0.00099020
+Merge Sort In-Place,333,343,0.00103960
+Merge Sort In-Place,333,344,0.00096050
+Merge Sort In-Place,333,345,0.00098130
+Merge Sort In-Place,333,346,0.00092840
+Merge Sort In-Place,333,347,0.00098710
+Merge Sort In-Place,333,348,0.00095870
+Merge Sort In-Place,333,349,0.00080070
+Merge Sort In-Place,333,350,0.00096580
+Merge Sort In-Place,333,351,0.00100700
+Merge Sort In-Place,333,352,0.00101940
+Merge Sort In-Place,333,353,0.00094860
+Merge Sort In-Place,333,354,0.00103640
+Merge Sort In-Place,333,355,0.00104580
+Merge Sort In-Place,333,356,0.00083650
+Merge Sort In-Place,333,357,0.00098460
+Merge Sort In-Place,333,358,0.00105610
+Merge Sort In-Place,333,359,0.00093980
+Merge Sort In-Place,333,360,0.00095720
+Merge Sort In-Place,333,361,0.00106990
+Merge Sort In-Place,333,362,0.00097240
+Merge Sort In-Place,333,363,0.00098360
+Merge Sort In-Place,333,364,0.00100950
+Merge Sort In-Place,333,365,0.00096580
+Merge Sort In-Place,333,366,0.00106270
+Merge Sort In-Place,333,367,0.00097590
+Merge Sort In-Place,333,368,0.00101910
+Merge Sort In-Place,333,369,0.00073840
+Merge Sort In-Place,333,370,0.00098620
+Merge Sort In-Place,333,371,0.00100400
+Merge Sort In-Place,333,372,0.00098660
+Merge Sort In-Place,333,373,0.00099230
+Merge Sort In-Place,333,374,0.00100070
+Merge Sort In-Place,333,375,0.00102990
+Merge Sort In-Place,333,376,0.00095230
+Merge Sort In-Place,333,377,0.00104150
+Merge Sort In-Place,333,378,0.00099900
+Merge Sort In-Place,333,379,0.00100610
+Merge Sort In-Place,333,380,0.00080180
+Merge Sort In-Place,333,381,0.00094960
+Merge Sort In-Place,333,382,0.00109410
+Merge Sort In-Place,333,383,0.00095360
+Merge Sort In-Place,333,384,0.00103550
+Merge Sort In-Place,333,385,0.00103140
+Merge Sort In-Place,333,386,0.00097820
+Merge Sort In-Place,333,387,0.00102940
+Merge Sort In-Place,333,388,0.00076490
+Merge Sort In-Place,333,389,0.00083860
+Merge Sort In-Place,333,390,0.00066210
+Merge Sort In-Place,333,391,0.00060560
+Merge Sort In-Place,333,392,0.00065740
+Merge Sort In-Place,333,393,0.00102780
+Merge Sort In-Place,333,394,0.00097070
+Merge Sort In-Place,333,395,0.00088260
+Merge Sort In-Place,333,396,0.00059530
+Merge Sort In-Place,333,397,0.00097800
+Merge Sort In-Place,333,398,0.00080460
+Merge Sort In-Place,333,399,0.00062250
+Merge Sort In-Place,333,400,0.00103710
+Merge Sort In-Place,333,401,0.00098650
+Merge Sort In-Place,333,402,0.00062780
+Merge Sort In-Place,333,403,0.00092560
+Merge Sort In-Place,333,404,0.00062060
+Merge Sort In-Place,333,405,0.00085790
+Merge Sort In-Place,333,406,0.00097090
+Merge Sort In-Place,333,407,0.00095080
+Merge Sort In-Place,333,408,0.00096520
+Merge Sort In-Place,333,409,0.00098610
+Merge Sort In-Place,333,410,0.00103220
+Merge Sort In-Place,333,411,0.00105140
+Merge Sort In-Place,333,412,0.00105750
+Merge Sort In-Place,333,413,0.00094590
+Merge Sort In-Place,333,414,0.00104100
+Merge Sort In-Place,333,415,0.00105300
+Merge Sort In-Place,333,416,0.00109430
+Merge Sort In-Place,333,417,0.00081240
+Merge Sort In-Place,333,418,0.00092150
+Merge Sort In-Place,333,419,0.00098890
+Merge Sort In-Place,333,420,0.00103410
+Merge Sort In-Place,333,421,0.00102110
+Merge Sort In-Place,333,422,0.00097870
+Merge Sort In-Place,333,423,0.00100240
+Merge Sort In-Place,333,424,0.00083240
+Merge Sort In-Place,333,425,0.00100070
+Merge Sort In-Place,333,426,0.00103450
+Merge Sort In-Place,333,427,0.00101000
+Merge Sort In-Place,333,428,0.00101370
+Merge Sort In-Place,333,429,0.00103410
+Merge Sort In-Place,333,430,0.00104320
+Merge Sort In-Place,333,431,0.00101830
+Merge Sort In-Place,333,432,0.00094720
+Merge Sort In-Place,333,433,0.00097080
+Merge Sort In-Place,333,434,0.00105160
+Merge Sort In-Place,333,435,0.00100020
+Merge Sort In-Place,333,436,0.00095700
+Merge Sort In-Place,333,437,0.00103060
+Merge Sort In-Place,333,438,0.00098010
+Merge Sort In-Place,333,439,0.00095650
+Merge Sort In-Place,333,440,0.00085040
+Merge Sort In-Place,333,441,0.00097700
+Merge Sort In-Place,333,442,0.00090360
+Merge Sort In-Place,333,443,0.00095750
+Merge Sort In-Place,333,444,0.00104980
+Merge Sort In-Place,333,445,0.00073660
+Merge Sort In-Place,333,446,0.00102030
+Merge Sort In-Place,333,447,0.00101970
+Merge Sort In-Place,333,448,0.00097820
+Merge Sort In-Place,333,449,0.00096210
+Merge Sort In-Place,333,450,0.00100080
+Merge Sort In-Place,333,451,0.00099290
+Merge Sort In-Place,333,452,0.00105730
+Merge Sort In-Place,333,453,0.00087100
+Merge Sort In-Place,333,454,0.00092680
+Merge Sort In-Place,333,455,0.00096150
+Merge Sort In-Place,333,456,0.00102800
+Merge Sort In-Place,333,457,0.00100390
+Merge Sort In-Place,333,458,0.00095790
+Merge Sort In-Place,333,459,0.00104120
+Merge Sort In-Place,333,460,0.00104490
+Merge Sort In-Place,333,461,0.00080470
+Merge Sort In-Place,333,462,0.00107580
+Merge Sort In-Place,333,463,0.00094450
+Merge Sort In-Place,333,464,0.00100690
+Merge Sort In-Place,333,465,0.00098540
+Merge Sort In-Place,333,466,0.00096560
+Merge Sort In-Place,333,467,0.00098980
+Merge Sort In-Place,333,468,0.00091720
+Merge Sort In-Place,333,469,0.00104940
+Merge Sort In-Place,333,470,0.00100010
+Merge Sort In-Place,333,471,0.00101930
+Merge Sort In-Place,333,472,0.00083830
+Merge Sort In-Place,333,473,0.00113090
+Merge Sort In-Place,333,474,0.00111380
+Merge Sort In-Place,333,475,0.00105780
+Merge Sort In-Place,333,476,0.00105290
+Merge Sort In-Place,333,477,0.00100750
+Merge Sort In-Place,333,478,0.00099370
+Merge Sort In-Place,333,479,0.00103530
+Merge Sort In-Place,333,480,0.00091140
+Merge Sort In-Place,333,481,0.00086140
+Merge Sort In-Place,333,482,0.00097000
+Merge Sort In-Place,333,483,0.00088870
+Merge Sort In-Place,333,484,0.00080400
+Merge Sort In-Place,333,485,0.00105070
+Merge Sort In-Place,333,486,0.00102860
+Merge Sort In-Place,333,487,0.00093400
+Merge Sort In-Place,333,488,0.00076880
+Merge Sort In-Place,333,489,0.00104070
+Merge Sort In-Place,333,490,0.00088090
+Merge Sort In-Place,333,491,0.00091260
+Merge Sort In-Place,333,492,0.00087780
+Merge Sort In-Place,333,493,0.00084370
+Merge Sort In-Place,333,494,0.00100430
+Merge Sort In-Place,333,495,0.00104190
+Merge Sort In-Place,333,496,0.00102910
+Merge Sort In-Place,333,497,0.00093990
+Merge Sort In-Place,333,498,0.00106720
+Merge Sort In-Place,333,499,0.00099730
+Merge Sort In-Place,333,500,0.00102070
+Odd-Even Sort,333,1,0.00639200
+Odd-Even Sort,333,2,0.00661610
+Odd-Even Sort,333,3,0.00663150
+Odd-Even Sort,333,4,0.00676590
+Odd-Even Sort,333,5,0.00650980
+Odd-Even Sort,333,6,0.00675700
+Odd-Even Sort,333,7,0.00734640
+Odd-Even Sort,333,8,0.00651220
+Odd-Even Sort,333,9,0.00718600
+Odd-Even Sort,333,10,0.00627260
+Odd-Even Sort,333,11,0.00655400
+Odd-Even Sort,333,12,0.00676910
+Odd-Even Sort,333,13,0.00662930
+Odd-Even Sort,333,14,0.00671920
+Odd-Even Sort,333,15,0.00649360
+Odd-Even Sort,333,16,0.00651240
+Odd-Even Sort,333,17,0.00674230
+Odd-Even Sort,333,18,0.00672270
+Odd-Even Sort,333,19,0.00650690
+Odd-Even Sort,333,20,0.00641430
+Odd-Even Sort,333,21,0.00662240
+Odd-Even Sort,333,22,0.00645530
+Odd-Even Sort,333,23,0.00777180
+Odd-Even Sort,333,24,0.00676210
+Odd-Even Sort,333,25,0.00671900
+Odd-Even Sort,333,26,0.00748680
+Odd-Even Sort,333,27,0.00671610
+Odd-Even Sort,333,28,0.00649360
+Odd-Even Sort,333,29,0.00646630
+Odd-Even Sort,333,30,0.00678500
+Odd-Even Sort,333,31,0.00657540
+Odd-Even Sort,333,32,0.00657870
+Odd-Even Sort,333,33,0.00649680
+Odd-Even Sort,333,34,0.00735500
+Odd-Even Sort,333,35,0.00671210
+Odd-Even Sort,333,36,0.00775450
+Odd-Even Sort,333,37,0.00646550
+Odd-Even Sort,333,38,0.00661620
+Odd-Even Sort,333,39,0.00709020
+Odd-Even Sort,333,40,0.00641540
+Odd-Even Sort,333,41,0.00708730
+Odd-Even Sort,333,42,0.00670090
+Odd-Even Sort,333,43,0.00677520
+Odd-Even Sort,333,44,0.00706890
+Odd-Even Sort,333,45,0.00660100
+Odd-Even Sort,333,46,0.00629400
+Odd-Even Sort,333,47,0.00665470
+Odd-Even Sort,333,48,0.00668320
+Odd-Even Sort,333,49,0.00851790
+Odd-Even Sort,333,50,0.00676360
+Odd-Even Sort,333,51,0.00643180
+Odd-Even Sort,333,52,0.00654050
+Odd-Even Sort,333,53,0.00674960
+Odd-Even Sort,333,54,0.00853010
+Odd-Even Sort,333,55,0.00663620
+Odd-Even Sort,333,56,0.00674620
+Odd-Even Sort,333,57,0.00656990
+Odd-Even Sort,333,58,0.00659590
+Odd-Even Sort,333,59,0.00856160
+Odd-Even Sort,333,60,0.00696200
+Odd-Even Sort,333,61,0.00755890
+Odd-Even Sort,333,62,0.00647130
+Odd-Even Sort,333,63,0.00634210
+Odd-Even Sort,333,64,0.00653680
+Odd-Even Sort,333,65,0.00675310
+Odd-Even Sort,333,66,0.00682170
+Odd-Even Sort,333,67,0.00716670
+Odd-Even Sort,333,68,0.00671770
+Odd-Even Sort,333,69,0.00714350
+Odd-Even Sort,333,70,0.00732640
+Odd-Even Sort,333,71,0.00650300
+Odd-Even Sort,333,72,0.00629970
+Odd-Even Sort,333,73,0.00646990
+Odd-Even Sort,333,74,0.00692210
+Odd-Even Sort,333,75,0.00724280
+Odd-Even Sort,333,76,0.00736240
+Odd-Even Sort,333,77,0.00660600
+Odd-Even Sort,333,78,0.00707240
+Odd-Even Sort,333,79,0.00639170
+Odd-Even Sort,333,80,0.00708300
+Odd-Even Sort,333,81,0.00734610
+Odd-Even Sort,333,82,0.00666190
+Odd-Even Sort,333,83,0.00677960
+Odd-Even Sort,333,84,0.00741380
+Odd-Even Sort,333,85,0.00877770
+Odd-Even Sort,333,86,0.00635760
+Odd-Even Sort,333,87,0.00665940
+Odd-Even Sort,333,88,0.00671640
+Odd-Even Sort,333,89,0.00787520
+Odd-Even Sort,333,90,0.00725450
+Odd-Even Sort,333,91,0.00621150
+Odd-Even Sort,333,92,0.00696440
+Odd-Even Sort,333,93,0.00714570
+Odd-Even Sort,333,94,0.00768730
+Odd-Even Sort,333,95,0.00627630
+Odd-Even Sort,333,96,0.00726520
+Odd-Even Sort,333,97,0.00719060
+Odd-Even Sort,333,98,0.00689050
+Odd-Even Sort,333,99,0.00748050
+Odd-Even Sort,333,100,0.00663060
+Odd-Even Sort,333,101,0.00703150
+Odd-Even Sort,333,102,0.00757250
+Odd-Even Sort,333,103,0.00654410
+Odd-Even Sort,333,104,0.00713800
+Odd-Even Sort,333,105,0.00729670
+Odd-Even Sort,333,106,0.00713490
+Odd-Even Sort,333,107,0.00678690
+Odd-Even Sort,333,108,0.00649170
+Odd-Even Sort,333,109,0.00667850
+Odd-Even Sort,333,110,0.00713700
+Odd-Even Sort,333,111,0.00663140
+Odd-Even Sort,333,112,0.00691840
+Odd-Even Sort,333,113,0.00691490
+Odd-Even Sort,333,114,0.00671470
+Odd-Even Sort,333,115,0.00689270
+Odd-Even Sort,333,116,0.00704930
+Odd-Even Sort,333,117,0.00721520
+Odd-Even Sort,333,118,0.00673390
+Odd-Even Sort,333,119,0.00662040
+Odd-Even Sort,333,120,0.00642490
+Odd-Even Sort,333,121,0.00666220
+Odd-Even Sort,333,122,0.00713320
+Odd-Even Sort,333,123,0.00656150
+Odd-Even Sort,333,124,0.00675470
+Odd-Even Sort,333,125,0.00695430
+Odd-Even Sort,333,126,0.00656930
+Odd-Even Sort,333,127,0.00686420
+Odd-Even Sort,333,128,0.00773420
+Odd-Even Sort,333,129,0.00619160
+Odd-Even Sort,333,130,0.00695960
+Odd-Even Sort,333,131,0.00650950
+Odd-Even Sort,333,132,0.00656430
+Odd-Even Sort,333,133,0.00715910
+Odd-Even Sort,333,134,0.00674100
+Odd-Even Sort,333,135,0.00712750
+Odd-Even Sort,333,136,0.00718790
+Odd-Even Sort,333,137,0.00628020
+Odd-Even Sort,333,138,0.00710630
+Odd-Even Sort,333,139,0.00717620
+Odd-Even Sort,333,140,0.00670920
+Odd-Even Sort,333,141,0.00669950
+Odd-Even Sort,333,142,0.00741020
+Odd-Even Sort,333,143,0.00676840
+Odd-Even Sort,333,144,0.00648210
+Odd-Even Sort,333,145,0.00677280
+Odd-Even Sort,333,146,0.00639890
+Odd-Even Sort,333,147,0.00760060
+Odd-Even Sort,333,148,0.00739560
+Odd-Even Sort,333,149,0.00700370
+Odd-Even Sort,333,150,0.00673200
+Odd-Even Sort,333,151,0.00735210
+Odd-Even Sort,333,152,0.00698710
+Odd-Even Sort,333,153,0.00653780
+Odd-Even Sort,333,154,0.00728400
+Odd-Even Sort,333,155,0.00609670
+Odd-Even Sort,333,156,0.00710720
+Odd-Even Sort,333,157,0.00678840
+Odd-Even Sort,333,158,0.00785430
+Odd-Even Sort,333,159,0.00648390
+Odd-Even Sort,333,160,0.00797580
+Odd-Even Sort,333,161,0.00672360
+Odd-Even Sort,333,162,0.00744980
+Odd-Even Sort,333,163,0.00651370
+Odd-Even Sort,333,164,0.00660380
+Odd-Even Sort,333,165,0.00698400
+Odd-Even Sort,333,166,0.00700090
+Odd-Even Sort,333,167,0.00688360
+Odd-Even Sort,333,168,0.00661430
+Odd-Even Sort,333,169,0.00652220
+Odd-Even Sort,333,170,0.00637100
+Odd-Even Sort,333,171,0.00669600
+Odd-Even Sort,333,172,0.00684830
+Odd-Even Sort,333,173,0.00644480
+Odd-Even Sort,333,174,0.00772510
+Odd-Even Sort,333,175,0.00656430
+Odd-Even Sort,333,176,0.00644000
+Odd-Even Sort,333,177,0.00696310
+Odd-Even Sort,333,178,0.00743170
+Odd-Even Sort,333,179,0.00651780
+Odd-Even Sort,333,180,0.00682600
+Odd-Even Sort,333,181,0.00663010
+Odd-Even Sort,333,182,0.00641630
+Odd-Even Sort,333,183,0.00646850
+Odd-Even Sort,333,184,0.00693210
+Odd-Even Sort,333,185,0.00758580
+Odd-Even Sort,333,186,0.00671010
+Odd-Even Sort,333,187,0.00654260
+Odd-Even Sort,333,188,0.00702750
+Odd-Even Sort,333,189,0.00646570
+Odd-Even Sort,333,190,0.00683090
+Odd-Even Sort,333,191,0.00651270
+Odd-Even Sort,333,192,0.00676340
+Odd-Even Sort,333,193,0.00649840
+Odd-Even Sort,333,194,0.00984570
+Odd-Even Sort,333,195,0.00726710
+Odd-Even Sort,333,196,0.00670310
+Odd-Even Sort,333,197,0.00631840
+Odd-Even Sort,333,198,0.00619820
+Odd-Even Sort,333,199,0.00661730
+Odd-Even Sort,333,200,0.00828740
+Odd-Even Sort,333,201,0.00868560
+Odd-Even Sort,333,202,0.00637690
+Odd-Even Sort,333,203,0.00648170
+Odd-Even Sort,333,204,0.00811170
+Odd-Even Sort,333,205,0.00654800
+Odd-Even Sort,333,206,0.00622940
+Odd-Even Sort,333,207,0.00630210
+Odd-Even Sort,333,208,0.02459190
+Odd-Even Sort,333,209,0.00819380
+Odd-Even Sort,333,210,0.00642180
+Odd-Even Sort,333,211,0.00666480
+Odd-Even Sort,333,212,0.00829540
+Odd-Even Sort,333,213,0.00627300
+Odd-Even Sort,333,214,0.00661120
+Odd-Even Sort,333,215,0.00647610
+Odd-Even Sort,333,216,0.00693470
+Odd-Even Sort,333,217,0.00676630
+Odd-Even Sort,333,218,0.00698260
+Odd-Even Sort,333,219,0.00767960
+Odd-Even Sort,333,220,0.00640170
+Odd-Even Sort,333,221,0.00637290
+Odd-Even Sort,333,222,0.00928900
+Odd-Even Sort,333,223,0.00666240
+Odd-Even Sort,333,224,0.00664780
+Odd-Even Sort,333,225,0.00659670
+Odd-Even Sort,333,226,0.00629790
+Odd-Even Sort,333,227,0.00660430
+Odd-Even Sort,333,228,0.00655880
+Odd-Even Sort,333,229,0.00719310
+Odd-Even Sort,333,230,0.00685750
+Odd-Even Sort,333,231,0.00821330
+Odd-Even Sort,333,232,0.01971560
+Odd-Even Sort,333,233,0.00663690
+Odd-Even Sort,333,234,0.00785970
+Odd-Even Sort,333,235,0.00730170
+Odd-Even Sort,333,236,0.01366440
+Odd-Even Sort,333,237,0.00643860
+Odd-Even Sort,333,238,0.00679530
+Odd-Even Sort,333,239,0.00662680
+Odd-Even Sort,333,240,0.00733900
+Odd-Even Sort,333,241,0.00680560
+Odd-Even Sort,333,242,0.00850330
+Odd-Even Sort,333,243,0.00630540
+Odd-Even Sort,333,244,0.00689270
+Odd-Even Sort,333,245,0.00680260
+Odd-Even Sort,333,246,0.00684800
+Odd-Even Sort,333,247,0.01038090
+Odd-Even Sort,333,248,0.00683120
+Odd-Even Sort,333,249,0.00705370
+Odd-Even Sort,333,250,0.01262350
+Odd-Even Sort,333,251,0.00686490
+Odd-Even Sort,333,252,0.00864640
+Odd-Even Sort,333,253,0.00648840
+Odd-Even Sort,333,254,0.00669770
+Odd-Even Sort,333,255,0.00706040
+Odd-Even Sort,333,256,0.00672160
+Odd-Even Sort,333,257,0.00652920
+Odd-Even Sort,333,258,0.00727810
+Odd-Even Sort,333,259,0.00888850
+Odd-Even Sort,333,260,0.00681020
+Odd-Even Sort,333,261,0.00680740
+Odd-Even Sort,333,262,0.00713740
+Odd-Even Sort,333,263,0.00718240
+Odd-Even Sort,333,264,0.00665860
+Odd-Even Sort,333,265,0.00790300
+Odd-Even Sort,333,266,0.00606670
+Odd-Even Sort,333,267,0.00677210
+Odd-Even Sort,333,268,0.00662170
+Odd-Even Sort,333,269,0.00617710
+Odd-Even Sort,333,270,0.00655250
+Odd-Even Sort,333,271,0.00931400
+Odd-Even Sort,333,272,0.00707540
+Odd-Even Sort,333,273,0.00672430
+Odd-Even Sort,333,274,0.00657700
+Odd-Even Sort,333,275,0.00675650
+Odd-Even Sort,333,276,0.00667250
+Odd-Even Sort,333,277,0.00664820
+Odd-Even Sort,333,278,0.00675340
+Odd-Even Sort,333,279,0.01032770
+Odd-Even Sort,333,280,0.00848830
+Odd-Even Sort,333,281,0.00971800
+Odd-Even Sort,333,282,0.00719560
+Odd-Even Sort,333,283,0.01137340
+Odd-Even Sort,333,284,0.00673120
+Odd-Even Sort,333,285,0.00744610
+Odd-Even Sort,333,286,0.00857060
+Odd-Even Sort,333,287,0.00676980
+Odd-Even Sort,333,288,0.01546900
+Odd-Even Sort,333,289,0.00644970
+Odd-Even Sort,333,290,0.00774350
+Odd-Even Sort,333,291,0.00650200
+Odd-Even Sort,333,292,0.00633550
+Odd-Even Sort,333,293,0.00749140
+Odd-Even Sort,333,294,0.00695650
+Odd-Even Sort,333,295,0.00909120
+Odd-Even Sort,333,296,0.01321520
+Odd-Even Sort,333,297,0.00666940
+Odd-Even Sort,333,298,0.00694790
+Odd-Even Sort,333,299,0.01163700
+Odd-Even Sort,333,300,0.00729240
+Odd-Even Sort,333,301,0.00692690
+Odd-Even Sort,333,302,0.00687880
+Odd-Even Sort,333,303,0.00801790
+Odd-Even Sort,333,304,0.00686890
+Odd-Even Sort,333,305,0.00830850
+Odd-Even Sort,333,306,0.00842270
+Odd-Even Sort,333,307,0.00666840
+Odd-Even Sort,333,308,0.00662550
+Odd-Even Sort,333,309,0.00890360
+Odd-Even Sort,333,310,0.00934250
+Odd-Even Sort,333,311,0.00668910
+Odd-Even Sort,333,312,0.00736100
+Odd-Even Sort,333,313,0.00894630
+Odd-Even Sort,333,314,0.00657480
+Odd-Even Sort,333,315,0.01218470
+Odd-Even Sort,333,316,0.00816980
+Odd-Even Sort,333,317,0.00753510
+Odd-Even Sort,333,318,0.00615640
+Odd-Even Sort,333,319,0.00878970
+Odd-Even Sort,333,320,0.00694530
+Odd-Even Sort,333,321,0.00764380
+Odd-Even Sort,333,322,0.00616570
+Odd-Even Sort,333,323,0.00758290
+Odd-Even Sort,333,324,0.00638850
+Odd-Even Sort,333,325,0.00758930
+Odd-Even Sort,333,326,0.00661350
+Odd-Even Sort,333,327,0.00678910
+Odd-Even Sort,333,328,0.00645230
+Odd-Even Sort,333,329,0.00659500
+Odd-Even Sort,333,330,0.00741120
+Odd-Even Sort,333,331,0.01120360
+Odd-Even Sort,333,332,0.00704950
+Odd-Even Sort,333,333,0.01089170
+Odd-Even Sort,333,334,0.00649220
+Odd-Even Sort,333,335,0.00714220
+Odd-Even Sort,333,336,0.00808810
+Odd-Even Sort,333,337,0.00650340
+Odd-Even Sort,333,338,0.00683600
+Odd-Even Sort,333,339,0.00739140
+Odd-Even Sort,333,340,0.00920670
+Odd-Even Sort,333,341,0.00637920
+Odd-Even Sort,333,342,0.00666120
+Odd-Even Sort,333,343,0.00752910
+Odd-Even Sort,333,344,0.00633370
+Odd-Even Sort,333,345,0.00756790
+Odd-Even Sort,333,346,0.00646840
+Odd-Even Sort,333,347,0.00723460
+Odd-Even Sort,333,348,0.00773940
+Odd-Even Sort,333,349,0.00669130
+Odd-Even Sort,333,350,0.00678070
+Odd-Even Sort,333,351,0.00714130
+Odd-Even Sort,333,352,0.00707690
+Odd-Even Sort,333,353,0.00746480
+Odd-Even Sort,333,354,0.00691730
+Odd-Even Sort,333,355,0.00780720
+Odd-Even Sort,333,356,0.00686830
+Odd-Even Sort,333,357,0.00632740
+Odd-Even Sort,333,358,0.00858520
+Odd-Even Sort,333,359,0.00662870
+Odd-Even Sort,333,360,0.00633910
+Odd-Even Sort,333,361,0.00652600
+Odd-Even Sort,333,362,0.00679200
+Odd-Even Sort,333,363,0.00755600
+Odd-Even Sort,333,364,0.00728940
+Odd-Even Sort,333,365,0.00631960
+Odd-Even Sort,333,366,0.00659370
+Odd-Even Sort,333,367,0.00647460
+Odd-Even Sort,333,368,0.00729420
+Odd-Even Sort,333,369,0.00678280
+Odd-Even Sort,333,370,0.00668530
+Odd-Even Sort,333,371,0.00639390
+Odd-Even Sort,333,372,0.00673970
+Odd-Even Sort,333,373,0.00705330
+Odd-Even Sort,333,374,0.00674180
+Odd-Even Sort,333,375,0.00742280
+Odd-Even Sort,333,376,0.00672460
+Odd-Even Sort,333,377,0.00725430
+Odd-Even Sort,333,378,0.00617040
+Odd-Even Sort,333,379,0.00687490
+Odd-Even Sort,333,380,0.00643900
+Odd-Even Sort,333,381,0.00677690
+Odd-Even Sort,333,382,0.00686070
+Odd-Even Sort,333,383,0.00723520
+Odd-Even Sort,333,384,0.00672280
+Odd-Even Sort,333,385,0.00670520
+Odd-Even Sort,333,386,0.00646010
+Odd-Even Sort,333,387,0.00783150
+Odd-Even Sort,333,388,0.00773360
+Odd-Even Sort,333,389,0.00646080
+Odd-Even Sort,333,390,0.00655300
+Odd-Even Sort,333,391,0.00713060
+Odd-Even Sort,333,392,0.00743140
+Odd-Even Sort,333,393,0.00755110
+Odd-Even Sort,333,394,0.00704130
+Odd-Even Sort,333,395,0.00637140
+Odd-Even Sort,333,396,0.00692090
+Odd-Even Sort,333,397,0.00935540
+Odd-Even Sort,333,398,0.00761600
+Odd-Even Sort,333,399,0.00664340
+Odd-Even Sort,333,400,0.00665380
+Odd-Even Sort,333,401,0.00637330
+Odd-Even Sort,333,402,0.00763140
+Odd-Even Sort,333,403,0.00740160
+Odd-Even Sort,333,404,0.00704560
+Odd-Even Sort,333,405,0.00666900
+Odd-Even Sort,333,406,0.00666180
+Odd-Even Sort,333,407,0.00790040
+Odd-Even Sort,333,408,0.00741300
+Odd-Even Sort,333,409,0.00737590
+Odd-Even Sort,333,410,0.00641860
+Odd-Even Sort,333,411,0.00727810
+Odd-Even Sort,333,412,0.00713510
+Odd-Even Sort,333,413,0.00667540
+Odd-Even Sort,333,414,0.00701280
+Odd-Even Sort,333,415,0.00674720
+Odd-Even Sort,333,416,0.00625600
+Odd-Even Sort,333,417,0.00657310
+Odd-Even Sort,333,418,0.00714000
+Odd-Even Sort,333,419,0.00728990
+Odd-Even Sort,333,420,0.00675880
+Odd-Even Sort,333,421,0.00754520
+Odd-Even Sort,333,422,0.00765220
+Odd-Even Sort,333,423,0.00698390
+Odd-Even Sort,333,424,0.00651570
+Odd-Even Sort,333,425,0.00640090
+Odd-Even Sort,333,426,0.00646180
+Odd-Even Sort,333,427,0.00827370
+Odd-Even Sort,333,428,0.00775980
+Odd-Even Sort,333,429,0.00642570
+Odd-Even Sort,333,430,0.01548810
+Odd-Even Sort,333,431,0.00680160
+Odd-Even Sort,333,432,0.00861510
+Odd-Even Sort,333,433,0.00656570
+Odd-Even Sort,333,434,0.00658440
+Odd-Even Sort,333,435,0.00640750
+Odd-Even Sort,333,436,0.00670210
+Odd-Even Sort,333,437,0.00743410
+Odd-Even Sort,333,438,0.00679510
+Odd-Even Sort,333,439,0.00693860
+Odd-Even Sort,333,440,0.00614880
+Odd-Even Sort,333,441,0.00636000
+Odd-Even Sort,333,442,0.00758300
+Odd-Even Sort,333,443,0.00658840
+Odd-Even Sort,333,444,0.00693250
+Odd-Even Sort,333,445,0.00629930
+Odd-Even Sort,333,446,0.00698500
+Odd-Even Sort,333,447,0.00675590
+Odd-Even Sort,333,448,0.00653150
+Odd-Even Sort,333,449,0.00653380
+Odd-Even Sort,333,450,0.02258180
+Odd-Even Sort,333,451,0.00630630
+Odd-Even Sort,333,452,0.00720690
+Odd-Even Sort,333,453,0.00655930
+Odd-Even Sort,333,454,0.00818790
+Odd-Even Sort,333,455,0.00663190
+Odd-Even Sort,333,456,0.00642650
+Odd-Even Sort,333,457,0.00673870
+Odd-Even Sort,333,458,0.00667270
+Odd-Even Sort,333,459,0.00670910
+Odd-Even Sort,333,460,0.00769600
+Odd-Even Sort,333,461,0.00662220
+Odd-Even Sort,333,462,0.00676820
+Odd-Even Sort,333,463,0.00650910
+Odd-Even Sort,333,464,0.00924220
+Odd-Even Sort,333,465,0.00719640
+Odd-Even Sort,333,466,0.00650020
+Odd-Even Sort,333,467,0.01644910
+Odd-Even Sort,333,468,0.00732610
+Odd-Even Sort,333,469,0.00661600
+Odd-Even Sort,333,470,0.00659200
+Odd-Even Sort,333,471,0.00699320
+Odd-Even Sort,333,472,0.00639570
+Odd-Even Sort,333,473,0.00644950
+Odd-Even Sort,333,474,0.00813950
+Odd-Even Sort,333,475,0.01063890
+Odd-Even Sort,333,476,0.00661440
+Odd-Even Sort,333,477,0.00885930
+Odd-Even Sort,333,478,0.00639440
+Odd-Even Sort,333,479,0.00658990
+Odd-Even Sort,333,480,0.00633360
+Odd-Even Sort,333,481,0.00735400
+Odd-Even Sort,333,482,0.00993580
+Odd-Even Sort,333,483,0.00644940
+Odd-Even Sort,333,484,0.00691320
+Odd-Even Sort,333,485,0.00649200
+Odd-Even Sort,333,486,0.00978870
+Odd-Even Sort,333,487,0.00624910
+Odd-Even Sort,333,488,0.00713830
+Odd-Even Sort,333,489,0.00791060
+Odd-Even Sort,333,490,0.00650750
+Odd-Even Sort,333,491,0.00659530
+Odd-Even Sort,333,492,0.00677940
+Odd-Even Sort,333,493,0.00617520
+Odd-Even Sort,333,494,0.00716040
+Odd-Even Sort,333,495,0.00816460
+Odd-Even Sort,333,496,0.00680940
+Odd-Even Sort,333,497,0.00759330
+Odd-Even Sort,333,498,0.00691270
+Odd-Even Sort,333,499,0.00846710
+Odd-Even Sort,333,500,0.00658480
+Pancake Sort,333,1,0.00536780
+Pancake Sort,333,2,0.00510890
+Pancake Sort,333,3,0.00554460
+Pancake Sort,333,4,0.00534940
+Pancake Sort,333,5,0.00657040
+Pancake Sort,333,6,0.00511500
+Pancake Sort,333,7,0.00506170
+Pancake Sort,333,8,0.00519570
+Pancake Sort,333,9,0.00540800
+Pancake Sort,333,10,0.00504850
+Pancake Sort,333,11,0.00653380
+Pancake Sort,333,12,0.00507260
+Pancake Sort,333,13,0.00538320
+Pancake Sort,333,14,0.00503770
+Pancake Sort,333,15,0.00507170
+Pancake Sort,333,16,0.00654530
+Pancake Sort,333,17,0.00684590
+Pancake Sort,333,18,0.00547040
+Pancake Sort,333,19,0.00491100
+Pancake Sort,333,20,0.00529570
+Pancake Sort,333,21,0.00514920
+Pancake Sort,333,22,0.00711610
+Pancake Sort,333,23,0.00514900
+Pancake Sort,333,24,0.00522930
+Pancake Sort,333,25,0.00490550
+Pancake Sort,333,26,0.00676400
+Pancake Sort,333,27,0.00896920
+Pancake Sort,333,28,0.00532590
+Pancake Sort,333,29,0.00727050
+Pancake Sort,333,30,0.00667740
+Pancake Sort,333,31,0.00522910
+Pancake Sort,333,32,0.00522910
+Pancake Sort,333,33,0.00486080
+Pancake Sort,333,34,0.00604710
+Pancake Sort,333,35,0.00546810
+Pancake Sort,333,36,0.00562810
+Pancake Sort,333,37,0.00518200
+Pancake Sort,333,38,0.00664780
+Pancake Sort,333,39,0.00492560
+Pancake Sort,333,40,0.00577830
+Pancake Sort,333,41,0.00519780
+Pancake Sort,333,42,0.00655890
+Pancake Sort,333,43,0.00662830
+Pancake Sort,333,44,0.00535210
+Pancake Sort,333,45,0.00615610
+Pancake Sort,333,46,0.00527350
+Pancake Sort,333,47,0.00552450
+Pancake Sort,333,48,0.00499050
+Pancake Sort,333,49,0.00520320
+Pancake Sort,333,50,0.00664030
+Pancake Sort,333,51,0.00521400
+Pancake Sort,333,52,0.00515500
+Pancake Sort,333,53,0.00507370
+Pancake Sort,333,54,0.00683730
+Pancake Sort,333,55,0.00519290
+Pancake Sort,333,56,0.00498030
+Pancake Sort,333,57,0.00599900
+Pancake Sort,333,58,0.00529670
+Pancake Sort,333,59,0.00504240
+Pancake Sort,333,60,0.00539520
+Pancake Sort,333,61,0.00486680
+Pancake Sort,333,62,0.00607500
+Pancake Sort,333,63,0.00516500
+Pancake Sort,333,64,0.00494890
+Pancake Sort,333,65,0.00586880
+Pancake Sort,333,66,0.00595850
+Pancake Sort,333,67,0.00579660
+Pancake Sort,333,68,0.00561730
+Pancake Sort,333,69,0.00491110
+Pancake Sort,333,70,0.00606450
+Pancake Sort,333,71,0.00511560
+Pancake Sort,333,72,0.00523450
+Pancake Sort,333,73,0.00503370
+Pancake Sort,333,74,0.00616840
+Pancake Sort,333,75,0.00594830
+Pancake Sort,333,76,0.00605080
+Pancake Sort,333,77,0.00492810
+Pancake Sort,333,78,0.00529850
+Pancake Sort,333,79,0.00529430
+Pancake Sort,333,80,0.00518080
+Pancake Sort,333,81,0.00514700
+Pancake Sort,333,82,0.00500690
+Pancake Sort,333,83,0.00575250
+Pancake Sort,333,84,0.00495820
+Pancake Sort,333,85,0.00595670
+Pancake Sort,333,86,0.00550570
+Pancake Sort,333,87,0.00541460
+Pancake Sort,333,88,0.00520130
+Pancake Sort,333,89,0.00516040
+Pancake Sort,333,90,0.00515300
+Pancake Sort,333,91,0.00500420
+Pancake Sort,333,92,0.00506090
+Pancake Sort,333,93,0.00622980
+Pancake Sort,333,94,0.00528330
+Pancake Sort,333,95,0.00570190
+Pancake Sort,333,96,0.00514360
+Pancake Sort,333,97,0.00783520
+Pancake Sort,333,98,0.00527650
+Pancake Sort,333,99,0.00607510
+Pancake Sort,333,100,0.00632220
+Pancake Sort,333,101,0.00603670
+Pancake Sort,333,102,0.00521980
+Pancake Sort,333,103,0.00483120
+Pancake Sort,333,104,0.00536130
+Pancake Sort,333,105,0.00583680
+Pancake Sort,333,106,0.00520590
+Pancake Sort,333,107,0.00581820
+Pancake Sort,333,108,0.00549190
+Pancake Sort,333,109,0.01282670
+Pancake Sort,333,110,0.00539690
+Pancake Sort,333,111,0.00484310
+Pancake Sort,333,112,0.00525690
+Pancake Sort,333,113,0.00535870
+Pancake Sort,333,114,0.00518310
+Pancake Sort,333,115,0.00626680
+Pancake Sort,333,116,0.00615300
+Pancake Sort,333,117,0.01199340
+Pancake Sort,333,118,0.00490230
+Pancake Sort,333,119,0.00559240
+Pancake Sort,333,120,0.00503890
+Pancake Sort,333,121,0.00687150
+Pancake Sort,333,122,0.00611190
+Pancake Sort,333,123,0.00611820
+Pancake Sort,333,124,0.00538620
+Pancake Sort,333,125,0.00489280
+Pancake Sort,333,126,0.00509190
+Pancake Sort,333,127,0.00548660
+Pancake Sort,333,128,0.00558860
+Pancake Sort,333,129,0.00591800
+Pancake Sort,333,130,0.00574380
+Pancake Sort,333,131,0.00581490
+Pancake Sort,333,132,0.00525800
+Pancake Sort,333,133,0.00573490
+Pancake Sort,333,134,0.00490000
+Pancake Sort,333,135,0.00499440
+Pancake Sort,333,136,0.00523290
+Pancake Sort,333,137,0.00537210
+Pancake Sort,333,138,0.00585210
+Pancake Sort,333,139,0.00752390
+Pancake Sort,333,140,0.00632850
+Pancake Sort,333,141,0.00712260
+Pancake Sort,333,142,0.00575550
+Pancake Sort,333,143,0.00643770
+Pancake Sort,333,144,0.00504820
+Pancake Sort,333,145,0.00521230
+Pancake Sort,333,146,0.00566750
+Pancake Sort,333,147,0.00546050
+Pancake Sort,333,148,0.00502130
+Pancake Sort,333,149,0.00511740
+Pancake Sort,333,150,0.00556800
+Pancake Sort,333,151,0.00572420
+Pancake Sort,333,152,0.00591900
+Pancake Sort,333,153,0.00514470
+Pancake Sort,333,154,0.00493260
+Pancake Sort,333,155,0.00550070
+Pancake Sort,333,156,0.00584580
+Pancake Sort,333,157,0.00503470
+Pancake Sort,333,158,0.00519520
+Pancake Sort,333,159,0.00595990
+Pancake Sort,333,160,0.00515100
+Pancake Sort,333,161,0.00489380
+Pancake Sort,333,162,0.00594770
+Pancake Sort,333,163,0.00562690
+Pancake Sort,333,164,0.00541040
+Pancake Sort,333,165,0.00515420
+Pancake Sort,333,166,0.00599290
+Pancake Sort,333,167,0.00522350
+Pancake Sort,333,168,0.00503270
+Pancake Sort,333,169,0.00527610
+Pancake Sort,333,170,0.00532430
+Pancake Sort,333,171,0.00612600
+Pancake Sort,333,172,0.00565390
+Pancake Sort,333,173,0.00528960
+Pancake Sort,333,174,0.00542310
+Pancake Sort,333,175,0.00523460
+Pancake Sort,333,176,0.00517020
+Pancake Sort,333,177,0.00513100
+Pancake Sort,333,178,0.00575510
+Pancake Sort,333,179,0.00534680
+Pancake Sort,333,180,0.00562430
+Pancake Sort,333,181,0.00548280
+Pancake Sort,333,182,0.00552840
+Pancake Sort,333,183,0.00544740
+Pancake Sort,333,184,0.00613890
+Pancake Sort,333,185,0.00525980
+Pancake Sort,333,186,0.00557110
+Pancake Sort,333,187,0.00526310
+Pancake Sort,333,188,0.00546860
+Pancake Sort,333,189,0.00538760
+Pancake Sort,333,190,0.00584390
+Pancake Sort,333,191,0.00525880
+Pancake Sort,333,192,0.00520990
+Pancake Sort,333,193,0.00525980
+Pancake Sort,333,194,0.00533360
+Pancake Sort,333,195,0.00630200
+Pancake Sort,333,196,0.00609480
+Pancake Sort,333,197,0.00505710
+Pancake Sort,333,198,0.00530750
+Pancake Sort,333,199,0.00599310
+Pancake Sort,333,200,0.00516600
+Pancake Sort,333,201,0.00613340
+Pancake Sort,333,202,0.00582100
+Pancake Sort,333,203,0.00536610
+Pancake Sort,333,204,0.00502310
+Pancake Sort,333,205,0.00583620
+Pancake Sort,333,206,0.00535480
+Pancake Sort,333,207,0.00628190
+Pancake Sort,333,208,0.00526720
+Pancake Sort,333,209,0.00577260
+Pancake Sort,333,210,0.00508180
+Pancake Sort,333,211,0.00541040
+Pancake Sort,333,212,0.00530400
+Pancake Sort,333,213,0.00541870
+Pancake Sort,333,214,0.00574360
+Pancake Sort,333,215,0.00640610
+Pancake Sort,333,216,0.00616620
+Pancake Sort,333,217,0.00672890
+Pancake Sort,333,218,0.00503740
+Pancake Sort,333,219,0.00496550
+Pancake Sort,333,220,0.00520640
+Pancake Sort,333,221,0.00521120
+Pancake Sort,333,222,0.00704350
+Pancake Sort,333,223,0.00522530
+Pancake Sort,333,224,0.00517980
+Pancake Sort,333,225,0.00766470
+Pancake Sort,333,226,0.00497710
+Pancake Sort,333,227,0.00497100
+Pancake Sort,333,228,0.00607090
+Pancake Sort,333,229,0.00523600
+Pancake Sort,333,230,0.00511070
+Pancake Sort,333,231,0.00524790
+Pancake Sort,333,232,0.00784370
+Pancake Sort,333,233,0.00522660
+Pancake Sort,333,234,0.00508680
+Pancake Sort,333,235,0.00515050
+Pancake Sort,333,236,0.00575240
+Pancake Sort,333,237,0.00524440
+Pancake Sort,333,238,0.00581160
+Pancake Sort,333,239,0.00589250
+Pancake Sort,333,240,0.00519920
+Pancake Sort,333,241,0.00522320
+Pancake Sort,333,242,0.00516480
+Pancake Sort,333,243,0.00517810
+Pancake Sort,333,244,0.00574640
+Pancake Sort,333,245,0.00524520
+Pancake Sort,333,246,0.00591660
+Pancake Sort,333,247,0.00525760
+Pancake Sort,333,248,0.00612560
+Pancake Sort,333,249,0.00524170
+Pancake Sort,333,250,0.00601820
+Pancake Sort,333,251,0.00518420
+Pancake Sort,333,252,0.00519130
+Pancake Sort,333,253,0.00594160
+Pancake Sort,333,254,0.00518310
+Pancake Sort,333,255,0.00512430
+Pancake Sort,333,256,0.00519130
+Pancake Sort,333,257,0.00592930
+Pancake Sort,333,258,0.00576730
+Pancake Sort,333,259,0.00501120
+Pancake Sort,333,260,0.00620460
+Pancake Sort,333,261,0.00536390
+Pancake Sort,333,262,0.00522710
+Pancake Sort,333,263,0.00633920
+Pancake Sort,333,264,0.00528590
+Pancake Sort,333,265,0.00520910
+Pancake Sort,333,266,0.00689560
+Pancake Sort,333,267,0.00533010
+Pancake Sort,333,268,0.00496840
+Pancake Sort,333,269,0.00532660
+Pancake Sort,333,270,0.00605700
+Pancake Sort,333,271,0.00538720
+Pancake Sort,333,272,0.00516880
+Pancake Sort,333,273,0.00535760
+Pancake Sort,333,274,0.00616920
+Pancake Sort,333,275,0.00499500
+Pancake Sort,333,276,0.00531820
+Pancake Sort,333,277,0.00628460
+Pancake Sort,333,278,0.00685350
+Pancake Sort,333,279,0.00533830
+Pancake Sort,333,280,0.01182190
+Pancake Sort,333,281,0.00590300
+Pancake Sort,333,282,0.00527210
+Pancake Sort,333,283,0.00491050
+Pancake Sort,333,284,0.01132980
+Pancake Sort,333,285,0.00563260
+Pancake Sort,333,286,0.00562420
+Pancake Sort,333,287,0.00531210
+Pancake Sort,333,288,0.00512610
+Pancake Sort,333,289,0.00683430
+Pancake Sort,333,290,0.00701070
+Pancake Sort,333,291,0.00494650
+Pancake Sort,333,292,0.00520130
+Pancake Sort,333,293,0.00526340
+Pancake Sort,333,294,0.00524580
+Pancake Sort,333,295,0.00520340
+Pancake Sort,333,296,0.00491850
+Pancake Sort,333,297,0.00752970
+Pancake Sort,333,298,0.00856520
+Pancake Sort,333,299,0.01014280
+Pancake Sort,333,300,0.00547800
+Pancake Sort,333,301,0.00529720
+Pancake Sort,333,302,0.00524940
+Pancake Sort,333,303,0.00603560
+Pancake Sort,333,304,0.00682900
+Pancake Sort,333,305,0.00503710
+Pancake Sort,333,306,0.00510690
+Pancake Sort,333,307,0.00730810
+Pancake Sort,333,308,0.00523070
+Pancake Sort,333,309,0.00519220
+Pancake Sort,333,310,0.00728930
+Pancake Sort,333,311,0.00519590
+Pancake Sort,333,312,0.00502160
+Pancake Sort,333,313,0.00718710
+Pancake Sort,333,314,0.00569440
+Pancake Sort,333,315,0.00527070
+Pancake Sort,333,316,0.00523130
+Pancake Sort,333,317,0.00555940
+Pancake Sort,333,318,0.00648230
+Pancake Sort,333,319,0.00546310
+Pancake Sort,333,320,0.00501830
+Pancake Sort,333,321,0.00658180
+Pancake Sort,333,322,0.00515810
+Pancake Sort,333,323,0.00523790
+Pancake Sort,333,324,0.00543140
+Pancake Sort,333,325,0.00521470
+Pancake Sort,333,326,0.00528840
+Pancake Sort,333,327,0.00503860
+Pancake Sort,333,328,0.00523440
+Pancake Sort,333,329,0.00601390
+Pancake Sort,333,330,0.00573290
+Pancake Sort,333,331,0.00565860
+Pancake Sort,333,332,0.00521660
+Pancake Sort,333,333,0.00526140
+Pancake Sort,333,334,0.00522080
+Pancake Sort,333,335,0.00515960
+Pancake Sort,333,336,0.00554310
+Pancake Sort,333,337,0.00517440
+Pancake Sort,333,338,0.00500030
+Pancake Sort,333,339,0.00522380
+Pancake Sort,333,340,0.00686530
+Pancake Sort,333,341,0.00646410
+Pancake Sort,333,342,0.00586960
+Pancake Sort,333,343,0.00547150
+Pancake Sort,333,344,0.00518460
+Pancake Sort,333,345,0.00516940
+Pancake Sort,333,346,0.00522720
+Pancake Sort,333,347,0.00565600
+Pancake Sort,333,348,0.00509470
+Pancake Sort,333,349,0.00627280
+Pancake Sort,333,350,0.00534410
+Pancake Sort,333,351,0.00560140
+Pancake Sort,333,352,0.00521950
+Pancake Sort,333,353,0.00579920
+Pancake Sort,333,354,0.00520310
+Pancake Sort,333,355,0.00599180
+Pancake Sort,333,356,0.00522880
+Pancake Sort,333,357,0.00495770
+Pancake Sort,333,358,0.00519350
+Pancake Sort,333,359,0.00597950
+Pancake Sort,333,360,0.00571190
+Pancake Sort,333,361,0.00579360
+Pancake Sort,333,362,0.00517190
+Pancake Sort,333,363,0.00513820
+Pancake Sort,333,364,0.00541910
+Pancake Sort,333,365,0.00487960
+Pancake Sort,333,366,0.00519210
+Pancake Sort,333,367,0.00530400
+Pancake Sort,333,368,0.00538780
+Pancake Sort,333,369,0.00524190
+Pancake Sort,333,370,0.00687690
+Pancake Sort,333,371,0.00522910
+Pancake Sort,333,372,0.00542880
+Pancake Sort,333,373,0.00610800
+Pancake Sort,333,374,0.00515090
+Pancake Sort,333,375,0.00522790
+Pancake Sort,333,376,0.00542130
+Pancake Sort,333,377,0.00497960
+Pancake Sort,333,378,0.00502490
+Pancake Sort,333,379,0.00523840
+Pancake Sort,333,380,0.00626700
+Pancake Sort,333,381,0.00801520
+Pancake Sort,333,382,0.00519720
+Pancake Sort,333,383,0.00556940
+Pancake Sort,333,384,0.00521390
+Pancake Sort,333,385,0.00556600
+Pancake Sort,333,386,0.00499990
+Pancake Sort,333,387,0.00515150
+Pancake Sort,333,388,0.00526110
+Pancake Sort,333,389,0.00519890
+Pancake Sort,333,390,0.00581470
+Pancake Sort,333,391,0.00524590
+Pancake Sort,333,392,0.00657320
+Pancake Sort,333,393,0.00495990
+Pancake Sort,333,394,0.00519400
+Pancake Sort,333,395,0.00718700
+Pancake Sort,333,396,0.00506640
+Pancake Sort,333,397,0.00524230
+Pancake Sort,333,398,0.00521420
+Pancake Sort,333,399,0.00545260
+Pancake Sort,333,400,0.00517510
+Pancake Sort,333,401,0.00544150
+Pancake Sort,333,402,0.00520260
+Pancake Sort,333,403,0.00593110
+Pancake Sort,333,404,0.00531160
+Pancake Sort,333,405,0.00495100
+Pancake Sort,333,406,0.00523180
+Pancake Sort,333,407,0.00542370
+Pancake Sort,333,408,0.00559380
+Pancake Sort,333,409,0.00553770
+Pancake Sort,333,410,0.00521560
+Pancake Sort,333,411,0.00518520
+Pancake Sort,333,412,0.00502150
+Pancake Sort,333,413,0.00509940
+Pancake Sort,333,414,0.00606660
+Pancake Sort,333,415,0.00521630
+Pancake Sort,333,416,0.00543420
+Pancake Sort,333,417,0.00596630
+Pancake Sort,333,418,0.00554340
+Pancake Sort,333,419,0.00523940
+Pancake Sort,333,420,0.00576710
+Pancake Sort,333,421,0.00499370
+Pancake Sort,333,422,0.00891180
+Pancake Sort,333,423,0.00806370
+Pancake Sort,333,424,0.00579050
+Pancake Sort,333,425,0.00521960
+Pancake Sort,333,426,0.00541600
+Pancake Sort,333,427,0.00624370
+Pancake Sort,333,428,0.00607470
+Pancake Sort,333,429,0.00497490
+Pancake Sort,333,430,0.00576590
+Pancake Sort,333,431,0.00546480
+Pancake Sort,333,432,0.00520510
+Pancake Sort,333,433,0.00577210
+Pancake Sort,333,434,0.00534950
+Pancake Sort,333,435,0.00673450
+Pancake Sort,333,436,0.00497800
+Pancake Sort,333,437,0.00557670
+Pancake Sort,333,438,0.00517520
+Pancake Sort,333,439,0.00519740
+Pancake Sort,333,440,0.00611480
+Pancake Sort,333,441,0.00603730
+Pancake Sort,333,442,0.00565790
+Pancake Sort,333,443,0.00553920
+Pancake Sort,333,444,0.00540610
+Pancake Sort,333,445,0.00517860
+Pancake Sort,333,446,0.00646670
+Pancake Sort,333,447,0.00518310
+Pancake Sort,333,448,0.00508250
+Pancake Sort,333,449,0.00581060
+Pancake Sort,333,450,0.00562100
+Pancake Sort,333,451,0.00502220
+Pancake Sort,333,452,0.00551980
+Pancake Sort,333,453,0.00591300
+Pancake Sort,333,454,0.00522670
+Pancake Sort,333,455,0.00581910
+Pancake Sort,333,456,0.00522590
+Pancake Sort,333,457,0.00579990
+Pancake Sort,333,458,0.00518570
+Pancake Sort,333,459,0.00521190
+Pancake Sort,333,460,0.00504390
+Pancake Sort,333,461,0.00541720
+Pancake Sort,333,462,0.00512890
+Pancake Sort,333,463,0.00635310
+Pancake Sort,333,464,0.00532030
+Pancake Sort,333,465,0.00591980
+Pancake Sort,333,466,0.00612370
+Pancake Sort,333,467,0.00527420
+Pancake Sort,333,468,0.00554910
+Pancake Sort,333,469,0.00524120
+Pancake Sort,333,470,0.00530150
+Pancake Sort,333,471,0.00519830
+Pancake Sort,333,472,0.00527030
+Pancake Sort,333,473,0.00509930
+Pancake Sort,333,474,0.00611960
+Pancake Sort,333,475,0.00550330
+Pancake Sort,333,476,0.00525950
+Pancake Sort,333,477,0.00521330
+Pancake Sort,333,478,0.00632200
+Pancake Sort,333,479,0.00526650
+Pancake Sort,333,480,0.00561290
+Pancake Sort,333,481,0.00527180
+Pancake Sort,333,482,0.00517360
+Pancake Sort,333,483,0.00546970
+Pancake Sort,333,484,0.00519690
+Pancake Sort,333,485,0.00518900
+Pancake Sort,333,486,0.00524390
+Pancake Sort,333,487,0.00526530
+Pancake Sort,333,488,0.00597510
+Pancake Sort,333,489,0.00575510
+Pancake Sort,333,490,0.00529240
+Pancake Sort,333,491,0.00538090
+Pancake Sort,333,492,0.00610920
+Pancake Sort,333,493,0.00498500
+Pancake Sort,333,494,0.00517630
+Pancake Sort,333,495,0.00548680
+Pancake Sort,333,496,0.00528680
+Pancake Sort,333,497,0.00506700
+Pancake Sort,333,498,0.00527230
+Pancake Sort,333,499,0.00661760
+Pancake Sort,333,500,0.00519680
+Patience Sort,333,1,0.00049170
+Patience Sort,333,2,0.00051610
+Patience Sort,333,3,0.00049570
+Patience Sort,333,4,0.00052930
+Patience Sort,333,5,0.00049950
+Patience Sort,333,6,0.00051920
+Patience Sort,333,7,0.00055370
+Patience Sort,333,8,0.00051480
+Patience Sort,333,9,0.00049830
+Patience Sort,333,10,0.00049610
+Patience Sort,333,11,0.00046650
+Patience Sort,333,12,0.00053250
+Patience Sort,333,13,0.00047840
+Patience Sort,333,14,0.00051200
+Patience Sort,333,15,0.00051190
+Patience Sort,333,16,0.00051400
+Patience Sort,333,17,0.00055820
+Patience Sort,333,18,0.00052640
+Patience Sort,333,19,0.00051130
+Patience Sort,333,20,0.00050150
+Patience Sort,333,21,0.00050550
+Patience Sort,333,22,0.00047940
+Patience Sort,333,23,0.00049940
+Patience Sort,333,24,0.00050450
+Patience Sort,333,25,0.00047220
+Patience Sort,333,26,0.00053200
+Patience Sort,333,27,0.00051200
+Patience Sort,333,28,0.00049730
+Patience Sort,333,29,0.00051730
+Patience Sort,333,30,0.00048350
+Patience Sort,333,31,0.00049010
+Patience Sort,333,32,0.00051170
+Patience Sort,333,33,0.00051000
+Patience Sort,333,34,0.00048500
+Patience Sort,333,35,0.00051600
+Patience Sort,333,36,0.00053130
+Patience Sort,333,37,0.00052740
+Patience Sort,333,38,0.00050430
+Patience Sort,333,39,0.00051230
+Patience Sort,333,40,0.00050110
+Patience Sort,333,41,0.00051870
+Patience Sort,333,42,0.00052130
+Patience Sort,333,43,0.00053270
+Patience Sort,333,44,0.00050800
+Patience Sort,333,45,0.00048460
+Patience Sort,333,46,0.00050530
+Patience Sort,333,47,0.00052050
+Patience Sort,333,48,0.00050160
+Patience Sort,333,49,0.00051200
+Patience Sort,333,50,0.00049300
+Patience Sort,333,51,0.00052020
+Patience Sort,333,52,0.00052320
+Patience Sort,333,53,0.00051660
+Patience Sort,333,54,0.00049280
+Patience Sort,333,55,0.00054570
+Patience Sort,333,56,0.00048140
+Patience Sort,333,57,0.00049200
+Patience Sort,333,58,0.00051960
+Patience Sort,333,59,0.00049040
+Patience Sort,333,60,0.00047540
+Patience Sort,333,61,0.00049340
+Patience Sort,333,62,0.00047390
+Patience Sort,333,63,0.00048110
+Patience Sort,333,64,0.00049090
+Patience Sort,333,65,0.00049570
+Patience Sort,333,66,0.00071900
+Patience Sort,333,67,0.00050790
+Patience Sort,333,68,0.00051760
+Patience Sort,333,69,0.00052300
+Patience Sort,333,70,0.00052620
+Patience Sort,333,71,0.00050540
+Patience Sort,333,72,0.00049510
+Patience Sort,333,73,0.00050070
+Patience Sort,333,74,0.00050360
+Patience Sort,333,75,0.00050550
+Patience Sort,333,76,0.00051280
+Patience Sort,333,77,0.00047400
+Patience Sort,333,78,0.00052290
+Patience Sort,333,79,0.00050230
+Patience Sort,333,80,0.00053880
+Patience Sort,333,81,0.00050690
+Patience Sort,333,82,0.00057390
+Patience Sort,333,83,0.00054480
+Patience Sort,333,84,0.00053840
+Patience Sort,333,85,0.00057910
+Patience Sort,333,86,0.00050930
+Patience Sort,333,87,0.00054060
+Patience Sort,333,88,0.00056340
+Patience Sort,333,89,0.00052570
+Patience Sort,333,90,0.00052880
+Patience Sort,333,91,0.00102390
+Patience Sort,333,92,0.00048140
+Patience Sort,333,93,0.00054200
+Patience Sort,333,94,0.00050580
+Patience Sort,333,95,0.00052890
+Patience Sort,333,96,0.00055020
+Patience Sort,333,97,0.00050690
+Patience Sort,333,98,0.00053900
+Patience Sort,333,99,0.00052930
+Patience Sort,333,100,0.00050260
+Patience Sort,333,101,0.00054570
+Patience Sort,333,102,0.00046400
+Patience Sort,333,103,0.00051690
+Patience Sort,333,104,0.00049250
+Patience Sort,333,105,0.00049680
+Patience Sort,333,106,0.00047210
+Patience Sort,333,107,0.00050110
+Patience Sort,333,108,0.00050770
+Patience Sort,333,109,0.00052160
+Patience Sort,333,110,0.00050780
+Patience Sort,333,111,0.00050310
+Patience Sort,333,112,0.00047590
+Patience Sort,333,113,0.00051300
+Patience Sort,333,114,0.00053020
+Patience Sort,333,115,0.00039550
+Patience Sort,333,116,0.00049200
+Patience Sort,333,117,0.00046560
+Patience Sort,333,118,0.00051360
+Patience Sort,333,119,0.00049470
+Patience Sort,333,120,0.00049630
+Patience Sort,333,121,0.00053750
+Patience Sort,333,122,0.00049280
+Patience Sort,333,123,0.00051180
+Patience Sort,333,124,0.00045950
+Patience Sort,333,125,0.00048430
+Patience Sort,333,126,0.00048190
+Patience Sort,333,127,0.00050730
+Patience Sort,333,128,0.00052350
+Patience Sort,333,129,0.00050640
+Patience Sort,333,130,0.00053550
+Patience Sort,333,131,0.00050940
+Patience Sort,333,132,0.00054380
+Patience Sort,333,133,0.00050720
+Patience Sort,333,134,0.00049210
+Patience Sort,333,135,0.00040430
+Patience Sort,333,136,0.00053430
+Patience Sort,333,137,0.00050940
+Patience Sort,333,138,0.00047680
+Patience Sort,333,139,0.00049360
+Patience Sort,333,140,0.00051220
+Patience Sort,333,141,0.00052840
+Patience Sort,333,142,0.00049450
+Patience Sort,333,143,0.00051260
+Patience Sort,333,144,0.00052930
+Patience Sort,333,145,0.00049840
+Patience Sort,333,146,0.00048630
+Patience Sort,333,147,0.00047250
+Patience Sort,333,148,0.00050210
+Patience Sort,333,149,0.00045020
+Patience Sort,333,150,0.00050570
+Patience Sort,333,151,0.00039650
+Patience Sort,333,152,0.00046620
+Patience Sort,333,153,0.00051150
+Patience Sort,333,154,0.00040400
+Patience Sort,333,155,0.00028490
+Patience Sort,333,156,0.00026480
+Patience Sort,333,157,0.00047610
+Patience Sort,333,158,0.00046690
+Patience Sort,333,159,0.00051930
+Patience Sort,333,160,0.00048130
+Patience Sort,333,161,0.00053040
+Patience Sort,333,162,0.00049580
+Patience Sort,333,163,0.00046830
+Patience Sort,333,164,0.00048610
+Patience Sort,333,165,0.00028000
+Patience Sort,333,166,0.00045880
+Patience Sort,333,167,0.00046400
+Patience Sort,333,168,0.00038540
+Patience Sort,333,169,0.00050180
+Patience Sort,333,170,0.00050930
+Patience Sort,333,171,0.00050140
+Patience Sort,333,172,0.00051230
+Patience Sort,333,173,0.00052440
+Patience Sort,333,174,0.00034790
+Patience Sort,333,175,0.00047660
+Patience Sort,333,176,0.00051530
+Patience Sort,333,177,0.00043450
+Patience Sort,333,178,0.00049800
+Patience Sort,333,179,0.00051320
+Patience Sort,333,180,0.00040560
+Patience Sort,333,181,0.00028940
+Patience Sort,333,182,0.00048220
+Patience Sort,333,183,0.00036760
+Patience Sort,333,184,0.00050680
+Patience Sort,333,185,0.00050320
+Patience Sort,333,186,0.00045400
+Patience Sort,333,187,0.00051690
+Patience Sort,333,188,0.00039080
+Patience Sort,333,189,0.00033310
+Patience Sort,333,190,0.00048300
+Patience Sort,333,191,0.00029530
+Patience Sort,333,192,0.00045270
+Patience Sort,333,193,0.00027550
+Patience Sort,333,194,0.00042350
+Patience Sort,333,195,0.00050750
+Patience Sort,333,196,0.00033570
+Patience Sort,333,197,0.00052790
+Patience Sort,333,198,0.00029310
+Patience Sort,333,199,0.00048650
+Patience Sort,333,200,0.00048290
+Patience Sort,333,201,0.00051820
+Patience Sort,333,202,0.00037410
+Patience Sort,333,203,0.00048110
+Patience Sort,333,204,0.00049850
+Patience Sort,333,205,0.00045820
+Patience Sort,333,206,0.00037950
+Patience Sort,333,207,0.00029910
+Patience Sort,333,208,0.00027860
+Patience Sort,333,209,0.00041710
+Patience Sort,333,210,0.00049360
+Patience Sort,333,211,0.00045650
+Patience Sort,333,212,0.00052180
+Patience Sort,333,213,0.00049240
+Patience Sort,333,214,0.00027770
+Patience Sort,333,215,0.00053910
+Patience Sort,333,216,0.00049550
+Patience Sort,333,217,0.00048410
+Patience Sort,333,218,0.00043770
+Patience Sort,333,219,0.00028290
+Patience Sort,333,220,0.00035320
+Patience Sort,333,221,0.00047320
+Patience Sort,333,222,0.00050330
+Patience Sort,333,223,0.00040560
+Patience Sort,333,224,0.00048770
+Patience Sort,333,225,0.00044370
+Patience Sort,333,226,0.00031060
+Patience Sort,333,227,0.00048440
+Patience Sort,333,228,0.00045990
+Patience Sort,333,229,0.00050430
+Patience Sort,333,230,0.00043550
+Patience Sort,333,231,0.00051040
+Patience Sort,333,232,0.00050220
+Patience Sort,333,233,0.00051250
+Patience Sort,333,234,0.00050340
+Patience Sort,333,235,0.00048620
+Patience Sort,333,236,0.00046200
+Patience Sort,333,237,0.00049400
+Patience Sort,333,238,0.00045170
+Patience Sort,333,239,0.00047020
+Patience Sort,333,240,0.00046580
+Patience Sort,333,241,0.00029560
+Patience Sort,333,242,0.00046690
+Patience Sort,333,243,0.00048550
+Patience Sort,333,244,0.00050880
+Patience Sort,333,245,0.00049310
+Patience Sort,333,246,0.00050340
+Patience Sort,333,247,0.00045250
+Patience Sort,333,248,0.00048760
+Patience Sort,333,249,0.00030220
+Patience Sort,333,250,0.00048520
+Patience Sort,333,251,0.00046510
+Patience Sort,333,252,0.00050350
+Patience Sort,333,253,0.00048560
+Patience Sort,333,254,0.00053150
+Patience Sort,333,255,0.00042180
+Patience Sort,333,256,0.00050820
+Patience Sort,333,257,0.00038620
+Patience Sort,333,258,0.00047830
+Patience Sort,333,259,0.00048570
+Patience Sort,333,260,0.00045560
+Patience Sort,333,261,0.00050300
+Patience Sort,333,262,0.00049720
+Patience Sort,333,263,0.00029670
+Patience Sort,333,264,0.00042760
+Patience Sort,333,265,0.00035790
+Patience Sort,333,266,0.00049870
+Patience Sort,333,267,0.00046170
+Patience Sort,333,268,0.00052580
+Patience Sort,333,269,0.00048520
+Patience Sort,333,270,0.00046580
+Patience Sort,333,271,0.00048380
+Patience Sort,333,272,0.00047200
+Patience Sort,333,273,0.00038050
+Patience Sort,333,274,0.00048640
+Patience Sort,333,275,0.00046420
+Patience Sort,333,276,0.00039420
+Patience Sort,333,277,0.00035060
+Patience Sort,333,278,0.00028870
+Patience Sort,333,279,0.00050200
+Patience Sort,333,280,0.00051840
+Patience Sort,333,281,0.00044150
+Patience Sort,333,282,0.00041130
+Patience Sort,333,283,0.00046640
+Patience Sort,333,284,0.00051610
+Patience Sort,333,285,0.00047280
+Patience Sort,333,286,0.00048170
+Patience Sort,333,287,0.00033300
+Patience Sort,333,288,0.00046810
+Patience Sort,333,289,0.00045710
+Patience Sort,333,290,0.00037610
+Patience Sort,333,291,0.00046840
+Patience Sort,333,292,0.00028430
+Patience Sort,333,293,0.00051700
+Patience Sort,333,294,0.00028550
+Patience Sort,333,295,0.00046850
+Patience Sort,333,296,0.00048550
+Patience Sort,333,297,0.00051940
+Patience Sort,333,298,0.00030350
+Patience Sort,333,299,0.00028420
+Patience Sort,333,300,0.00048360
+Patience Sort,333,301,0.00049820
+Patience Sort,333,302,0.00038040
+Patience Sort,333,303,0.00061780
+Patience Sort,333,304,0.00046940
+Patience Sort,333,305,0.00051130
+Patience Sort,333,306,0.00049090
+Patience Sort,333,307,0.00048150
+Patience Sort,333,308,0.00049110
+Patience Sort,333,309,0.00051540
+Patience Sort,333,310,0.00035100
+Patience Sort,333,311,0.00040520
+Patience Sort,333,312,0.00048600
+Patience Sort,333,313,0.00043880
+Patience Sort,333,314,0.00044270
+Patience Sort,333,315,0.00046160
+Patience Sort,333,316,0.00044100
+Patience Sort,333,317,0.00031760
+Patience Sort,333,318,0.00041550
+Patience Sort,333,319,0.00032210
+Patience Sort,333,320,0.00049020
+Patience Sort,333,321,0.00053290
+Patience Sort,333,322,0.00053230
+Patience Sort,333,323,0.00052730
+Patience Sort,333,324,0.00045550
+Patience Sort,333,325,0.00043090
+Patience Sort,333,326,0.00047330
+Patience Sort,333,327,0.00050220
+Patience Sort,333,328,0.00045050
+Patience Sort,333,329,0.00037270
+Patience Sort,333,330,0.00043560
+Patience Sort,333,331,0.00053530
+Patience Sort,333,332,0.00047590
+Patience Sort,333,333,0.00048280
+Patience Sort,333,334,0.00043190
+Patience Sort,333,335,0.00050120
+Patience Sort,333,336,0.00048730
+Patience Sort,333,337,0.00039470
+Patience Sort,333,338,0.00052140
+Patience Sort,333,339,0.00034780
+Patience Sort,333,340,0.00050900
+Patience Sort,333,341,0.00047390
+Patience Sort,333,342,0.00048820
+Patience Sort,333,343,0.00050750
+Patience Sort,333,344,0.00044090
+Patience Sort,333,345,0.00047460
+Patience Sort,333,346,0.00049750
+Patience Sort,333,347,0.00053090
+Patience Sort,333,348,0.00051310
+Patience Sort,333,349,0.00047410
+Patience Sort,333,350,0.00042850
+Patience Sort,333,351,0.00052310
+Patience Sort,333,352,0.00050400
+Patience Sort,333,353,0.00046920
+Patience Sort,333,354,0.00048320
+Patience Sort,333,355,0.00052930
+Patience Sort,333,356,0.00051350
+Patience Sort,333,357,0.00044260
+Patience Sort,333,358,0.00029340
+Patience Sort,333,359,0.00051490
+Patience Sort,333,360,0.00051310
+Patience Sort,333,361,0.00048970
+Patience Sort,333,362,0.00050570
+Patience Sort,333,363,0.00035300
+Patience Sort,333,364,0.00039130
+Patience Sort,333,365,0.00046760
+Patience Sort,333,366,0.00052450
+Patience Sort,333,367,0.00026730
+Patience Sort,333,368,0.00030650
+Patience Sort,333,369,0.00048970
+Patience Sort,333,370,0.00050610
+Patience Sort,333,371,0.00049210
+Patience Sort,333,372,0.00048150
+Patience Sort,333,373,0.00040710
+Patience Sort,333,374,0.00026880
+Patience Sort,333,375,0.00052880
+Patience Sort,333,376,0.00035430
+Patience Sort,333,377,0.00043770
+Patience Sort,333,378,0.00043170
+Patience Sort,333,379,0.00032000
+Patience Sort,333,380,0.00040610
+Patience Sort,333,381,0.00054110
+Patience Sort,333,382,0.00048420
+Patience Sort,333,383,0.00050510
+Patience Sort,333,384,0.00046630
+Patience Sort,333,385,0.00049210
+Patience Sort,333,386,0.00045740
+Patience Sort,333,387,0.00037060
+Patience Sort,333,388,0.00038450
+Patience Sort,333,389,0.00027870
+Patience Sort,333,390,0.00048150
+Patience Sort,333,391,0.00048720
+Patience Sort,333,392,0.00049290
+Patience Sort,333,393,0.00048340
+Patience Sort,333,394,0.00047280
+Patience Sort,333,395,0.00053850
+Patience Sort,333,396,0.00048590
+Patience Sort,333,397,0.00046650
+Patience Sort,333,398,0.00045110
+Patience Sort,333,399,0.00039540
+Patience Sort,333,400,0.00043380
+Patience Sort,333,401,0.00030920
+Patience Sort,333,402,0.00055630
+Patience Sort,333,403,0.00049600
+Patience Sort,333,404,0.00045540
+Patience Sort,333,405,0.00044240
+Patience Sort,333,406,0.00047930
+Patience Sort,333,407,0.00044230
+Patience Sort,333,408,0.00048020
+Patience Sort,333,409,0.00051480
+Patience Sort,333,410,0.00049630
+Patience Sort,333,411,0.00050450
+Patience Sort,333,412,0.00049700
+Patience Sort,333,413,0.00049380
+Patience Sort,333,414,0.00048070
+Patience Sort,333,415,0.00049030
+Patience Sort,333,416,0.00046340
+Patience Sort,333,417,0.00051690
+Patience Sort,333,418,0.00042980
+Patience Sort,333,419,0.00047000
+Patience Sort,333,420,0.00037120
+Patience Sort,333,421,0.00040930
+Patience Sort,333,422,0.00048510
+Patience Sort,333,423,0.00047490
+Patience Sort,333,424,0.00048640
+Patience Sort,333,425,0.00048190
+Patience Sort,333,426,0.00049830
+Patience Sort,333,427,0.00034110
+Patience Sort,333,428,0.00046970
+Patience Sort,333,429,0.00034560
+Patience Sort,333,430,0.00041540
+Patience Sort,333,431,0.00048320
+Patience Sort,333,432,0.00046700
+Patience Sort,333,433,0.00047750
+Patience Sort,333,434,0.00044650
+Patience Sort,333,435,0.00052970
+Patience Sort,333,436,0.00040930
+Patience Sort,333,437,0.00046590
+Patience Sort,333,438,0.00036020
+Patience Sort,333,439,0.00027650
+Patience Sort,333,440,0.00044840
+Patience Sort,333,441,0.00050120
+Patience Sort,333,442,0.00047040
+Patience Sort,333,443,0.00033060
+Patience Sort,333,444,0.00046640
+Patience Sort,333,445,0.00045220
+Patience Sort,333,446,0.00048990
+Patience Sort,333,447,0.00051930
+Patience Sort,333,448,0.00043850
+Patience Sort,333,449,0.00031830
+Patience Sort,333,450,0.00046980
+Patience Sort,333,451,0.00032070
+Patience Sort,333,452,0.00052140
+Patience Sort,333,453,0.00047920
+Patience Sort,333,454,0.00047320
+Patience Sort,333,455,0.00046920
+Patience Sort,333,456,0.00047610
+Patience Sort,333,457,0.00039790
+Patience Sort,333,458,0.00050470
+Patience Sort,333,459,0.00039280
+Patience Sort,333,460,0.00051990
+Patience Sort,333,461,0.00034950
+Patience Sort,333,462,0.00048770
+Patience Sort,333,463,0.00032440
+Patience Sort,333,464,0.00050700
+Patience Sort,333,465,0.00050190
+Patience Sort,333,466,0.00049500
+Patience Sort,333,467,0.00050460
+Patience Sort,333,468,0.00051540
+Patience Sort,333,469,0.00046310
+Patience Sort,333,470,0.00052080
+Patience Sort,333,471,0.00050350
+Patience Sort,333,472,0.00047520
+Patience Sort,333,473,0.00043260
+Patience Sort,333,474,0.00047050
+Patience Sort,333,475,0.00051660
+Patience Sort,333,476,0.00050440
+Patience Sort,333,477,0.00030120
+Patience Sort,333,478,0.00030090
+Patience Sort,333,479,0.00047520
+Patience Sort,333,480,0.00053260
+Patience Sort,333,481,0.00028810
+Patience Sort,333,482,0.00049570
+Patience Sort,333,483,0.00028880
+Patience Sort,333,484,0.00042650
+Patience Sort,333,485,0.00045250
+Patience Sort,333,486,0.00028280
+Patience Sort,333,487,0.00048380
+Patience Sort,333,488,0.00047360
+Patience Sort,333,489,0.00046070
+Patience Sort,333,490,0.00029980
+Patience Sort,333,491,0.00052350
+Patience Sort,333,492,0.00053200
+Patience Sort,333,493,0.00047460
+Patience Sort,333,494,0.00046830
+Patience Sort,333,495,0.00048640
+Patience Sort,333,496,0.00050250
+Patience Sort,333,497,0.00029030
+Patience Sort,333,498,0.00048540
+Patience Sort,333,499,0.00031410
+Patience Sort,333,500,0.00051580
+Pigeonhole Sort,333,1,1.88084890
+Pigeonhole Sort,333,2,2.04985680
+Pigeonhole Sort,333,3,1.77780190
+Pigeonhole Sort,333,4,1.92513100
+Pigeonhole Sort,333,5,1.84991920
+Pigeonhole Sort,333,6,1.82850020
+Pigeonhole Sort,333,7,1.95012630
+Pigeonhole Sort,333,8,2.04381720
+Pigeonhole Sort,333,9,1.83952590
+Pigeonhole Sort,333,10,1.87549540
+Pigeonhole Sort,333,11,3.03203630
+Pigeonhole Sort,333,12,2.27191440
+Pigeonhole Sort,333,13,2.19861490
+Pigeonhole Sort,333,14,1.99137160
+Pigeonhole Sort,333,15,1.91576650
+Pigeonhole Sort,333,16,1.94188630
+Pigeonhole Sort,333,17,1.97792250
+Pigeonhole Sort,333,18,1.99570430
+Pigeonhole Sort,333,19,1.99940630
+Pigeonhole Sort,333,20,1.60951860
+Pigeonhole Sort,333,21,1.82151760
+Pigeonhole Sort,333,22,2.28199490
+Pigeonhole Sort,333,23,1.85512790
+Pigeonhole Sort,333,24,1.73902190
+Pigeonhole Sort,333,25,2.25013600
+Pigeonhole Sort,333,26,1.63124970
+Pigeonhole Sort,333,27,2.10300300
+Pigeonhole Sort,333,28,2.55399680
+Pigeonhole Sort,333,29,1.96157120
+Pigeonhole Sort,333,30,1.93836950
+Pigeonhole Sort,333,31,1.83897310
+Pigeonhole Sort,333,32,2.14512820
+Pigeonhole Sort,333,33,2.00553040
+Pigeonhole Sort,333,34,2.06140090
+Pigeonhole Sort,333,35,2.33312410
+Pigeonhole Sort,333,36,2.21704820
+Pigeonhole Sort,333,37,2.11825300
+Pigeonhole Sort,333,38,1.99647820
+Pigeonhole Sort,333,39,1.87559690
+Pigeonhole Sort,333,40,2.17340340
+Pigeonhole Sort,333,41,2.20113370
+Pigeonhole Sort,333,42,1.99887790
+Pigeonhole Sort,333,43,2.25201040
+Pigeonhole Sort,333,44,2.10884600
+Pigeonhole Sort,333,45,2.25053580
+Pigeonhole Sort,333,46,2.35962620
+Pigeonhole Sort,333,47,2.32747880
+Pigeonhole Sort,333,48,2.03564130
+Pigeonhole Sort,333,49,2.27045710
+Pigeonhole Sort,333,50,2.35240150
+Pigeonhole Sort,333,51,2.28317860
+Pigeonhole Sort,333,52,2.10405590
+Pigeonhole Sort,333,53,2.41097810
+Pigeonhole Sort,333,54,2.11007040
+Pigeonhole Sort,333,55,2.30874930
+Pigeonhole Sort,333,56,2.18102900
+Pigeonhole Sort,333,57,2.24298320
+Pigeonhole Sort,333,58,2.06755330
+Pigeonhole Sort,333,59,1.92875440
+Pigeonhole Sort,333,60,2.54745610
+Pigeonhole Sort,333,61,2.44393560
+Pigeonhole Sort,333,62,2.29090670
+Pigeonhole Sort,333,63,2.08538000
+Pigeonhole Sort,333,64,2.39314670
+Pigeonhole Sort,333,65,2.41775310
+Pigeonhole Sort,333,66,2.16839380
+Pigeonhole Sort,333,67,2.34503010
+Pigeonhole Sort,333,68,2.06759270
+Pigeonhole Sort,333,69,1.99834130
+Pigeonhole Sort,333,70,2.31115180
+Pigeonhole Sort,333,71,2.35022030
+Pigeonhole Sort,333,72,2.50690170
+Pigeonhole Sort,333,73,2.42723540
+Pigeonhole Sort,333,74,2.64004070
+Pigeonhole Sort,333,75,2.12145010
+Pigeonhole Sort,333,76,2.22103980
+Pigeonhole Sort,333,77,2.50536270
+Pigeonhole Sort,333,78,2.46679940
+Pigeonhole Sort,333,79,2.90613690
+Pigeonhole Sort,333,80,2.23956060
+Pigeonhole Sort,333,81,2.48619690
+Pigeonhole Sort,333,82,2.46939730
+Pigeonhole Sort,333,83,2.41643860
+Pigeonhole Sort,333,84,2.68590500
+Pigeonhole Sort,333,85,2.12708550
+Pigeonhole Sort,333,86,2.83617290
+Pigeonhole Sort,333,87,2.71255070
+Pigeonhole Sort,333,88,2.88170380
+Pigeonhole Sort,333,89,2.58813250
+Pigeonhole Sort,333,90,2.49967530
+Pigeonhole Sort,333,91,2.46068050
+Pigeonhole Sort,333,92,2.40955060
+Pigeonhole Sort,333,93,2.23554820
+Pigeonhole Sort,333,94,3.48389250
+Pigeonhole Sort,333,95,2.66729180
+Pigeonhole Sort,333,96,2.39531490
+Pigeonhole Sort,333,97,2.49080480
+Pigeonhole Sort,333,98,2.65831830
+Pigeonhole Sort,333,99,2.76056860
+Pigeonhole Sort,333,100,2.68010910
+Pigeonhole Sort,333,101,2.78723310
+Pigeonhole Sort,333,102,2.45499740
+Pigeonhole Sort,333,103,2.35851760
+Pigeonhole Sort,333,104,2.58593600
+Pigeonhole Sort,333,105,2.52746490
+Pigeonhole Sort,333,106,2.66748490
+Pigeonhole Sort,333,107,2.16557710
+Pigeonhole Sort,333,108,2.83490960
+Pigeonhole Sort,333,109,2.83629790
+Pigeonhole Sort,333,110,3.30879800
+Pigeonhole Sort,333,111,2.73790920
+Pigeonhole Sort,333,112,2.19529840
+Pigeonhole Sort,333,113,2.57386530
+Pigeonhole Sort,333,114,2.75324120
+Pigeonhole Sort,333,115,2.50047660
+Pigeonhole Sort,333,116,2.32767470
+Pigeonhole Sort,333,117,2.39467510
+Pigeonhole Sort,333,118,2.78719270
+Pigeonhole Sort,333,119,2.87753470
+Pigeonhole Sort,333,120,2.53863320
+Pigeonhole Sort,333,121,2.62300850
+Pigeonhole Sort,333,122,2.19838100
+Pigeonhole Sort,333,123,2.39207480
+Pigeonhole Sort,333,124,2.59765730
+Pigeonhole Sort,333,125,2.50634580
+Pigeonhole Sort,333,126,2.36173810
+Pigeonhole Sort,333,127,2.73542980
+Pigeonhole Sort,333,128,2.48357400
+Pigeonhole Sort,333,129,3.11385810
+Pigeonhole Sort,333,130,2.50378210
+Pigeonhole Sort,333,131,2.62149130
+Pigeonhole Sort,333,132,2.39288020
+Pigeonhole Sort,333,133,2.62783340
+Pigeonhole Sort,333,134,2.59310620
+Pigeonhole Sort,333,135,2.59893280
+Pigeonhole Sort,333,136,2.62218070
+Pigeonhole Sort,333,137,2.57908560
+Pigeonhole Sort,333,138,2.74515850
+Pigeonhole Sort,333,139,2.39641180
+Pigeonhole Sort,333,140,2.73780620
+Pigeonhole Sort,333,141,2.62627860
+Pigeonhole Sort,333,142,3.14660680
+Pigeonhole Sort,333,143,2.85000740
+Pigeonhole Sort,333,144,2.60213480
+Pigeonhole Sort,333,145,3.18894030
+Pigeonhole Sort,333,146,2.61237790
+Pigeonhole Sort,333,147,2.49988390
+Pigeonhole Sort,333,148,2.73287690
+Pigeonhole Sort,333,149,2.86950240
+Pigeonhole Sort,333,150,2.47013870
+Pigeonhole Sort,333,151,2.93948600
+Pigeonhole Sort,333,152,3.38512120
+Pigeonhole Sort,333,153,2.84367040
+Pigeonhole Sort,333,154,2.47196070
+Pigeonhole Sort,333,155,2.91212690
+Pigeonhole Sort,333,156,2.52132980
+Pigeonhole Sort,333,157,2.87539720
+Pigeonhole Sort,333,158,2.68810150
+Pigeonhole Sort,333,159,2.88167660
+Pigeonhole Sort,333,160,2.73566870
+Pigeonhole Sort,333,161,2.97453870
+Pigeonhole Sort,333,162,2.82925600
+Pigeonhole Sort,333,163,2.62781650
+Pigeonhole Sort,333,164,2.82992000
+Pigeonhole Sort,333,165,2.67491870
+Pigeonhole Sort,333,166,2.80313630
+Pigeonhole Sort,333,167,2.62288310
+Pigeonhole Sort,333,168,2.58240020
+Pigeonhole Sort,333,169,3.46836830
+Pigeonhole Sort,333,170,2.74377670
+Pigeonhole Sort,333,171,2.68150790
+Pigeonhole Sort,333,172,2.76734070
+Pigeonhole Sort,333,173,2.59022680
+Pigeonhole Sort,333,174,2.47515980
+Pigeonhole Sort,333,175,2.69417140
+Pigeonhole Sort,333,176,3.16460130
+Pigeonhole Sort,333,177,2.48642670
+Pigeonhole Sort,333,178,2.46324160
+Pigeonhole Sort,333,179,2.61290260
+Pigeonhole Sort,333,180,2.49042360
+Pigeonhole Sort,333,181,2.78335700
+Pigeonhole Sort,333,182,2.57078360
+Pigeonhole Sort,333,183,2.46733360
+Pigeonhole Sort,333,184,3.42582330
+Pigeonhole Sort,333,185,2.71894880
+Pigeonhole Sort,333,186,2.61939300
+Pigeonhole Sort,333,187,2.73574520
+Pigeonhole Sort,333,188,2.63332760
+Pigeonhole Sort,333,189,3.22207500
+Pigeonhole Sort,333,190,2.84539270
+Pigeonhole Sort,333,191,2.70779530
+Pigeonhole Sort,333,192,2.81296700
+Pigeonhole Sort,333,193,2.66736170
+Pigeonhole Sort,333,194,3.31719730
+Pigeonhole Sort,333,195,2.59215920
+Pigeonhole Sort,333,196,2.76960280
+Pigeonhole Sort,333,197,2.83511070
+Pigeonhole Sort,333,198,2.84902400
+Pigeonhole Sort,333,199,2.60452000
+Pigeonhole Sort,333,200,2.56189470
+Pigeonhole Sort,333,201,2.48880500
+Pigeonhole Sort,333,202,2.87367700
+Pigeonhole Sort,333,203,2.63094760
+Pigeonhole Sort,333,204,2.87540570
+Pigeonhole Sort,333,205,2.97824320
+Pigeonhole Sort,333,206,2.56573360
+Pigeonhole Sort,333,207,2.72712810
+Pigeonhole Sort,333,208,3.34068900
+Pigeonhole Sort,333,209,2.64694020
+Pigeonhole Sort,333,210,2.82299840
+Pigeonhole Sort,333,211,2.70331510
+Pigeonhole Sort,333,212,2.64268650
+Pigeonhole Sort,333,213,2.79067730
+Pigeonhole Sort,333,214,2.80636810
+Pigeonhole Sort,333,215,3.08000070
+Pigeonhole Sort,333,216,3.28765640
+Pigeonhole Sort,333,217,2.97609220
+Pigeonhole Sort,333,218,2.44840300
+Pigeonhole Sort,333,219,2.61706660
+Pigeonhole Sort,333,220,2.83312900
+Pigeonhole Sort,333,221,2.60149970
+Pigeonhole Sort,333,222,2.84642160
+Pigeonhole Sort,333,223,2.89838720
+Pigeonhole Sort,333,224,2.67143890
+Pigeonhole Sort,333,225,3.18620690
+Pigeonhole Sort,333,226,2.46723490
+Pigeonhole Sort,333,227,2.65015100
+Pigeonhole Sort,333,228,2.79559200
+Pigeonhole Sort,333,229,2.76739740
+Pigeonhole Sort,333,230,2.70307390
+Pigeonhole Sort,333,231,2.88655340
+Pigeonhole Sort,333,232,2.79658590
+Pigeonhole Sort,333,233,2.75460050
+Pigeonhole Sort,333,234,3.16556310
+Pigeonhole Sort,333,235,2.81446870
+Pigeonhole Sort,333,236,2.84257220
+Pigeonhole Sort,333,237,2.62959720
+Pigeonhole Sort,333,238,2.62798080
+Pigeonhole Sort,333,239,2.75746580
+Pigeonhole Sort,333,240,2.79137920
+Pigeonhole Sort,333,241,2.64021000
+Pigeonhole Sort,333,242,2.74739040
+Pigeonhole Sort,333,243,2.80734130
+Pigeonhole Sort,333,244,2.75630050
+Pigeonhole Sort,333,245,2.91086660
+Pigeonhole Sort,333,246,2.44711880
+Pigeonhole Sort,333,247,2.87471800
+Pigeonhole Sort,333,248,2.30247270
+Pigeonhole Sort,333,249,2.66905690
+Pigeonhole Sort,333,250,2.70764150
+Pigeonhole Sort,333,251,2.79289510
+Pigeonhole Sort,333,252,3.19183550
+Pigeonhole Sort,333,253,2.75064380
+Pigeonhole Sort,333,254,3.07765290
+Pigeonhole Sort,333,255,2.79809260
+Pigeonhole Sort,333,256,2.34607210
+Pigeonhole Sort,333,257,2.48235150
+Pigeonhole Sort,333,258,2.72738780
+Pigeonhole Sort,333,259,2.92477900
+Pigeonhole Sort,333,260,2.72862570
+Pigeonhole Sort,333,261,2.63950710
+Pigeonhole Sort,333,262,2.49680420
+Pigeonhole Sort,333,263,2.96137450
+Pigeonhole Sort,333,264,3.30161890
+Pigeonhole Sort,333,265,2.92003730
+Pigeonhole Sort,333,266,2.59660440
+Pigeonhole Sort,333,267,2.87371180
+Pigeonhole Sort,333,268,2.62059210
+Pigeonhole Sort,333,269,2.74683400
+Pigeonhole Sort,333,270,3.15788390
+Pigeonhole Sort,333,271,2.61080790
+Pigeonhole Sort,333,272,2.48316990
+Pigeonhole Sort,333,273,3.16797960
+Pigeonhole Sort,333,274,2.82794760
+Pigeonhole Sort,333,275,3.11277080
+Pigeonhole Sort,333,276,3.00430010
+Pigeonhole Sort,333,277,2.87448950
+Pigeonhole Sort,333,278,2.62420970
+Pigeonhole Sort,333,279,2.86991080
+Pigeonhole Sort,333,280,2.68929740
+Pigeonhole Sort,333,281,2.58375790
+Pigeonhole Sort,333,282,2.88035240
+Pigeonhole Sort,333,283,2.41072250
+Pigeonhole Sort,333,284,2.69140610
+Pigeonhole Sort,333,285,2.70048600
+Pigeonhole Sort,333,286,2.75794890
+Pigeonhole Sort,333,287,2.90657380
+Pigeonhole Sort,333,288,2.49791340
+Pigeonhole Sort,333,289,2.69338410
+Pigeonhole Sort,333,290,2.77923900
+Pigeonhole Sort,333,291,2.84063440
+Pigeonhole Sort,333,292,2.63679650
+Pigeonhole Sort,333,293,2.76615320
+Pigeonhole Sort,333,294,2.74387760
+Pigeonhole Sort,333,295,2.39212010
+Pigeonhole Sort,333,296,2.47422080
+Pigeonhole Sort,333,297,2.72188120
+Pigeonhole Sort,333,298,2.70917480
+Pigeonhole Sort,333,299,2.86269540
+Pigeonhole Sort,333,300,2.77197330
+Pigeonhole Sort,333,301,3.01517030
+Pigeonhole Sort,333,302,2.49305270
+Pigeonhole Sort,333,303,2.99102210
+Pigeonhole Sort,333,304,2.52523680
+Pigeonhole Sort,333,305,2.51366390
+Pigeonhole Sort,333,306,2.92624150
+Pigeonhole Sort,333,307,2.68654190
+Pigeonhole Sort,333,308,2.77535890
+Pigeonhole Sort,333,309,2.71854640
+Pigeonhole Sort,333,310,2.69273170
+Pigeonhole Sort,333,311,2.85070190
+Pigeonhole Sort,333,312,2.84411930
+Pigeonhole Sort,333,313,2.48602490
+Pigeonhole Sort,333,314,2.91078330
+Pigeonhole Sort,333,315,3.10794210
+Pigeonhole Sort,333,316,2.80954780
+Pigeonhole Sort,333,317,2.68861480
+Pigeonhole Sort,333,318,2.52676710
+Pigeonhole Sort,333,319,2.62962410
+Pigeonhole Sort,333,320,2.61997010
+Pigeonhole Sort,333,321,2.77863320
+Pigeonhole Sort,333,322,3.05138580
+Pigeonhole Sort,333,323,2.80350090
+Pigeonhole Sort,333,324,2.88423670
+Pigeonhole Sort,333,325,2.73581440
+Pigeonhole Sort,333,326,3.04342340
+Pigeonhole Sort,333,327,2.84339610
+Pigeonhole Sort,333,328,2.91879160
+Pigeonhole Sort,333,329,2.59048190
+Pigeonhole Sort,333,330,3.00341400
+Pigeonhole Sort,333,331,2.97348000
+Pigeonhole Sort,333,332,2.80190980
+Pigeonhole Sort,333,333,2.82765290
+Pigeonhole Sort,333,334,2.74197920
+Pigeonhole Sort,333,335,2.90858730
+Pigeonhole Sort,333,336,2.83844540
+Pigeonhole Sort,333,337,2.80465840
+Pigeonhole Sort,333,338,2.95530210
+Pigeonhole Sort,333,339,2.66810170
+Pigeonhole Sort,333,340,2.67672590
+Pigeonhole Sort,333,341,2.64894550
+Pigeonhole Sort,333,342,2.35050370
+Pigeonhole Sort,333,343,2.77436940
+Pigeonhole Sort,333,344,2.82269540
+Pigeonhole Sort,333,345,2.79574990
+Pigeonhole Sort,333,346,2.77590090
+Pigeonhole Sort,333,347,2.55437380
+Pigeonhole Sort,333,348,2.75220100
+Pigeonhole Sort,333,349,2.38449210
+Pigeonhole Sort,333,350,3.05525420
+Pigeonhole Sort,333,351,2.70053500
+Pigeonhole Sort,333,352,2.32752280
+Pigeonhole Sort,333,353,3.36140610
+Pigeonhole Sort,333,354,2.76308100
+Pigeonhole Sort,333,355,2.74550410
+Pigeonhole Sort,333,356,2.79976400
+Pigeonhole Sort,333,357,2.85389760
+Pigeonhole Sort,333,358,2.77078450
+Pigeonhole Sort,333,359,2.48618390
+Pigeonhole Sort,333,360,2.85107220
+Pigeonhole Sort,333,361,2.72363510
+Pigeonhole Sort,333,362,2.90393120
+Pigeonhole Sort,333,363,2.73337990
+Pigeonhole Sort,333,364,2.85094220
+Pigeonhole Sort,333,365,2.88712880
+Pigeonhole Sort,333,366,3.10491510
+Pigeonhole Sort,333,367,2.69637170
+Pigeonhole Sort,333,368,2.66054000
+Pigeonhole Sort,333,369,2.65803520
+Pigeonhole Sort,333,370,2.92306420
+Pigeonhole Sort,333,371,2.91509830
+Pigeonhole Sort,333,372,2.75209560
+Pigeonhole Sort,333,373,2.52886780
+Pigeonhole Sort,333,374,2.51451620
+Pigeonhole Sort,333,375,2.54104040
+Pigeonhole Sort,333,376,2.58817820
+Pigeonhole Sort,333,377,2.64336350
+Pigeonhole Sort,333,378,2.41420370
+Pigeonhole Sort,333,379,2.67914820
+Pigeonhole Sort,333,380,2.56691520
+Pigeonhole Sort,333,381,2.58697640
+Pigeonhole Sort,333,382,2.54230730
+Pigeonhole Sort,333,383,2.63839860
+Pigeonhole Sort,333,384,3.11036370
+Pigeonhole Sort,333,385,2.77266390
+Pigeonhole Sort,333,386,2.61345200
+Pigeonhole Sort,333,387,2.65164840
+Pigeonhole Sort,333,388,3.46849610
+Pigeonhole Sort,333,389,2.79732620
+Pigeonhole Sort,333,390,2.76357850
+Pigeonhole Sort,333,391,2.74111190
+Pigeonhole Sort,333,392,3.03407030
+Pigeonhole Sort,333,393,2.64717660
+Pigeonhole Sort,333,394,3.26090920
+Pigeonhole Sort,333,395,2.66240330
+Pigeonhole Sort,333,396,2.73661050
+Pigeonhole Sort,333,397,2.72810530
+Pigeonhole Sort,333,398,2.82680700
+Pigeonhole Sort,333,399,2.77547520
+Pigeonhole Sort,333,400,2.87577050
+Pigeonhole Sort,333,401,2.68745820
+Pigeonhole Sort,333,402,2.60734490
+Pigeonhole Sort,333,403,2.72784440
+Pigeonhole Sort,333,404,3.13430890
+Pigeonhole Sort,333,405,3.06841910
+Pigeonhole Sort,333,406,2.47094700
+Pigeonhole Sort,333,407,2.72429770
+Pigeonhole Sort,333,408,2.96634260
+Pigeonhole Sort,333,409,2.57317310
+Pigeonhole Sort,333,410,2.77217600
+Pigeonhole Sort,333,411,2.89158990
+Pigeonhole Sort,333,412,2.77616450
+Pigeonhole Sort,333,413,2.60235010
+Pigeonhole Sort,333,414,2.58782230
+Pigeonhole Sort,333,415,2.48990270
+Pigeonhole Sort,333,416,2.96931720
+Pigeonhole Sort,333,417,2.82912190
+Pigeonhole Sort,333,418,3.04538840
+Pigeonhole Sort,333,419,2.65180020
+Pigeonhole Sort,333,420,2.59316310
+Pigeonhole Sort,333,421,2.63783870
+Pigeonhole Sort,333,422,2.53439390
+Pigeonhole Sort,333,423,3.21494180
+Pigeonhole Sort,333,424,2.81650980
+Pigeonhole Sort,333,425,3.07366280
+Pigeonhole Sort,333,426,2.65316140
+Pigeonhole Sort,333,427,2.54322060
+Pigeonhole Sort,333,428,2.73745710
+Pigeonhole Sort,333,429,2.46501790
+Pigeonhole Sort,333,430,2.80312530
+Pigeonhole Sort,333,431,2.69984760
+Pigeonhole Sort,333,432,2.70264230
+Pigeonhole Sort,333,433,2.66034300
+Pigeonhole Sort,333,434,2.68138230
+Pigeonhole Sort,333,435,2.55013800
+Pigeonhole Sort,333,436,2.92528630
+Pigeonhole Sort,333,437,2.57081810
+Pigeonhole Sort,333,438,3.54119080
+Pigeonhole Sort,333,439,2.57200100
+Pigeonhole Sort,333,440,2.85055450
+Pigeonhole Sort,333,441,3.44281750
+Pigeonhole Sort,333,442,2.63068270
+Pigeonhole Sort,333,443,2.69296710
+Pigeonhole Sort,333,444,2.95987330
+Pigeonhole Sort,333,445,2.82715660
+Pigeonhole Sort,333,446,2.60811380
+Pigeonhole Sort,333,447,2.50834840
+Pigeonhole Sort,333,448,2.59569890
+Pigeonhole Sort,333,449,2.60117860
+Pigeonhole Sort,333,450,2.41307100
+Pigeonhole Sort,333,451,2.90141970
+Pigeonhole Sort,333,452,2.49370250
+Pigeonhole Sort,333,453,3.03403860
+Pigeonhole Sort,333,454,2.44867240
+Pigeonhole Sort,333,455,2.71049700
+Pigeonhole Sort,333,456,2.84209930
+Pigeonhole Sort,333,457,2.73900080
+Pigeonhole Sort,333,458,2.65608050
+Pigeonhole Sort,333,459,2.82208160
+Pigeonhole Sort,333,460,2.86824340
+Pigeonhole Sort,333,461,2.83471580
+Pigeonhole Sort,333,462,2.77863520
+Pigeonhole Sort,333,463,3.10994300
+Pigeonhole Sort,333,464,3.41591480
+Pigeonhole Sort,333,465,2.80956460
+Pigeonhole Sort,333,466,2.54885150
+Pigeonhole Sort,333,467,2.85745250
+Pigeonhole Sort,333,468,2.67856240
+Pigeonhole Sort,333,469,2.61515170
+Pigeonhole Sort,333,470,2.80485500
+Pigeonhole Sort,333,471,2.61944390
+Pigeonhole Sort,333,472,2.67637220
+Pigeonhole Sort,333,473,2.70433840
+Pigeonhole Sort,333,474,2.78133480
+Pigeonhole Sort,333,475,2.47469860
+Pigeonhole Sort,333,476,2.81293440
+Pigeonhole Sort,333,477,3.07916420
+Pigeonhole Sort,333,478,2.84451330
+Pigeonhole Sort,333,479,2.59516400
+Pigeonhole Sort,333,480,2.74810870
+Pigeonhole Sort,333,481,3.05981560
+Pigeonhole Sort,333,482,2.71170850
+Pigeonhole Sort,333,483,2.63165760
+Pigeonhole Sort,333,484,2.80097410
+Pigeonhole Sort,333,485,2.62929310
+Pigeonhole Sort,333,486,2.95004500
+Pigeonhole Sort,333,487,2.96970420
+Pigeonhole Sort,333,488,2.77722530
+Pigeonhole Sort,333,489,2.63406250
+Pigeonhole Sort,333,490,2.74533890
+Pigeonhole Sort,333,491,2.33361960
+Pigeonhole Sort,333,492,2.56246600
+Pigeonhole Sort,333,493,2.58130840
+Pigeonhole Sort,333,494,2.44946720
+Pigeonhole Sort,333,495,2.24484060
+Pigeonhole Sort,333,496,2.04532300
+Pigeonhole Sort,333,497,2.01027860
+Pigeonhole Sort,333,498,1.82689480
+Pigeonhole Sort,333,499,1.69835070
+Pigeonhole Sort,333,500,1.39063050
+Polyphase Merge Sort,333,1,0.00038770
+Polyphase Merge Sort,333,2,0.00059380
+Polyphase Merge Sort,333,3,0.00034190
+Polyphase Merge Sort,333,4,0.00035650
+Polyphase Merge Sort,333,5,0.00035140
+Polyphase Merge Sort,333,6,0.00037900
+Polyphase Merge Sort,333,7,0.00031770
+Polyphase Merge Sort,333,8,0.00035470
+Polyphase Merge Sort,333,9,0.00034260
+Polyphase Merge Sort,333,10,0.00035920
+Polyphase Merge Sort,333,11,0.00038950
+Polyphase Merge Sort,333,12,0.00033460
+Polyphase Merge Sort,333,13,0.00044390
+Polyphase Merge Sort,333,14,0.00095430
+Polyphase Merge Sort,333,15,0.00046830
+Polyphase Merge Sort,333,16,0.00074300
+Polyphase Merge Sort,333,17,0.00034430
+Polyphase Merge Sort,333,18,0.00033320
+Polyphase Merge Sort,333,19,0.00073630
+Polyphase Merge Sort,333,20,0.00034790
+Polyphase Merge Sort,333,21,0.00033290
+Polyphase Merge Sort,333,22,0.00034370
+Polyphase Merge Sort,333,23,0.00034610
+Polyphase Merge Sort,333,24,0.00070220
+Polyphase Merge Sort,333,25,0.00032650
+Polyphase Merge Sort,333,26,0.00053910
+Polyphase Merge Sort,333,27,0.00032170
+Polyphase Merge Sort,333,28,0.00029750
+Polyphase Merge Sort,333,29,0.00071610
+Polyphase Merge Sort,333,30,0.00032230
+Polyphase Merge Sort,333,31,0.00030920
+Polyphase Merge Sort,333,32,0.00027010
+Polyphase Merge Sort,333,33,0.00025190
+Polyphase Merge Sort,333,34,0.00034590
+Polyphase Merge Sort,333,35,0.00025400
+Polyphase Merge Sort,333,36,0.00052570
+Polyphase Merge Sort,333,37,0.00025860
+Polyphase Merge Sort,333,38,0.00024060
+Polyphase Merge Sort,333,39,0.00029990
+Polyphase Merge Sort,333,40,0.00036100
+Polyphase Merge Sort,333,41,0.00034150
+Polyphase Merge Sort,333,42,0.00031120
+Polyphase Merge Sort,333,43,0.00034330
+Polyphase Merge Sort,333,44,0.00037930
+Polyphase Merge Sort,333,45,0.00030330
+Polyphase Merge Sort,333,46,0.00033040
+Polyphase Merge Sort,333,47,0.00055430
+Polyphase Merge Sort,333,48,0.00033090
+Polyphase Merge Sort,333,49,0.00029670
+Polyphase Merge Sort,333,50,0.00032830
+Polyphase Merge Sort,333,51,0.00064300
+Polyphase Merge Sort,333,52,0.00059370
+Polyphase Merge Sort,333,53,0.00029940
+Polyphase Merge Sort,333,54,0.00030310
+Polyphase Merge Sort,333,55,0.00030910
+Polyphase Merge Sort,333,56,0.00055680
+Polyphase Merge Sort,333,57,0.00060640
+Polyphase Merge Sort,333,58,0.00187910
+Polyphase Merge Sort,333,59,0.00033880
+Polyphase Merge Sort,333,60,0.00031580
+Polyphase Merge Sort,333,61,0.00034130
+Polyphase Merge Sort,333,62,0.00054460
+Polyphase Merge Sort,333,63,0.00033910
+Polyphase Merge Sort,333,64,0.00064490
+Polyphase Merge Sort,333,65,0.00032110
+Polyphase Merge Sort,333,66,0.00031680
+Polyphase Merge Sort,333,67,0.00032110
+Polyphase Merge Sort,333,68,0.00035290
+Polyphase Merge Sort,333,69,0.00031130
+Polyphase Merge Sort,333,70,0.00031060
+Polyphase Merge Sort,333,71,0.00032090
+Polyphase Merge Sort,333,72,0.00034330
+Polyphase Merge Sort,333,73,0.00034380
+Polyphase Merge Sort,333,74,0.00033870
+Polyphase Merge Sort,333,75,0.00028480
+Polyphase Merge Sort,333,76,0.00033040
+Polyphase Merge Sort,333,77,0.00029450
+Polyphase Merge Sort,333,78,0.00036350
+Polyphase Merge Sort,333,79,0.00035020
+Polyphase Merge Sort,333,80,0.00029560
+Polyphase Merge Sort,333,81,0.00034200
+Polyphase Merge Sort,333,82,0.00050740
+Polyphase Merge Sort,333,83,0.00029480
+Polyphase Merge Sort,333,84,0.00035680
+Polyphase Merge Sort,333,85,0.00033220
+Polyphase Merge Sort,333,86,0.00031040
+Polyphase Merge Sort,333,87,0.00034720
+Polyphase Merge Sort,333,88,0.00036090
+Polyphase Merge Sort,333,89,0.00033060
+Polyphase Merge Sort,333,90,0.00040290
+Polyphase Merge Sort,333,91,0.00031670
+Polyphase Merge Sort,333,92,0.00031170
+Polyphase Merge Sort,333,93,0.00033560
+Polyphase Merge Sort,333,94,0.00031700
+Polyphase Merge Sort,333,95,0.00031020
+Polyphase Merge Sort,333,96,0.00032860
+Polyphase Merge Sort,333,97,0.00029990
+Polyphase Merge Sort,333,98,0.00030590
+Polyphase Merge Sort,333,99,0.00032310
+Polyphase Merge Sort,333,100,0.00029100
+Polyphase Merge Sort,333,101,0.00030100
+Polyphase Merge Sort,333,102,0.00032550
+Polyphase Merge Sort,333,103,0.00034480
+Polyphase Merge Sort,333,104,0.00031790
+Polyphase Merge Sort,333,105,0.00033990
+Polyphase Merge Sort,333,106,0.00031490
+Polyphase Merge Sort,333,107,0.00033480
+Polyphase Merge Sort,333,108,0.00034560
+Polyphase Merge Sort,333,109,0.00032850
+Polyphase Merge Sort,333,110,0.00032030
+Polyphase Merge Sort,333,111,0.00034920
+Polyphase Merge Sort,333,112,0.00038500
+Polyphase Merge Sort,333,113,0.00035920
+Polyphase Merge Sort,333,114,0.00039300
+Polyphase Merge Sort,333,115,0.00039260
+Polyphase Merge Sort,333,116,0.00036060
+Polyphase Merge Sort,333,117,0.00037240
+Polyphase Merge Sort,333,118,0.00051580
+Polyphase Merge Sort,333,119,0.00041250
+Polyphase Merge Sort,333,120,0.00047690
+Polyphase Merge Sort,333,121,0.00035450
+Polyphase Merge Sort,333,122,0.00052020
+Polyphase Merge Sort,333,123,0.00037390
+Polyphase Merge Sort,333,124,0.00044940
+Polyphase Merge Sort,333,125,0.00040110
+Polyphase Merge Sort,333,126,0.00034550
+Polyphase Merge Sort,333,127,0.00037930
+Polyphase Merge Sort,333,128,0.00040970
+Polyphase Merge Sort,333,129,0.00036020
+Polyphase Merge Sort,333,130,0.00036520
+Polyphase Merge Sort,333,131,0.00034700
+Polyphase Merge Sort,333,132,0.00036340
+Polyphase Merge Sort,333,133,0.00035240
+Polyphase Merge Sort,333,134,0.00037680
+Polyphase Merge Sort,333,135,0.00045060
+Polyphase Merge Sort,333,136,0.00039640
+Polyphase Merge Sort,333,137,0.00034730
+Polyphase Merge Sort,333,138,0.00039260
+Polyphase Merge Sort,333,139,0.00036330
+Polyphase Merge Sort,333,140,0.00035720
+Polyphase Merge Sort,333,141,0.00041470
+Polyphase Merge Sort,333,142,0.00036640
+Polyphase Merge Sort,333,143,0.00032070
+Polyphase Merge Sort,333,144,0.00038680
+Polyphase Merge Sort,333,145,0.00034760
+Polyphase Merge Sort,333,146,0.00031040
+Polyphase Merge Sort,333,147,0.00034690
+Polyphase Merge Sort,333,148,0.00037380
+Polyphase Merge Sort,333,149,0.00036020
+Polyphase Merge Sort,333,150,0.00037790
+Polyphase Merge Sort,333,151,0.00035040
+Polyphase Merge Sort,333,152,0.00036010
+Polyphase Merge Sort,333,153,0.00042980
+Polyphase Merge Sort,333,154,0.00039110
+Polyphase Merge Sort,333,155,0.00039360
+Polyphase Merge Sort,333,156,0.00045830
+Polyphase Merge Sort,333,157,0.00041340
+Polyphase Merge Sort,333,158,0.00043230
+Polyphase Merge Sort,333,159,0.00052270
+Polyphase Merge Sort,333,160,0.00152140
+Polyphase Merge Sort,333,161,0.00044160
+Polyphase Merge Sort,333,162,0.00037730
+Polyphase Merge Sort,333,163,0.00047760
+Polyphase Merge Sort,333,164,0.00056590
+Polyphase Merge Sort,333,165,0.00049340
+Polyphase Merge Sort,333,166,0.00054490
+Polyphase Merge Sort,333,167,0.00173220
+Polyphase Merge Sort,333,168,0.00052760
+Polyphase Merge Sort,333,169,0.00035170
+Polyphase Merge Sort,333,170,0.00038470
+Polyphase Merge Sort,333,171,0.00035250
+Polyphase Merge Sort,333,172,0.00038310
+Polyphase Merge Sort,333,173,0.00124510
+Polyphase Merge Sort,333,174,0.00047330
+Polyphase Merge Sort,333,175,0.00060470
+Polyphase Merge Sort,333,176,0.00037170
+Polyphase Merge Sort,333,177,0.00085220
+Polyphase Merge Sort,333,178,0.00039540
+Polyphase Merge Sort,333,179,0.00039870
+Polyphase Merge Sort,333,180,0.00043430
+Polyphase Merge Sort,333,181,0.00037790
+Polyphase Merge Sort,333,182,0.00034510
+Polyphase Merge Sort,333,183,0.00030620
+Polyphase Merge Sort,333,184,0.00169870
+Polyphase Merge Sort,333,185,0.00033980
+Polyphase Merge Sort,333,186,0.00036170
+Polyphase Merge Sort,333,187,0.00049970
+Polyphase Merge Sort,333,188,0.00037560
+Polyphase Merge Sort,333,189,0.00034800
+Polyphase Merge Sort,333,190,0.00032210
+Polyphase Merge Sort,333,191,0.00035200
+Polyphase Merge Sort,333,192,0.00202310
+Polyphase Merge Sort,333,193,0.00034590
+Polyphase Merge Sort,333,194,0.00029750
+Polyphase Merge Sort,333,195,0.00042060
+Polyphase Merge Sort,333,196,0.00040010
+Polyphase Merge Sort,333,197,0.00033360
+Polyphase Merge Sort,333,198,0.00030530
+Polyphase Merge Sort,333,199,0.00038920
+Polyphase Merge Sort,333,200,0.00047850
+Polyphase Merge Sort,333,201,0.00108830
+Polyphase Merge Sort,333,202,0.00042400
+Polyphase Merge Sort,333,203,0.00039930
+Polyphase Merge Sort,333,204,0.00036730
+Polyphase Merge Sort,333,205,0.00056650
+Polyphase Merge Sort,333,206,0.00095910
+Polyphase Merge Sort,333,207,0.00041220
+Polyphase Merge Sort,333,208,0.00041300
+Polyphase Merge Sort,333,209,0.00056160
+Polyphase Merge Sort,333,210,0.00055830
+Polyphase Merge Sort,333,211,0.00072120
+Polyphase Merge Sort,333,212,0.00053330
+Polyphase Merge Sort,333,213,0.00057440
+Polyphase Merge Sort,333,214,0.00047920
+Polyphase Merge Sort,333,215,0.00040460
+Polyphase Merge Sort,333,216,0.00044140
+Polyphase Merge Sort,333,217,0.00043830
+Polyphase Merge Sort,333,218,0.00128050
+Polyphase Merge Sort,333,219,0.00045150
+Polyphase Merge Sort,333,220,0.00041640
+Polyphase Merge Sort,333,221,0.00046040
+Polyphase Merge Sort,333,222,0.00035540
+Polyphase Merge Sort,333,223,0.00033450
+Polyphase Merge Sort,333,224,0.00034840
+Polyphase Merge Sort,333,225,0.00042590
+Polyphase Merge Sort,333,226,0.00085730
+Polyphase Merge Sort,333,227,0.00052410
+Polyphase Merge Sort,333,228,0.00049720
+Polyphase Merge Sort,333,229,0.00056140
+Polyphase Merge Sort,333,230,0.00048440
+Polyphase Merge Sort,333,231,0.00047730
+Polyphase Merge Sort,333,232,0.00046600
+Polyphase Merge Sort,333,233,0.00051780
+Polyphase Merge Sort,333,234,0.00174860
+Polyphase Merge Sort,333,235,0.00054130
+Polyphase Merge Sort,333,236,0.00051240
+Polyphase Merge Sort,333,237,0.00051450
+Polyphase Merge Sort,333,238,0.00195720
+Polyphase Merge Sort,333,239,0.00028120
+Polyphase Merge Sort,333,240,0.00026600
+Polyphase Merge Sort,333,241,0.00037040
+Polyphase Merge Sort,333,242,0.00034440
+Polyphase Merge Sort,333,243,0.00041300
+Polyphase Merge Sort,333,244,0.00037490
+Polyphase Merge Sort,333,245,0.00047550
+Polyphase Merge Sort,333,246,0.00040970
+Polyphase Merge Sort,333,247,0.00039180
+Polyphase Merge Sort,333,248,0.00399930
+Polyphase Merge Sort,333,249,0.00040960
+Polyphase Merge Sort,333,250,0.00060690
+Polyphase Merge Sort,333,251,0.00038740
+Polyphase Merge Sort,333,252,0.00061160
+Polyphase Merge Sort,333,253,0.00038440
+Polyphase Merge Sort,333,254,0.00051750
+Polyphase Merge Sort,333,255,0.00045560
+Polyphase Merge Sort,333,256,0.00052170
+Polyphase Merge Sort,333,257,0.00040410
+Polyphase Merge Sort,333,258,0.00059250
+Polyphase Merge Sort,333,259,0.00040230
+Polyphase Merge Sort,333,260,0.00109320
+Polyphase Merge Sort,333,261,0.00038260
+Polyphase Merge Sort,333,262,0.00028620
+Polyphase Merge Sort,333,263,0.00043750
+Polyphase Merge Sort,333,264,0.00033330
+Polyphase Merge Sort,333,265,0.00031040
+Polyphase Merge Sort,333,266,0.00044710
+Polyphase Merge Sort,333,267,0.00046310
+Polyphase Merge Sort,333,268,0.00042230
+Polyphase Merge Sort,333,269,0.00045460
+Polyphase Merge Sort,333,270,0.00063260
+Polyphase Merge Sort,333,271,0.00097700
+Polyphase Merge Sort,333,272,0.00057230
+Polyphase Merge Sort,333,273,0.00052820
+Polyphase Merge Sort,333,274,0.00049530
+Polyphase Merge Sort,333,275,0.00054400
+Polyphase Merge Sort,333,276,0.00051780
+Polyphase Merge Sort,333,277,0.00033320
+Polyphase Merge Sort,333,278,0.00056890
+Polyphase Merge Sort,333,279,0.00037470
+Polyphase Merge Sort,333,280,0.00053490
+Polyphase Merge Sort,333,281,0.00057410
+Polyphase Merge Sort,333,282,0.00142100
+Polyphase Merge Sort,333,283,0.00050350
+Polyphase Merge Sort,333,284,0.00057680
+Polyphase Merge Sort,333,285,0.00049770
+Polyphase Merge Sort,333,286,0.00135460
+Polyphase Merge Sort,333,287,0.00047550
+Polyphase Merge Sort,333,288,0.00041370
+Polyphase Merge Sort,333,289,0.00030990
+Polyphase Merge Sort,333,290,0.00034710
+Polyphase Merge Sort,333,291,0.00069950
+Polyphase Merge Sort,333,292,0.00039010
+Polyphase Merge Sort,333,293,0.00036810
+Polyphase Merge Sort,333,294,0.00033270
+Polyphase Merge Sort,333,295,0.00039100
+Polyphase Merge Sort,333,296,0.00031040
+Polyphase Merge Sort,333,297,0.00033770
+Polyphase Merge Sort,333,298,0.00053730
+Polyphase Merge Sort,333,299,0.00033850
+Polyphase Merge Sort,333,300,0.00033500
+Polyphase Merge Sort,333,301,0.00037230
+Polyphase Merge Sort,333,302,0.00033430
+Polyphase Merge Sort,333,303,0.00031850
+Polyphase Merge Sort,333,304,0.00035150
+Polyphase Merge Sort,333,305,0.00034150
+Polyphase Merge Sort,333,306,0.00035220
+Polyphase Merge Sort,333,307,0.00028750
+Polyphase Merge Sort,333,308,0.00031220
+Polyphase Merge Sort,333,309,0.00030370
+Polyphase Merge Sort,333,310,0.00028530
+Polyphase Merge Sort,333,311,0.00032280
+Polyphase Merge Sort,333,312,0.00031580
+Polyphase Merge Sort,333,313,0.00030030
+Polyphase Merge Sort,333,314,0.00031740
+Polyphase Merge Sort,333,315,0.00033490
+Polyphase Merge Sort,333,316,0.00029830
+Polyphase Merge Sort,333,317,0.00031160
+Polyphase Merge Sort,333,318,0.00033850
+Polyphase Merge Sort,333,319,0.00029380
+Polyphase Merge Sort,333,320,0.00034080
+Polyphase Merge Sort,333,321,0.00027910
+Polyphase Merge Sort,333,322,0.00033650
+Polyphase Merge Sort,333,323,0.00031440
+Polyphase Merge Sort,333,324,0.00027280
+Polyphase Merge Sort,333,325,0.00036470
+Polyphase Merge Sort,333,326,0.00028600
+Polyphase Merge Sort,333,327,0.00031770
+Polyphase Merge Sort,333,328,0.00033110
+Polyphase Merge Sort,333,329,0.00028790
+Polyphase Merge Sort,333,330,0.00031240
+Polyphase Merge Sort,333,331,0.00023840
+Polyphase Merge Sort,333,332,0.00033450
+Polyphase Merge Sort,333,333,0.00025710
+Polyphase Merge Sort,333,334,0.00031570
+Polyphase Merge Sort,333,335,0.00034280
+Polyphase Merge Sort,333,336,0.00024120
+Polyphase Merge Sort,333,337,0.00039150
+Polyphase Merge Sort,333,338,0.00038570
+Polyphase Merge Sort,333,339,0.00025260
+Polyphase Merge Sort,333,340,0.00034900
+Polyphase Merge Sort,333,341,0.00036160
+Polyphase Merge Sort,333,342,0.00025280
+Polyphase Merge Sort,333,343,0.00036850
+Polyphase Merge Sort,333,344,0.00038530
+Polyphase Merge Sort,333,345,0.00027170
+Polyphase Merge Sort,333,346,0.00026520
+Polyphase Merge Sort,333,347,0.00036980
+Polyphase Merge Sort,333,348,0.00038140
+Polyphase Merge Sort,333,349,0.00025210
+Polyphase Merge Sort,333,350,0.00034020
+Polyphase Merge Sort,333,351,0.00037880
+Polyphase Merge Sort,333,352,0.00024560
+Polyphase Merge Sort,333,353,0.00037380
+Polyphase Merge Sort,333,354,0.00040360
+Polyphase Merge Sort,333,355,0.00026660
+Polyphase Merge Sort,333,356,0.00038410
+Polyphase Merge Sort,333,357,0.00032700
+Polyphase Merge Sort,333,358,0.00044370
+Polyphase Merge Sort,333,359,0.00036900
+Polyphase Merge Sort,333,360,0.00029210
+Polyphase Merge Sort,333,361,0.00035970
+Polyphase Merge Sort,333,362,0.00038310
+Polyphase Merge Sort,333,363,0.00031590
+Polyphase Merge Sort,333,364,0.00044840
+Polyphase Merge Sort,333,365,0.00034500
+Polyphase Merge Sort,333,366,0.00029500
+Polyphase Merge Sort,333,367,0.00039070
+Polyphase Merge Sort,333,368,0.00037380
+Polyphase Merge Sort,333,369,0.00029790
+Polyphase Merge Sort,333,370,0.00047840
+Polyphase Merge Sort,333,371,0.00030810
+Polyphase Merge Sort,333,372,0.00036310
+Polyphase Merge Sort,333,373,0.00024750
+Polyphase Merge Sort,333,374,0.00031220
+Polyphase Merge Sort,333,375,0.00033050
+Polyphase Merge Sort,333,376,0.00022610
+Polyphase Merge Sort,333,377,0.00030990
+Polyphase Merge Sort,333,378,0.00023470
+Polyphase Merge Sort,333,379,0.00033750
+Polyphase Merge Sort,333,380,0.00029910
+Polyphase Merge Sort,333,381,0.00022630
+Polyphase Merge Sort,333,382,0.00036310
+Polyphase Merge Sort,333,383,0.00029920
+Polyphase Merge Sort,333,384,0.00022060
+Polyphase Merge Sort,333,385,0.00035530
+Polyphase Merge Sort,333,386,0.00030300
+Polyphase Merge Sort,333,387,0.00023880
+Polyphase Merge Sort,333,388,0.00032550
+Polyphase Merge Sort,333,389,0.00029170
+Polyphase Merge Sort,333,390,0.00023410
+Polyphase Merge Sort,333,391,0.00032060
+Polyphase Merge Sort,333,392,0.00028430
+Polyphase Merge Sort,333,393,0.00022100
+Polyphase Merge Sort,333,394,0.00034660
+Polyphase Merge Sort,333,395,0.00029650
+Polyphase Merge Sort,333,396,0.00022490
+Polyphase Merge Sort,333,397,0.00022910
+Polyphase Merge Sort,333,398,0.00030840
+Polyphase Merge Sort,333,399,0.00034200
+Polyphase Merge Sort,333,400,0.00022180
+Polyphase Merge Sort,333,401,0.00037400
+Polyphase Merge Sort,333,402,0.00035340
+Polyphase Merge Sort,333,403,0.00022640
+Polyphase Merge Sort,333,404,0.00035040
+Polyphase Merge Sort,333,405,0.00023500
+Polyphase Merge Sort,333,406,0.00073540
+Polyphase Merge Sort,333,407,0.00033350
+Polyphase Merge Sort,333,408,0.00028810
+Polyphase Merge Sort,333,409,0.00032810
+Polyphase Merge Sort,333,410,0.00041360
+Polyphase Merge Sort,333,411,0.00025130
+Polyphase Merge Sort,333,412,0.00041630
+Polyphase Merge Sort,333,413,0.00026260
+Polyphase Merge Sort,333,414,0.00055700
+Polyphase Merge Sort,333,415,0.00033160
+Polyphase Merge Sort,333,416,0.00029880
+Polyphase Merge Sort,333,417,0.00039170
+Polyphase Merge Sort,333,418,0.00042180
+Polyphase Merge Sort,333,419,0.00037160
+Polyphase Merge Sort,333,420,0.00042640
+Polyphase Merge Sort,333,421,0.00052540
+Polyphase Merge Sort,333,422,0.00030560
+Polyphase Merge Sort,333,423,0.00035130
+Polyphase Merge Sort,333,424,0.00038160
+Polyphase Merge Sort,333,425,0.00049970
+Polyphase Merge Sort,333,426,0.00046790
+Polyphase Merge Sort,333,427,0.00054710
+Polyphase Merge Sort,333,428,0.00028430
+Polyphase Merge Sort,333,429,0.00044620
+Polyphase Merge Sort,333,430,0.00044070
+Polyphase Merge Sort,333,431,0.00046660
+Polyphase Merge Sort,333,432,0.00027310
+Polyphase Merge Sort,333,433,0.00049840
+Polyphase Merge Sort,333,434,0.00042470
+Polyphase Merge Sort,333,435,0.00025560
+Polyphase Merge Sort,333,436,0.00040120
+Polyphase Merge Sort,333,437,0.00024870
+Polyphase Merge Sort,333,438,0.00024190
+Polyphase Merge Sort,333,439,0.00034560
+Polyphase Merge Sort,333,440,0.00033500
+Polyphase Merge Sort,333,441,0.00023190
+Polyphase Merge Sort,333,442,0.00042650
+Polyphase Merge Sort,333,443,0.00035810
+Polyphase Merge Sort,333,444,0.00033560
+Polyphase Merge Sort,333,445,0.00028770
+Polyphase Merge Sort,333,446,0.00034230
+Polyphase Merge Sort,333,447,0.00022850
+Polyphase Merge Sort,333,448,0.00048560
+Polyphase Merge Sort,333,449,0.00026870
+Polyphase Merge Sort,333,450,0.00027780
+Polyphase Merge Sort,333,451,0.00035640
+Polyphase Merge Sort,333,452,0.00031100
+Polyphase Merge Sort,333,453,0.00022180
+Polyphase Merge Sort,333,454,0.00033130
+Polyphase Merge Sort,333,455,0.00031820
+Polyphase Merge Sort,333,456,0.00023830
+Polyphase Merge Sort,333,457,0.00028830
+Polyphase Merge Sort,333,458,0.00031910
+Polyphase Merge Sort,333,459,0.00028390
+Polyphase Merge Sort,333,460,0.00038540
+Polyphase Merge Sort,333,461,0.00036370
+Polyphase Merge Sort,333,462,0.00024320
+Polyphase Merge Sort,333,463,0.00045580
+Polyphase Merge Sort,333,464,0.00038550
+Polyphase Merge Sort,333,465,0.00026240
+Polyphase Merge Sort,333,466,0.00046660
+Polyphase Merge Sort,333,467,0.00032500
+Polyphase Merge Sort,333,468,0.00033470
+Polyphase Merge Sort,333,469,0.00041730
+Polyphase Merge Sort,333,470,0.00033930
+Polyphase Merge Sort,333,471,0.00030760
+Polyphase Merge Sort,333,472,0.00043760
+Polyphase Merge Sort,333,473,0.00031790
+Polyphase Merge Sort,333,474,0.00046740
+Polyphase Merge Sort,333,475,0.00038800
+Polyphase Merge Sort,333,476,0.00038990
+Polyphase Merge Sort,333,477,0.00031090
+Polyphase Merge Sort,333,478,0.00027700
+Polyphase Merge Sort,333,479,0.00030740
+Polyphase Merge Sort,333,480,0.00030350
+Polyphase Merge Sort,333,481,0.00028250
+Polyphase Merge Sort,333,482,0.00030160
+Polyphase Merge Sort,333,483,0.00030000
+Polyphase Merge Sort,333,484,0.00027330
+Polyphase Merge Sort,333,485,0.00032140
+Polyphase Merge Sort,333,486,0.00030940
+Polyphase Merge Sort,333,487,0.00027790
+Polyphase Merge Sort,333,488,0.00030790
+Polyphase Merge Sort,333,489,0.00030840
+Polyphase Merge Sort,333,490,0.00027160
+Polyphase Merge Sort,333,491,0.00030760
+Polyphase Merge Sort,333,492,0.00031770
+Polyphase Merge Sort,333,493,0.00028100
+Polyphase Merge Sort,333,494,0.00031760
+Polyphase Merge Sort,333,495,0.00031460
+Polyphase Merge Sort,333,496,0.00027530
+Polyphase Merge Sort,333,497,0.00040840
+Polyphase Merge Sort,333,498,0.00029250
+Polyphase Merge Sort,333,499,0.00032850
+Polyphase Merge Sort,333,500,0.00032130
+Postman Sort,333,1,0.00077850
+Postman Sort,333,2,0.00062630
+Postman Sort,333,3,0.00103240
+Postman Sort,333,4,0.00078440
+Postman Sort,333,5,0.00074930
+Postman Sort,333,6,0.00061920
+Postman Sort,333,7,0.00086430
+Postman Sort,333,8,0.00059180
+Postman Sort,333,9,0.00077660
+Postman Sort,333,10,0.00083150
+Postman Sort,333,11,0.00059850
+Postman Sort,333,12,0.00082440
+Postman Sort,333,13,0.00074770
+Postman Sort,333,14,0.00060030
+Postman Sort,333,15,0.00074890
+Postman Sort,333,16,0.00076530
+Postman Sort,333,17,0.00088370
+Postman Sort,333,18,0.00063850
+Postman Sort,333,19,0.00063230
+Postman Sort,333,20,0.00076670
+Postman Sort,333,21,0.00064870
+Postman Sort,333,22,0.00070230
+Postman Sort,333,23,0.00069610
+Postman Sort,333,24,0.00066030
+Postman Sort,333,25,0.00083920
+Postman Sort,333,26,0.00076070
+Postman Sort,333,27,0.00072000
+Postman Sort,333,28,0.00065610
+Postman Sort,333,29,0.00077180
+Postman Sort,333,30,0.00074290
+Postman Sort,333,31,0.00071840
+Postman Sort,333,32,0.00060290
+Postman Sort,333,33,0.00075300
+Postman Sort,333,34,0.00074750
+Postman Sort,333,35,0.00070670
+Postman Sort,333,36,0.00058980
+Postman Sort,333,37,0.00075090
+Postman Sort,333,38,0.00076730
+Postman Sort,333,39,0.00061360
+Postman Sort,333,40,0.00069730
+Postman Sort,333,41,0.00059260
+Postman Sort,333,42,0.00075420
+Postman Sort,333,43,0.00070950
+Postman Sort,333,44,0.00068240
+Postman Sort,333,45,0.00059520
+Postman Sort,333,46,0.00074290
+Postman Sort,333,47,0.00073020
+Postman Sort,333,48,0.00068730
+Postman Sort,333,49,0.00060090
+Postman Sort,333,50,0.00075000
+Postman Sort,333,51,0.00072980
+Postman Sort,333,52,0.00068460
+Postman Sort,333,53,0.00058970
+Postman Sort,333,54,0.00074950
+Postman Sort,333,55,0.00074160
+Postman Sort,333,56,0.00065540
+Postman Sort,333,57,0.00059220
+Postman Sort,333,58,0.00061900
+Postman Sort,333,59,0.00086220
+Postman Sort,333,60,0.00076080
+Postman Sort,333,61,0.00076210
+Postman Sort,333,62,0.00064790
+Postman Sort,333,63,0.00076000
+Postman Sort,333,64,0.00078490
+Postman Sort,333,65,0.00085340
+Postman Sort,333,66,0.00065470
+Postman Sort,333,67,0.00074990
+Postman Sort,333,68,0.00076390
+Postman Sort,333,69,0.00080400
+Postman Sort,333,70,0.00065990
+Postman Sort,333,71,0.00076480
+Postman Sort,333,72,0.00077850
+Postman Sort,333,73,0.00067050
+Postman Sort,333,74,0.00092240
+Postman Sort,333,75,0.00065910
+Postman Sort,333,76,0.00060410
+Postman Sort,333,77,0.00077540
+Postman Sort,333,78,0.00083320
+Postman Sort,333,79,0.00059990
+Postman Sort,333,80,0.00065270
+Postman Sort,333,81,0.00076970
+Postman Sort,333,82,0.00082270
+Postman Sort,333,83,0.00062500
+Postman Sort,333,84,0.00066980
+Postman Sort,333,85,0.00074790
+Postman Sort,333,86,0.00060600
+Postman Sort,333,87,0.00068260
+Postman Sort,333,88,0.00085420
+Postman Sort,333,89,0.00073130
+Postman Sort,333,90,0.00059490
+Postman Sort,333,91,0.00069490
+Postman Sort,333,92,0.00074730
+Postman Sort,333,93,0.00077220
+Postman Sort,333,94,0.00058190
+Postman Sort,333,95,0.00087970
+Postman Sort,333,96,0.00074270
+Postman Sort,333,97,0.00073440
+Postman Sort,333,98,0.00058160
+Postman Sort,333,99,0.00075320
+Postman Sort,333,100,0.00073640
+Postman Sort,333,101,0.00061210
+Postman Sort,333,102,0.00078780
+Postman Sort,333,103,0.00075460
+Postman Sort,333,104,0.00063310
+Postman Sort,333,105,0.00078300
+Postman Sort,333,106,0.00132190
+Postman Sort,333,107,0.00068190
+Postman Sort,333,108,0.00082640
+Postman Sort,333,109,0.00068630
+Postman Sort,333,110,0.00082510
+Postman Sort,333,111,0.00072970
+Postman Sort,333,112,0.00080470
+Postman Sort,333,113,0.00068270
+Postman Sort,333,114,0.00080020
+Postman Sort,333,115,0.00076520
+Postman Sort,333,116,0.00067510
+Postman Sort,333,117,0.00076220
+Postman Sort,333,118,0.00077950
+Postman Sort,333,119,0.00066940
+Postman Sort,333,120,0.00077900
+Postman Sort,333,121,0.00084570
+Postman Sort,333,122,0.00066490
+Postman Sort,333,123,0.00073090
+Postman Sort,333,124,0.00078860
+Postman Sort,333,125,0.00067590
+Postman Sort,333,126,0.00087580
+Postman Sort,333,127,0.00075850
+Postman Sort,333,128,0.00063270
+Postman Sort,333,129,0.00080420
+Postman Sort,333,130,0.00091230
+Postman Sort,333,131,0.00071690
+Postman Sort,333,132,0.00061450
+Postman Sort,333,133,0.00077490
+Postman Sort,333,134,0.00072940
+Postman Sort,333,135,0.00060990
+Postman Sort,333,136,0.00083770
+Postman Sort,333,137,0.00075170
+Postman Sort,333,138,0.00073890
+Postman Sort,333,139,0.00060460
+Postman Sort,333,140,0.00076640
+Postman Sort,333,141,0.00076440
+Postman Sort,333,142,0.00059290
+Postman Sort,333,143,0.00080410
+Postman Sort,333,144,0.00059070
+Postman Sort,333,145,0.00078150
+Postman Sort,333,146,0.00074100
+Postman Sort,333,147,0.00079500
+Postman Sort,333,148,0.00059110
+Postman Sort,333,149,0.00074770
+Postman Sort,333,150,0.00087170
+Postman Sort,333,151,0.00076480
+Postman Sort,333,152,0.00059440
+Postman Sort,333,153,0.00917950
+Postman Sort,333,154,0.00086830
+Postman Sort,333,155,0.00079280
+Postman Sort,333,156,0.00085060
+Postman Sort,333,157,0.00065300
+Postman Sort,333,158,0.00072130
+Postman Sort,333,159,0.00084250
+Postman Sort,333,160,0.00064620
+Postman Sort,333,161,0.00073670
+Postman Sort,333,162,0.00078340
+Postman Sort,333,163,0.00066340
+Postman Sort,333,164,0.00075620
+Postman Sort,333,165,0.00077670
+Postman Sort,333,166,0.00065660
+Postman Sort,333,167,0.00086180
+Postman Sort,333,168,0.00078260
+Postman Sort,333,169,0.00079760
+Postman Sort,333,170,0.00071360
+Postman Sort,333,171,0.00067450
+Postman Sort,333,172,0.00072000
+Postman Sort,333,173,0.00075440
+Postman Sort,333,174,0.03612110
+Postman Sort,333,175,0.00092190
+Postman Sort,333,176,0.00075450
+Postman Sort,333,177,0.00074110
+Postman Sort,333,178,0.00072960
+Postman Sort,333,179,0.00206410
+Postman Sort,333,180,0.00079770
+Postman Sort,333,181,0.00074810
+Postman Sort,333,182,0.00092160
+Postman Sort,333,183,0.00077720
+Postman Sort,333,184,0.00083850
+Postman Sort,333,185,0.00075430
+Postman Sort,333,186,0.00075040
+Postman Sort,333,187,0.00072150
+Postman Sort,333,188,0.00073040
+Postman Sort,333,189,0.00073300
+Postman Sort,333,190,0.00066850
+Postman Sort,333,191,0.00073430
+Postman Sort,333,192,0.00072650
+Postman Sort,333,193,0.00076660
+Postman Sort,333,194,0.00100040
+Postman Sort,333,195,0.00104790
+Postman Sort,333,196,0.00062770
+Postman Sort,333,197,0.00072780
+Postman Sort,333,198,0.00061670
+Postman Sort,333,199,0.00059560
+Postman Sort,333,200,0.00060080
+Postman Sort,333,201,0.00058160
+Postman Sort,333,202,0.00071730
+Postman Sort,333,203,0.00061240
+Postman Sort,333,204,0.00062020
+Postman Sort,333,205,0.00072580
+Postman Sort,333,206,0.00130910
+Postman Sort,333,207,0.00059780
+Postman Sort,333,208,0.00072970
+Postman Sort,333,209,0.00087960
+Postman Sort,333,210,0.00071990
+Postman Sort,333,211,0.00145040
+Postman Sort,333,212,0.00078650
+Postman Sort,333,213,0.00077040
+Postman Sort,333,214,0.00067680
+Postman Sort,333,215,0.02409590
+Postman Sort,333,216,0.00081700
+Postman Sort,333,217,0.00060520
+Postman Sort,333,218,0.00065640
+Postman Sort,333,219,0.00108000
+Postman Sort,333,220,0.00065770
+Postman Sort,333,221,0.00078820
+Postman Sort,333,222,0.00065220
+Postman Sort,333,223,0.00066520
+Postman Sort,333,224,0.00076900
+Postman Sort,333,225,0.00066480
+Postman Sort,333,226,0.00083310
+Postman Sort,333,227,0.00067890
+Postman Sort,333,228,0.00065870
+Postman Sort,333,229,0.00065860
+Postman Sort,333,230,0.00080380
+Postman Sort,333,231,0.00121850
+Postman Sort,333,232,0.00077040
+Postman Sort,333,233,0.00083830
+Postman Sort,333,234,0.00075120
+Postman Sort,333,235,0.00092380
+Postman Sort,333,236,0.00076490
+Postman Sort,333,237,0.00077850
+Postman Sort,333,238,0.00077440
+Postman Sort,333,239,0.00081950
+Postman Sort,333,240,0.00083250
+Postman Sort,333,241,0.00076140
+Postman Sort,333,242,0.00072180
+Postman Sort,333,243,0.00109190
+Postman Sort,333,244,0.01084080
+Postman Sort,333,245,0.00081530
+Postman Sort,333,246,0.00086670
+Postman Sort,333,247,0.00063680
+Postman Sort,333,248,0.00077010
+Postman Sort,333,249,0.00119780
+Postman Sort,333,250,0.00081470
+Postman Sort,333,251,0.00091040
+Postman Sort,333,252,0.00085910
+Postman Sort,333,253,0.00098700
+Postman Sort,333,254,0.00086240
+Postman Sort,333,255,0.00791360
+Postman Sort,333,256,0.00094230
+Postman Sort,333,257,0.00077310
+Postman Sort,333,258,0.00077690
+Postman Sort,333,259,0.00064670
+Postman Sort,333,260,0.00064100
+Postman Sort,333,261,0.00065400
+Postman Sort,333,262,0.00079080
+Postman Sort,333,263,0.00103490
+Postman Sort,333,264,0.00065310
+Postman Sort,333,265,0.00083420
+Postman Sort,333,266,0.00092510
+Postman Sort,333,267,0.00065050
+Postman Sort,333,268,0.00077650
+Postman Sort,333,269,0.00065400
+Postman Sort,333,270,0.00089350
+Postman Sort,333,271,0.00441530
+Postman Sort,333,272,0.00066930
+Postman Sort,333,273,0.00363800
+Postman Sort,333,274,0.00064510
+Postman Sort,333,275,0.00070900
+Postman Sort,333,276,0.00081240
+Postman Sort,333,277,0.00060300
+Postman Sort,333,278,0.00074720
+Postman Sort,333,279,0.00076070
+Postman Sort,333,280,0.00087600
+Postman Sort,333,281,0.00243370
+Postman Sort,333,282,0.00079130
+Postman Sort,333,283,0.00060940
+Postman Sort,333,284,0.00096230
+Postman Sort,333,285,0.00061820
+Postman Sort,333,286,0.00078630
+Postman Sort,333,287,0.00061420
+Postman Sort,333,288,0.00079950
+Postman Sort,333,289,0.00151660
+Postman Sort,333,290,0.00060210
+Postman Sort,333,291,0.00080930
+Postman Sort,333,292,0.00111520
+Postman Sort,333,293,0.00123860
+Postman Sort,333,294,0.00087030
+Postman Sort,333,295,0.00091630
+Postman Sort,333,296,0.00085510
+Postman Sort,333,297,0.00269130
+Postman Sort,333,298,0.00066730
+Postman Sort,333,299,0.00078190
+Postman Sort,333,300,0.01246090
+Postman Sort,333,301,0.00078580
+Postman Sort,333,302,0.00084990
+Postman Sort,333,303,0.00078820
+Postman Sort,333,304,0.00114340
+Postman Sort,333,305,0.00659730
+Postman Sort,333,306,0.00073580
+Postman Sort,333,307,0.00094460
+Postman Sort,333,308,0.00078190
+Postman Sort,333,309,0.00102400
+Postman Sort,333,310,0.00083120
+Postman Sort,333,311,0.00089450
+Postman Sort,333,312,0.00097220
+Postman Sort,333,313,0.00081280
+Postman Sort,333,314,0.00084510
+Postman Sort,333,315,0.00711350
+Postman Sort,333,316,0.00106340
+Postman Sort,333,317,0.00081390
+Postman Sort,333,318,0.01810130
+Postman Sort,333,319,0.00106950
+Postman Sort,333,320,0.00108610
+Postman Sort,333,321,0.00061850
+Postman Sort,333,322,0.00062810
+Postman Sort,333,323,0.00061320
+Postman Sort,333,324,0.00080520
+Postman Sort,333,325,0.00062020
+Postman Sort,333,326,0.00114740
+Postman Sort,333,327,0.00061550
+Postman Sort,333,328,0.00060490
+Postman Sort,333,329,0.00082450
+Postman Sort,333,330,0.01459890
+Postman Sort,333,331,0.00075580
+Postman Sort,333,332,0.00311870
+Postman Sort,333,333,0.00075440
+Postman Sort,333,334,0.00084710
+Postman Sort,333,335,0.00079470
+Postman Sort,333,336,0.00075270
+Postman Sort,333,337,0.00069640
+Postman Sort,333,338,0.00085850
+Postman Sort,333,339,0.00077880
+Postman Sort,333,340,0.00082360
+Postman Sort,333,341,0.00083540
+Postman Sort,333,342,0.00082550
+Postman Sort,333,343,0.00311900
+Postman Sort,333,344,0.00072090
+Postman Sort,333,345,0.00071330
+Postman Sort,333,346,0.00189040
+Postman Sort,333,347,0.00076160
+Postman Sort,333,348,0.00065480
+Postman Sort,333,349,0.00085500
+Postman Sort,333,350,0.00081510
+Postman Sort,333,351,0.00070490
+Postman Sort,333,352,0.00086510
+Postman Sort,333,353,0.01788250
+Postman Sort,333,354,0.00133660
+Postman Sort,333,355,0.00068320
+Postman Sort,333,356,0.00172750
+Postman Sort,333,357,0.00078490
+Postman Sort,333,358,0.00079170
+Postman Sort,333,359,0.00075160
+Postman Sort,333,360,0.00082610
+Postman Sort,333,361,0.00605620
+Postman Sort,333,362,0.00075890
+Postman Sort,333,363,0.00075500
+Postman Sort,333,364,0.00080000
+Postman Sort,333,365,0.00069020
+Postman Sort,333,366,0.00078380
+Postman Sort,333,367,0.00081550
+Postman Sort,333,368,0.00086570
+Postman Sort,333,369,0.00086660
+Postman Sort,333,370,0.00091480
+Postman Sort,333,371,0.00082740
+Postman Sort,333,372,0.00060440
+Postman Sort,333,373,0.00066170
+Postman Sort,333,374,0.00077670
+Postman Sort,333,375,0.00074530
+Postman Sort,333,376,0.00067690
+Postman Sort,333,377,0.00078960
+Postman Sort,333,378,0.00125490
+Postman Sort,333,379,0.00068360
+Postman Sort,333,380,0.00067470
+Postman Sort,333,381,0.00075720
+Postman Sort,333,382,0.00066460
+Postman Sort,333,383,0.00104710
+Postman Sort,333,384,0.00068460
+Postman Sort,333,385,0.00080830
+Postman Sort,333,386,0.00066290
+Postman Sort,333,387,0.00067410
+Postman Sort,333,388,0.00075910
+Postman Sort,333,389,0.00088930
+Postman Sort,333,390,0.00064430
+Postman Sort,333,391,0.00065860
+Postman Sort,333,392,0.00077390
+Postman Sort,333,393,0.00067020
+Postman Sort,333,394,0.00287550
+Postman Sort,333,395,0.00103140
+Postman Sort,333,396,0.00066300
+Postman Sort,333,397,0.00080280
+Postman Sort,333,398,0.00067480
+Postman Sort,333,399,0.00066560
+Postman Sort,333,400,0.00145500
+Postman Sort,333,401,0.00065170
+Postman Sort,333,402,0.00080940
+Postman Sort,333,403,0.00067110
+Postman Sort,333,404,0.00065560
+Postman Sort,333,405,0.00078550
+Postman Sort,333,406,0.00066250
+Postman Sort,333,407,0.00151820
+Postman Sort,333,408,0.00066820
+Postman Sort,333,409,0.00067280
+Postman Sort,333,410,0.00081670
+Postman Sort,333,411,0.00287750
+Postman Sort,333,412,0.00065820
+Postman Sort,333,413,0.00067020
+Postman Sort,333,414,0.00078220
+Postman Sort,333,415,0.00060050
+Postman Sort,333,416,0.00104040
+Postman Sort,333,417,0.00066710
+Postman Sort,333,418,0.00079770
+Postman Sort,333,419,0.00059490
+Postman Sort,333,420,0.00065980
+Postman Sort,333,421,0.00086660
+Postman Sort,333,422,0.00108980
+Postman Sort,333,423,0.00916940
+Postman Sort,333,424,0.00073010
+Postman Sort,333,425,0.00064930
+Postman Sort,333,426,0.00124190
+Postman Sort,333,427,0.00066100
+Postman Sort,333,428,0.00076130
+Postman Sort,333,429,0.00078280
+Postman Sort,333,430,0.00079280
+Postman Sort,333,431,0.00065780
+Postman Sort,333,432,0.00073840
+Postman Sort,333,433,0.00074600
+Postman Sort,333,434,0.00065130
+Postman Sort,333,435,0.00071440
+Postman Sort,333,436,0.00191120
+Postman Sort,333,437,0.00065410
+Postman Sort,333,438,0.00186090
+Postman Sort,333,439,0.00072260
+Postman Sort,333,440,0.00065100
+Postman Sort,333,441,0.00070780
+Postman Sort,333,442,0.00064860
+Postman Sort,333,443,0.00152410
+Postman Sort,333,444,0.00071840
+Postman Sort,333,445,0.00064260
+Postman Sort,333,446,0.00067970
+Postman Sort,333,447,0.00090090
+Postman Sort,333,448,0.00071730
+Postman Sort,333,449,0.00072270
+Postman Sort,333,450,0.00062710
+Postman Sort,333,451,0.00105380
+Postman Sort,333,452,0.00075260
+Postman Sort,333,453,0.00066970
+Postman Sort,333,454,0.00103310
+Postman Sort,333,455,0.00077840
+Postman Sort,333,456,0.00065020
+Postman Sort,333,457,0.00076890
+Postman Sort,333,458,0.00085100
+Postman Sort,333,459,0.00067170
+Postman Sort,333,460,0.00065720
+Postman Sort,333,461,0.00078660
+Postman Sort,333,462,0.00069160
+Postman Sort,333,463,0.00093440
+Postman Sort,333,464,0.00066270
+Postman Sort,333,465,0.00072410
+Postman Sort,333,466,0.00081810
+Postman Sort,333,467,0.00067710
+Postman Sort,333,468,0.00062320
+Postman Sort,333,469,0.00064240
+Postman Sort,333,470,0.00085900
+Postman Sort,333,471,0.00059410
+Postman Sort,333,472,0.00075990
+Postman Sort,333,473,0.00094780
+Postman Sort,333,474,0.00062460
+Postman Sort,333,475,0.00076080
+Postman Sort,333,476,0.00061370
+Postman Sort,333,477,0.00094210
+Postman Sort,333,478,0.00077220
+Postman Sort,333,479,0.00061190
+Postman Sort,333,480,0.00080510
+Postman Sort,333,481,0.00073760
+Postman Sort,333,482,0.00061020
+Postman Sort,333,483,0.00075440
+Postman Sort,333,484,0.00091600
+Postman Sort,333,485,0.00082310
+Postman Sort,333,486,0.00059840
+Postman Sort,333,487,0.00078020
+Postman Sort,333,488,0.01970050
+Postman Sort,333,489,0.00077050
+Postman Sort,333,490,0.00059970
+Postman Sort,333,491,0.00074050
+Postman Sort,333,492,0.00076380
+Postman Sort,333,493,0.00065420
+Postman Sort,333,494,0.00076020
+Postman Sort,333,495,0.00066500
+Postman Sort,333,496,0.00072170
+Postman Sort,333,497,0.00079530
+Postman Sort,333,498,0.00066910
+Postman Sort,333,499,0.00078400
+Postman Sort,333,500,0.00067980
+Quick Sort,333,1,0.00072230
+Quick Sort,333,2,0.00085600
+Quick Sort,333,3,0.00069070
+Quick Sort,333,4,0.00064990
+Quick Sort,333,5,0.00074750
+Quick Sort,333,6,0.00066470
+Quick Sort,333,7,0.00068100
+Quick Sort,333,8,0.00071200
+Quick Sort,333,9,0.00060540
+Quick Sort,333,10,0.00081620
+Quick Sort,333,11,0.00058630
+Quick Sort,333,12,0.00075040
+Quick Sort,333,13,0.00076070
+Quick Sort,333,14,0.00077940
+Quick Sort,333,15,0.00059690
+Quick Sort,333,16,0.00063820
+Quick Sort,333,17,0.00054900
+Quick Sort,333,18,0.00138410
+Quick Sort,333,19,0.00066380
+Quick Sort,333,20,0.00067690
+Quick Sort,333,21,0.00066130
+Quick Sort,333,22,0.00065000
+Quick Sort,333,23,0.00064620
+Quick Sort,333,24,0.00055550
+Quick Sort,333,25,0.00170680
+Quick Sort,333,26,0.00067420
+Quick Sort,333,27,0.00066060
+Quick Sort,333,28,0.00051200
+Quick Sort,333,29,0.00065440
+Quick Sort,333,30,0.00063840
+Quick Sort,333,31,0.00071360
+Quick Sort,333,32,0.00066240
+Quick Sort,333,33,0.00055110
+Quick Sort,333,34,0.00064810
+Quick Sort,333,35,0.00118090
+Quick Sort,333,36,0.00052070
+Quick Sort,333,37,0.00219580
+Quick Sort,333,38,0.00075720
+Quick Sort,333,39,0.00058900
+Quick Sort,333,40,0.00077630
+Quick Sort,333,41,0.00055380
+Quick Sort,333,42,0.00071640
+Quick Sort,333,43,0.02701920
+Quick Sort,333,44,0.00069940
+Quick Sort,333,45,0.00059410
+Quick Sort,333,46,0.00079740
+Quick Sort,333,47,0.00059110
+Quick Sort,333,48,0.00082880
+Quick Sort,333,49,0.00065360
+Quick Sort,333,50,0.00070660
+Quick Sort,333,51,0.00064420
+Quick Sort,333,52,0.00068650
+Quick Sort,333,53,0.00068280
+Quick Sort,333,54,0.00062510
+Quick Sort,333,55,0.00064330
+Quick Sort,333,56,0.00070640
+Quick Sort,333,57,0.00069410
+Quick Sort,333,58,0.00086500
+Quick Sort,333,59,0.00064520
+Quick Sort,333,60,0.00063970
+Quick Sort,333,61,0.00067870
+Quick Sort,333,62,0.00073920
+Quick Sort,333,63,0.00066740
+Quick Sort,333,64,0.00061070
+Quick Sort,333,65,0.00064200
+Quick Sort,333,66,0.00060800
+Quick Sort,333,67,0.00063490
+Quick Sort,333,68,0.00072990
+Quick Sort,333,69,0.00066240
+Quick Sort,333,70,0.00056230
+Quick Sort,333,71,0.00064370
+Quick Sort,333,72,0.00068650
+Quick Sort,333,73,0.00064220
+Quick Sort,333,74,0.00060240
+Quick Sort,333,75,0.00060380
+Quick Sort,333,76,0.00069860
+Quick Sort,333,77,0.02050220
+Quick Sort,333,78,0.00065160
+Quick Sort,333,79,0.00067650
+Quick Sort,333,80,0.00074460
+Quick Sort,333,81,0.00065510
+Quick Sort,333,82,0.00065730
+Quick Sort,333,83,0.00072500
+Quick Sort,333,84,0.00067980
+Quick Sort,333,85,0.00067780
+Quick Sort,333,86,0.00070890
+Quick Sort,333,87,0.00068780
+Quick Sort,333,88,0.00063720
+Quick Sort,333,89,0.00062810
+Quick Sort,333,90,0.00069760
+Quick Sort,333,91,0.00066390
+Quick Sort,333,92,0.00059380
+Quick Sort,333,93,0.00076010
+Quick Sort,333,94,0.00059810
+Quick Sort,333,95,0.00060310
+Quick Sort,333,96,0.00061210
+Quick Sort,333,97,0.00072790
+Quick Sort,333,98,0.00068950
+Quick Sort,333,99,0.00079080
+Quick Sort,333,100,0.00061450
+Quick Sort,333,101,0.00066510
+Quick Sort,333,102,0.00099170
+Quick Sort,333,103,0.00069630
+Quick Sort,333,104,0.00065140
+Quick Sort,333,105,0.00069730
+Quick Sort,333,106,0.00072230
+Quick Sort,333,107,0.00083750
+Quick Sort,333,108,0.00069850
+Quick Sort,333,109,0.00072450
+Quick Sort,333,110,0.00098810
+Quick Sort,333,111,0.00071850
+Quick Sort,333,112,0.00074340
+Quick Sort,333,113,0.00065370
+Quick Sort,333,114,0.00080710
+Quick Sort,333,115,0.01044100
+Quick Sort,333,116,0.00064000
+Quick Sort,333,117,0.00061820
+Quick Sort,333,118,0.00058010
+Quick Sort,333,119,0.00067610
+Quick Sort,333,120,0.00059890
+Quick Sort,333,121,0.00124360
+Quick Sort,333,122,0.00069190
+Quick Sort,333,123,0.00065690
+Quick Sort,333,124,0.00063450
+Quick Sort,333,125,0.00085860
+Quick Sort,333,126,0.00071530
+Quick Sort,333,127,0.00068310
+Quick Sort,333,128,0.00067220
+Quick Sort,333,129,0.00069730
+Quick Sort,333,130,0.00127400
+Quick Sort,333,131,0.00065240
+Quick Sort,333,132,0.00074460
+Quick Sort,333,133,0.00072740
+Quick Sort,333,134,0.00061740
+Quick Sort,333,135,0.00071960
+Quick Sort,333,136,0.00061260
+Quick Sort,333,137,0.00080910
+Quick Sort,333,138,0.00072010
+Quick Sort,333,139,0.00061080
+Quick Sort,333,140,0.00063130
+Quick Sort,333,141,0.00064410
+Quick Sort,333,142,0.00094920
+Quick Sort,333,143,0.00069480
+Quick Sort,333,144,0.00065570
+Quick Sort,333,145,0.00067370
+Quick Sort,333,146,0.00059820
+Quick Sort,333,147,0.00070040
+Quick Sort,333,148,0.00069270
+Quick Sort,333,149,0.00060740
+Quick Sort,333,150,0.00062350
+Quick Sort,333,151,0.00060290
+Quick Sort,333,152,0.00058900
+Quick Sort,333,153,0.00066960
+Quick Sort,333,154,0.00068100
+Quick Sort,333,155,0.00088150
+Quick Sort,333,156,0.00065540
+Quick Sort,333,157,0.00063740
+Quick Sort,333,158,0.00078080
+Quick Sort,333,159,0.00065330
+Quick Sort,333,160,0.00065760
+Quick Sort,333,161,0.00076780
+Quick Sort,333,162,0.00063880
+Quick Sort,333,163,0.00066450
+Quick Sort,333,164,0.00072400
+Quick Sort,333,165,0.00062780
+Quick Sort,333,166,0.00066560
+Quick Sort,333,167,0.00064890
+Quick Sort,333,168,0.00060720
+Quick Sort,333,169,0.00068170
+Quick Sort,333,170,0.00072650
+Quick Sort,333,171,0.00065980
+Quick Sort,333,172,0.00067730
+Quick Sort,333,173,0.00068460
+Quick Sort,333,174,0.00065340
+Quick Sort,333,175,0.00079420
+Quick Sort,333,176,0.00069000
+Quick Sort,333,177,0.00068630
+Quick Sort,333,178,0.00076970
+Quick Sort,333,179,0.00074390
+Quick Sort,333,180,0.00081020
+Quick Sort,333,181,0.00076100
+Quick Sort,333,182,0.00072670
+Quick Sort,333,183,0.00068350
+Quick Sort,333,184,0.00065960
+Quick Sort,333,185,0.00076190
+Quick Sort,333,186,0.00067290
+Quick Sort,333,187,0.00060370
+Quick Sort,333,188,0.00067810
+Quick Sort,333,189,0.00066490
+Quick Sort,333,190,0.00089980
+Quick Sort,333,191,0.00066370
+Quick Sort,333,192,0.00063090
+Quick Sort,333,193,0.00070100
+Quick Sort,333,194,0.00080950
+Quick Sort,333,195,0.00072320
+Quick Sort,333,196,0.00070450
+Quick Sort,333,197,0.00072320
+Quick Sort,333,198,0.00069940
+Quick Sort,333,199,0.00089550
+Quick Sort,333,200,0.00069640
+Quick Sort,333,201,0.00064690
+Quick Sort,333,202,0.00067180
+Quick Sort,333,203,0.00069750
+Quick Sort,333,204,0.00080060
+Quick Sort,333,205,0.00062130
+Quick Sort,333,206,0.00067470
+Quick Sort,333,207,0.00069910
+Quick Sort,333,208,0.00077560
+Quick Sort,333,209,0.00067490
+Quick Sort,333,210,0.00064560
+Quick Sort,333,211,0.00073960
+Quick Sort,333,212,0.00069460
+Quick Sort,333,213,0.00109160
+Quick Sort,333,214,0.00074350
+Quick Sort,333,215,0.00066740
+Quick Sort,333,216,0.00060650
+Quick Sort,333,217,0.00894710
+Quick Sort,333,218,0.00068600
+Quick Sort,333,219,0.00071210
+Quick Sort,333,220,0.00057080
+Quick Sort,333,221,0.00073310
+Quick Sort,333,222,0.00068040
+Quick Sort,333,223,0.00072040
+Quick Sort,333,224,0.00078120
+Quick Sort,333,225,0.00070120
+Quick Sort,333,226,0.00069780
+Quick Sort,333,227,0.00075980
+Quick Sort,333,228,0.00072270
+Quick Sort,333,229,0.00068540
+Quick Sort,333,230,0.00073670
+Quick Sort,333,231,0.00819900
+Quick Sort,333,232,0.00063470
+Quick Sort,333,233,0.00066920
+Quick Sort,333,234,0.00072110
+Quick Sort,333,235,0.00066730
+Quick Sort,333,236,0.00062930
+Quick Sort,333,237,0.00057890
+Quick Sort,333,238,0.00070240
+Quick Sort,333,239,0.00100060
+Quick Sort,333,240,0.00075460
+Quick Sort,333,241,0.00067100
+Quick Sort,333,242,0.00081650
+Quick Sort,333,243,0.00064240
+Quick Sort,333,244,0.00071040
+Quick Sort,333,245,0.00061230
+Quick Sort,333,246,0.00076610
+Quick Sort,333,247,0.00066570
+Quick Sort,333,248,0.00073680
+Quick Sort,333,249,0.00061140
+Quick Sort,333,250,0.00069110
+Quick Sort,333,251,0.00059550
+Quick Sort,333,252,0.00058640
+Quick Sort,333,253,0.00156910
+Quick Sort,333,254,0.00073490
+Quick Sort,333,255,0.00061480
+Quick Sort,333,256,0.00058370
+Quick Sort,333,257,0.00058410
+Quick Sort,333,258,0.00069020
+Quick Sort,333,259,0.00082940
+Quick Sort,333,260,0.00060900
+Quick Sort,333,261,0.00063360
+Quick Sort,333,262,0.00082120
+Quick Sort,333,263,0.00067700
+Quick Sort,333,264,0.00063380
+Quick Sort,333,265,0.00067990
+Quick Sort,333,266,0.00063280
+Quick Sort,333,267,0.00069010
+Quick Sort,333,268,0.00061480
+Quick Sort,333,269,0.00061460
+Quick Sort,333,270,0.00066530
+Quick Sort,333,271,0.00072300
+Quick Sort,333,272,0.00063020
+Quick Sort,333,273,0.00058120
+Quick Sort,333,274,0.02646350
+Quick Sort,333,275,0.00064300
+Quick Sort,333,276,0.00074580
+Quick Sort,333,277,0.00066040
+Quick Sort,333,278,0.00075720
+Quick Sort,333,279,0.00064640
+Quick Sort,333,280,0.00061250
+Quick Sort,333,281,0.00072590
+Quick Sort,333,282,0.00067430
+Quick Sort,333,283,0.00060980
+Quick Sort,333,284,0.00062350
+Quick Sort,333,285,0.00064040
+Quick Sort,333,286,0.00080500
+Quick Sort,333,287,0.00067210
+Quick Sort,333,288,0.00062780
+Quick Sort,333,289,0.00064680
+Quick Sort,333,290,0.00063730
+Quick Sort,333,291,0.00070140
+Quick Sort,333,292,0.00063630
+Quick Sort,333,293,0.00073130
+Quick Sort,333,294,0.00063930
+Quick Sort,333,295,0.00069960
+Quick Sort,333,296,0.00066920
+Quick Sort,333,297,0.00068720
+Quick Sort,333,298,0.00060580
+Quick Sort,333,299,0.00073190
+Quick Sort,333,300,0.00062120
+Quick Sort,333,301,0.00062600
+Quick Sort,333,302,0.00065880
+Quick Sort,333,303,0.00067350
+Quick Sort,333,304,0.00064330
+Quick Sort,333,305,0.00061200
+Quick Sort,333,306,0.00074370
+Quick Sort,333,307,0.00064430
+Quick Sort,333,308,0.00079930
+Quick Sort,333,309,0.00069130
+Quick Sort,333,310,0.00062730
+Quick Sort,333,311,0.00067690
+Quick Sort,333,312,0.00073820
+Quick Sort,333,313,0.00065460
+Quick Sort,333,314,0.00068370
+Quick Sort,333,315,0.00073940
+Quick Sort,333,316,0.00067350
+Quick Sort,333,317,0.00068870
+Quick Sort,333,318,0.00063710
+Quick Sort,333,319,0.00064200
+Quick Sort,333,320,0.00066320
+Quick Sort,333,321,0.00064050
+Quick Sort,333,322,0.00067590
+Quick Sort,333,323,0.00073020
+Quick Sort,333,324,0.00069900
+Quick Sort,333,325,0.00066640
+Quick Sort,333,326,0.00080000
+Quick Sort,333,327,0.00059280
+Quick Sort,333,328,0.00064000
+Quick Sort,333,329,0.00063890
+Quick Sort,333,330,0.00066390
+Quick Sort,333,331,0.00062080
+Quick Sort,333,332,0.00067530
+Quick Sort,333,333,0.00070250
+Quick Sort,333,334,0.00069610
+Quick Sort,333,335,0.00065980
+Quick Sort,333,336,0.00063300
+Quick Sort,333,337,0.00062930
+Quick Sort,333,338,0.00066070
+Quick Sort,333,339,0.00064740
+Quick Sort,333,340,0.00063660
+Quick Sort,333,341,0.00060290
+Quick Sort,333,342,0.00060730
+Quick Sort,333,343,0.00062000
+Quick Sort,333,344,0.00066850
+Quick Sort,333,345,0.00067820
+Quick Sort,333,346,0.00068900
+Quick Sort,333,347,0.00063450
+Quick Sort,333,348,0.00062100
+Quick Sort,333,349,0.00068100
+Quick Sort,333,350,0.00061580
+Quick Sort,333,351,0.00068530
+Quick Sort,333,352,0.00059440
+Quick Sort,333,353,0.00052970
+Quick Sort,333,354,0.00065660
+Quick Sort,333,355,0.00064950
+Quick Sort,333,356,0.00062560
+Quick Sort,333,357,0.00057200
+Quick Sort,333,358,0.00065530
+Quick Sort,333,359,0.00900570
+Quick Sort,333,360,0.00062940
+Quick Sort,333,361,0.00057490
+Quick Sort,333,362,0.00063200
+Quick Sort,333,363,0.00800410
+Quick Sort,333,364,0.00057680
+Quick Sort,333,365,0.00061000
+Quick Sort,333,366,0.00057780
+Quick Sort,333,367,0.00058960
+Quick Sort,333,368,0.00057880
+Quick Sort,333,369,0.00202500
+Quick Sort,333,370,0.00056730
+Quick Sort,333,371,0.00067840
+Quick Sort,333,372,0.00085480
+Quick Sort,333,373,0.00078960
+Quick Sort,333,374,0.00056130
+Quick Sort,333,375,0.00064060
+Quick Sort,333,376,0.00064840
+Quick Sort,333,377,0.00073490
+Quick Sort,333,378,0.00075170
+Quick Sort,333,379,0.00073910
+Quick Sort,333,380,0.00066980
+Quick Sort,333,381,0.00070020
+Quick Sort,333,382,0.00079550
+Quick Sort,333,383,0.00063610
+Quick Sort,333,384,0.00068520
+Quick Sort,333,385,0.00058380
+Quick Sort,333,386,0.00072260
+Quick Sort,333,387,0.00072080
+Quick Sort,333,388,0.00130560
+Quick Sort,333,389,0.00062520
+Quick Sort,333,390,0.00054260
+Quick Sort,333,391,0.00167500
+Quick Sort,333,392,0.00064510
+Quick Sort,333,393,0.00064860
+Quick Sort,333,394,0.00165240
+Quick Sort,333,395,0.00077300
+Quick Sort,333,396,0.00071160
+Quick Sort,333,397,0.00068010
+Quick Sort,333,398,0.00076030
+Quick Sort,333,399,0.00061800
+Quick Sort,333,400,0.00067320
+Quick Sort,333,401,0.00318290
+Quick Sort,333,402,0.00067610
+Quick Sort,333,403,0.00175530
+Quick Sort,333,404,0.00066840
+Quick Sort,333,405,0.00151800
+Quick Sort,333,406,0.00074770
+Quick Sort,333,407,0.00067630
+Quick Sort,333,408,0.00187470
+Quick Sort,333,409,0.00070990
+Quick Sort,333,410,0.00064580
+Quick Sort,333,411,0.00071410
+Quick Sort,333,412,0.00342090
+Quick Sort,333,413,0.00069550
+Quick Sort,333,414,0.00059850
+Quick Sort,333,415,0.00074960
+Quick Sort,333,416,0.00068280
+Quick Sort,333,417,0.00075140
+Quick Sort,333,418,0.00069340
+Quick Sort,333,419,0.00064510
+Quick Sort,333,420,0.00061460
+Quick Sort,333,421,0.00087990
+Quick Sort,333,422,0.00073830
+Quick Sort,333,423,0.00190650
+Quick Sort,333,424,0.00078520
+Quick Sort,333,425,0.00069330
+Quick Sort,333,426,0.00071650
+Quick Sort,333,427,0.00068930
+Quick Sort,333,428,0.00067600
+Quick Sort,333,429,0.00067460
+Quick Sort,333,430,0.00061660
+Quick Sort,333,431,0.00113610
+Quick Sort,333,432,0.00072790
+Quick Sort,333,433,0.00057740
+Quick Sort,333,434,0.00066280
+Quick Sort,333,435,0.00075930
+Quick Sort,333,436,0.00070660
+Quick Sort,333,437,0.00065540
+Quick Sort,333,438,0.00070760
+Quick Sort,333,439,0.00074890
+Quick Sort,333,440,0.00109230
+Quick Sort,333,441,0.00059510
+Quick Sort,333,442,0.00079130
+Quick Sort,333,443,0.00065220
+Quick Sort,333,444,0.00063610
+Quick Sort,333,445,0.00063660
+Quick Sort,333,446,0.00061690
+Quick Sort,333,447,0.00070750
+Quick Sort,333,448,0.00105350
+Quick Sort,333,449,0.00064110
+Quick Sort,333,450,0.00065370
+Quick Sort,333,451,0.00064980
+Quick Sort,333,452,0.00068280
+Quick Sort,333,453,0.00063080
+Quick Sort,333,454,0.00087150
+Quick Sort,333,455,0.00065130
+Quick Sort,333,456,0.00060310
+Quick Sort,333,457,0.00071630
+Quick Sort,333,458,0.00060180
+Quick Sort,333,459,0.00059690
+Quick Sort,333,460,0.00062790
+Quick Sort,333,461,0.00086530
+Quick Sort,333,462,0.00059510
+Quick Sort,333,463,0.00062360
+Quick Sort,333,464,0.00055870
+Quick Sort,333,465,0.00060050
+Quick Sort,333,466,0.00061090
+Quick Sort,333,467,0.00069560
+Quick Sort,333,468,0.00093450
+Quick Sort,333,469,0.00063120
+Quick Sort,333,470,0.00065770
+Quick Sort,333,471,0.00062850
+Quick Sort,333,472,0.00063610
+Quick Sort,333,473,0.00062610
+Quick Sort,333,474,0.00065370
+Quick Sort,333,475,0.00101680
+Quick Sort,333,476,0.00061270
+Quick Sort,333,477,0.00071060
+Quick Sort,333,478,0.00065210
+Quick Sort,333,479,0.00066610
+Quick Sort,333,480,0.00063210
+Quick Sort,333,481,0.00142110
+Quick Sort,333,482,0.00105770
+Quick Sort,333,483,0.00066290
+Quick Sort,333,484,0.00063960
+Quick Sort,333,485,0.00064660
+Quick Sort,333,486,0.00060420
+Quick Sort,333,487,0.00063400
+Quick Sort,333,488,0.00320990
+Quick Sort,333,489,0.00070890
+Quick Sort,333,490,0.00072530
+Quick Sort,333,491,0.00066840
+Quick Sort,333,492,0.00070790
+Quick Sort,333,493,0.00150480
+Quick Sort,333,494,0.00077440
+Quick Sort,333,495,0.00067370
+Quick Sort,333,496,0.00072140
+Quick Sort,333,497,0.00073780
+Quick Sort,333,498,0.00061510
+Quick Sort,333,499,0.00077640
+Quick Sort,333,500,0.00067120
+Radix Sort,333,1,0.00077170
+Radix Sort,333,2,0.00079830
+Radix Sort,333,3,0.00077270
+Radix Sort,333,4,0.00065900
+Radix Sort,333,5,0.02228970
+Radix Sort,333,6,0.00068930
+Radix Sort,333,7,0.00063280
+Radix Sort,333,8,0.00064090
+Radix Sort,333,9,0.00089090
+Radix Sort,333,10,0.00078310
+Radix Sort,333,11,0.00085440
+Radix Sort,333,12,0.00084520
+Radix Sort,333,13,0.00078840
+Radix Sort,333,14,0.00083350
+Radix Sort,333,15,0.00092270
+Radix Sort,333,16,0.00067870
+Radix Sort,333,17,0.00079820
+Radix Sort,333,18,0.00077950
+Radix Sort,333,19,0.00080140
+Radix Sort,333,20,0.00076800
+Radix Sort,333,21,0.00076990
+Radix Sort,333,22,0.00076300
+Radix Sort,333,23,0.00080440
+Radix Sort,333,24,0.00092140
+Radix Sort,333,25,0.00078790
+Radix Sort,333,26,0.03378440
+Radix Sort,333,27,0.00081490
+Radix Sort,333,28,0.00088620
+Radix Sort,333,29,0.00089550
+Radix Sort,333,30,0.00087220
+Radix Sort,333,31,0.00087120
+Radix Sort,333,32,0.00259580
+Radix Sort,333,33,0.00076700
+Radix Sort,333,34,0.00092200
+Radix Sort,333,35,0.00086670
+Radix Sort,333,36,0.00075610
+Radix Sort,333,37,0.00079330
+Radix Sort,333,38,0.00069060
+Radix Sort,333,39,0.00081300
+Radix Sort,333,40,0.00078650
+Radix Sort,333,41,0.00073390
+Radix Sort,333,42,0.00067930
+Radix Sort,333,43,0.00071620
+Radix Sort,333,44,0.00068370
+Radix Sort,333,45,0.00067710
+Radix Sort,333,46,0.00067790
+Radix Sort,333,47,0.00070940
+Radix Sort,333,48,0.00066700
+Radix Sort,333,49,0.00068300
+Radix Sort,333,50,0.00084270
+Radix Sort,333,51,0.00066790
+Radix Sort,333,52,0.00092700
+Radix Sort,333,53,0.00118300
+Radix Sort,333,54,0.00066850
+Radix Sort,333,55,0.00081080
+Radix Sort,333,56,0.00064430
+Radix Sort,333,57,0.00072040
+Radix Sort,333,58,0.00076830
+Radix Sort,333,59,0.00066960
+Radix Sort,333,60,0.00060990
+Radix Sort,333,61,0.00079280
+Radix Sort,333,62,0.00097750
+Radix Sort,333,63,0.00059800
+Radix Sort,333,64,0.00082670
+Radix Sort,333,65,0.00073260
+Radix Sort,333,66,0.00075260
+Radix Sort,333,67,0.00065440
+Radix Sort,333,68,0.00069580
+Radix Sort,333,69,0.00073940
+Radix Sort,333,70,0.00068880
+Radix Sort,333,71,0.00158400
+Radix Sort,333,72,0.00067930
+Radix Sort,333,73,0.02029690
+Radix Sort,333,74,0.00075640
+Radix Sort,333,75,0.00095650
+Radix Sort,333,76,0.00064840
+Radix Sort,333,77,0.00131110
+Radix Sort,333,78,0.00073560
+Radix Sort,333,79,0.00156160
+Radix Sort,333,80,0.00205400
+Radix Sort,333,81,0.00110320
+Radix Sort,333,82,0.00264560
+Radix Sort,333,83,0.00090720
+Radix Sort,333,84,0.00084560
+Radix Sort,333,85,0.00199630
+Radix Sort,333,86,0.00086250
+Radix Sort,333,87,0.00126570
+Radix Sort,333,88,0.00074180
+Radix Sort,333,89,0.00075150
+Radix Sort,333,90,0.00150370
+Radix Sort,333,91,0.00086640
+Radix Sort,333,92,0.00077430
+Radix Sort,333,93,0.00073310
+Radix Sort,333,94,0.00076400
+Radix Sort,333,95,0.00067550
+Radix Sort,333,96,0.00119930
+Radix Sort,333,97,0.00072980
+Radix Sort,333,98,0.00071780
+Radix Sort,333,99,0.00074770
+Radix Sort,333,100,0.00072870
+Radix Sort,333,101,0.00081140
+Radix Sort,333,102,0.00076270
+Radix Sort,333,103,0.00076120
+Radix Sort,333,104,0.00071110
+Radix Sort,333,105,0.00088660
+Radix Sort,333,106,0.00092490
+Radix Sort,333,107,0.00159500
+Radix Sort,333,108,0.00079250
+Radix Sort,333,109,0.00107010
+Radix Sort,333,110,0.00076920
+Radix Sort,333,111,0.00088870
+Radix Sort,333,112,0.00076470
+Radix Sort,333,113,0.00076430
+Radix Sort,333,114,0.00076790
+Radix Sort,333,115,0.00081860
+Radix Sort,333,116,0.00074390
+Radix Sort,333,117,0.00075400
+Radix Sort,333,118,0.00077500
+Radix Sort,333,119,0.00073690
+Radix Sort,333,120,0.00089270
+Radix Sort,333,121,0.00082600
+Radix Sort,333,122,0.00076100
+Radix Sort,333,123,0.00074470
+Radix Sort,333,124,0.00071060
+Radix Sort,333,125,0.00087030
+Radix Sort,333,126,0.00077420
+Radix Sort,333,127,0.00073990
+Radix Sort,333,128,0.00076030
+Radix Sort,333,129,0.01590540
+Radix Sort,333,130,0.00076110
+Radix Sort,333,131,0.00092180
+Radix Sort,333,132,0.00077480
+Radix Sort,333,133,0.00092230
+Radix Sort,333,134,0.00082200
+Radix Sort,333,135,0.00077270
+Radix Sort,333,136,0.00077430
+Radix Sort,333,137,0.00081870
+Radix Sort,333,138,0.00077670
+Radix Sort,333,139,0.00077990
+Radix Sort,333,140,0.00076700
+Radix Sort,333,141,0.00114320
+Radix Sort,333,142,0.00076640
+Radix Sort,333,143,0.00074870
+Radix Sort,333,144,0.00090810
+Radix Sort,333,145,0.00077260
+Radix Sort,333,146,0.00489930
+Radix Sort,333,147,0.00097520
+Radix Sort,333,148,0.00076690
+Radix Sort,333,149,0.00076710
+Radix Sort,333,150,0.00075050
+Radix Sort,333,151,0.00084650
+Radix Sort,333,152,0.00075850
+Radix Sort,333,153,0.00075010
+Radix Sort,333,154,0.00085130
+Radix Sort,333,155,0.00077580
+Radix Sort,333,156,0.00077700
+Radix Sort,333,157,0.00078020
+Radix Sort,333,158,0.00062490
+Radix Sort,333,159,0.00076560
+Radix Sort,333,160,0.00070480
+Radix Sort,333,161,0.00080640
+Radix Sort,333,162,0.00243350
+Radix Sort,333,163,0.00079100
+Radix Sort,333,164,0.00065750
+Radix Sort,333,165,0.00077530
+Radix Sort,333,166,0.00076780
+Radix Sort,333,167,0.00060980
+Radix Sort,333,168,0.00935490
+Radix Sort,333,169,0.00061690
+Radix Sort,333,170,0.00073240
+Radix Sort,333,171,0.00203040
+Radix Sort,333,172,0.00063260
+Radix Sort,333,173,0.00201560
+Radix Sort,333,174,0.00079110
+Radix Sort,333,175,0.00212720
+Radix Sort,333,176,0.00072240
+Radix Sort,333,177,0.00079230
+Radix Sort,333,178,0.00193670
+Radix Sort,333,179,0.00088980
+Radix Sort,333,180,0.00331920
+Radix Sort,333,181,0.00098820
+Radix Sort,333,182,0.00399450
+Radix Sort,333,183,0.00080670
+Radix Sort,333,184,0.00614790
+Radix Sort,333,185,0.00083610
+Radix Sort,333,186,0.00079360
+Radix Sort,333,187,0.00111460
+Radix Sort,333,188,0.00079170
+Radix Sort,333,189,0.00076960
+Radix Sort,333,190,0.00086060
+Radix Sort,333,191,0.00082200
+Radix Sort,333,192,0.00086120
+Radix Sort,333,193,0.00077570
+Radix Sort,333,194,0.00081080
+Radix Sort,333,195,0.00083400
+Radix Sort,333,196,0.00062610
+Radix Sort,333,197,0.00178540
+Radix Sort,333,198,0.00088910
+Radix Sort,333,199,0.00082710
+Radix Sort,333,200,0.00063380
+Radix Sort,333,201,0.00082610
+Radix Sort,333,202,0.00094040
+Radix Sort,333,203,0.00086040
+Radix Sort,333,204,0.00319340
+Radix Sort,333,205,0.00064570
+Radix Sort,333,206,0.00081260
+Radix Sort,333,207,0.00089200
+Radix Sort,333,208,0.00062910
+Radix Sort,333,209,0.00086660
+Radix Sort,333,210,0.00080170
+Radix Sort,333,211,0.00076470
+Radix Sort,333,212,0.00074750
+Radix Sort,333,213,0.00115840
+Radix Sort,333,214,0.00086380
+Radix Sort,333,215,0.00076020
+Radix Sort,333,216,0.00074290
+Radix Sort,333,217,0.00083440
+Radix Sort,333,218,0.00074900
+Radix Sort,333,219,0.00075220
+Radix Sort,333,220,0.00073810
+Radix Sort,333,221,0.00082330
+Radix Sort,333,222,0.00077890
+Radix Sort,333,223,0.00119350
+Radix Sort,333,224,0.00075200
+Radix Sort,333,225,0.00073270
+Radix Sort,333,226,0.00081270
+Radix Sort,333,227,0.00068160
+Radix Sort,333,228,0.00122800
+Radix Sort,333,229,0.00088440
+Radix Sort,333,230,0.00070320
+Radix Sort,333,231,0.00080000
+Radix Sort,333,232,0.00082040
+Radix Sort,333,233,0.00080170
+Radix Sort,333,234,0.00110240
+Radix Sort,333,235,0.00084460
+Radix Sort,333,236,0.00076590
+Radix Sort,333,237,0.00077140
+Radix Sort,333,238,0.00076470
+Radix Sort,333,239,0.00074320
+Radix Sort,333,240,0.00068540
+Radix Sort,333,241,0.00078310
+Radix Sort,333,242,0.00095280
+Radix Sort,333,243,0.00076150
+Radix Sort,333,244,0.00081600
+Radix Sort,333,245,0.00075100
+Radix Sort,333,246,0.00070810
+Radix Sort,333,247,0.00074640
+Radix Sort,333,248,0.00062850
+Radix Sort,333,249,0.00078160
+Radix Sort,333,250,0.00074690
+Radix Sort,333,251,0.00064150
+Radix Sort,333,252,0.00064700
+Radix Sort,333,253,0.00076620
+Radix Sort,333,254,0.00077160
+Radix Sort,333,255,0.00077180
+Radix Sort,333,256,0.00062040
+Radix Sort,333,257,0.00066210
+Radix Sort,333,258,0.00429780
+Radix Sort,333,259,0.00088510
+Radix Sort,333,260,0.00082230
+Radix Sort,333,261,0.00071030
+Radix Sort,333,262,0.00075050
+Radix Sort,333,263,0.00063240
+Radix Sort,333,264,0.00089100
+Radix Sort,333,265,0.00085610
+Radix Sort,333,266,0.00090640
+Radix Sort,333,267,0.00076260
+Radix Sort,333,268,0.00087910
+Radix Sort,333,269,0.00087950
+Radix Sort,333,270,0.00071410
+Radix Sort,333,271,0.00082690
+Radix Sort,333,272,0.00081910
+Radix Sort,333,273,0.00078880
+Radix Sort,333,274,0.00076740
+Radix Sort,333,275,0.00092890
+Radix Sort,333,276,0.00078410
+Radix Sort,333,277,0.00090540
+Radix Sort,333,278,0.00076590
+Radix Sort,333,279,0.00076940
+Radix Sort,333,280,0.00070880
+Radix Sort,333,281,0.00077250
+Radix Sort,333,282,0.00078060
+Radix Sort,333,283,0.00089090
+Radix Sort,333,284,0.00078600
+Radix Sort,333,285,0.00095160
+Radix Sort,333,286,0.00076200
+Radix Sort,333,287,0.00081830
+Radix Sort,333,288,0.00080660
+Radix Sort,333,289,0.00084450
+Radix Sort,333,290,0.00076620
+Radix Sort,333,291,0.00076750
+Radix Sort,333,292,0.00076660
+Radix Sort,333,293,0.00081940
+Radix Sort,333,294,0.00089250
+Radix Sort,333,295,0.00076900
+Radix Sort,333,296,0.00084920
+Radix Sort,333,297,0.00079520
+Radix Sort,333,298,0.00079530
+Radix Sort,333,299,0.00078750
+Radix Sort,333,300,0.00082460
+Radix Sort,333,301,0.00075330
+Radix Sort,333,302,0.00078180
+Radix Sort,333,303,0.00106550
+Radix Sort,333,304,0.00077980
+Radix Sort,333,305,0.00079600
+Radix Sort,333,306,0.00075570
+Radix Sort,333,307,0.00076690
+Radix Sort,333,308,0.00076600
+Radix Sort,333,309,0.00074370
+Radix Sort,333,310,0.00073480
+Radix Sort,333,311,0.00083570
+Radix Sort,333,312,0.00154440
+Radix Sort,333,313,0.00077590
+Radix Sort,333,314,0.00083440
+Radix Sort,333,315,0.00074050
+Radix Sort,333,316,0.00075830
+Radix Sort,333,317,0.00075360
+Radix Sort,333,318,0.00075100
+Radix Sort,333,319,0.00076650
+Radix Sort,333,320,0.00115480
+Radix Sort,333,321,0.00094510
+Radix Sort,333,322,0.00076400
+Radix Sort,333,323,0.00075330
+Radix Sort,333,324,0.00076330
+Radix Sort,333,325,0.00140740
+Radix Sort,333,326,0.00068710
+Radix Sort,333,327,0.00085640
+Radix Sort,333,328,0.00076260
+Radix Sort,333,329,0.00093870
+Radix Sort,333,330,0.00074360
+Radix Sort,333,331,0.00080560
+Radix Sort,333,332,0.00075140
+Radix Sort,333,333,0.00083010
+Radix Sort,333,334,0.00160680
+Radix Sort,333,335,0.00073060
+Radix Sort,333,336,0.00076620
+Radix Sort,333,337,0.00078740
+Radix Sort,333,338,0.00079340
+Radix Sort,333,339,0.00069220
+Radix Sort,333,340,0.00078220
+Radix Sort,333,341,0.00090660
+Radix Sort,333,342,0.00077450
+Radix Sort,333,343,0.00083480
+Radix Sort,333,344,0.00077890
+Radix Sort,333,345,0.00079730
+Radix Sort,333,346,0.00077420
+Radix Sort,333,347,0.00079750
+Radix Sort,333,348,0.00077890
+Radix Sort,333,349,0.00078460
+Radix Sort,333,350,0.00076390
+Radix Sort,333,351,0.00077530
+Radix Sort,333,352,0.00076820
+Radix Sort,333,353,0.00077950
+Radix Sort,333,354,0.00079840
+Radix Sort,333,355,0.00080230
+Radix Sort,333,356,0.00079590
+Radix Sort,333,357,0.00076470
+Radix Sort,333,358,0.00076880
+Radix Sort,333,359,0.00076670
+Radix Sort,333,360,0.00076190
+Radix Sort,333,361,0.00077470
+Radix Sort,333,362,0.00076460
+Radix Sort,333,363,0.00080480
+Radix Sort,333,364,0.00077630
+Radix Sort,333,365,0.00079510
+Radix Sort,333,366,0.00075830
+Radix Sort,333,367,0.00083510
+Radix Sort,333,368,0.00075070
+Radix Sort,333,369,0.00077600
+Radix Sort,333,370,0.00077150
+Radix Sort,333,371,0.00078730
+Radix Sort,333,372,0.00076170
+Radix Sort,333,373,0.00075860
+Radix Sort,333,374,0.00077820
+Radix Sort,333,375,0.00076270
+Radix Sort,333,376,0.00081980
+Radix Sort,333,377,0.00075810
+Radix Sort,333,378,0.00076180
+Radix Sort,333,379,0.00078330
+Radix Sort,333,380,0.00079000
+Radix Sort,333,381,0.00076260
+Radix Sort,333,382,0.00079740
+Radix Sort,333,383,0.00077300
+Radix Sort,333,384,0.00081730
+Radix Sort,333,385,0.00076510
+Radix Sort,333,386,0.00078800
+Radix Sort,333,387,0.00073310
+Radix Sort,333,388,0.00079840
+Radix Sort,333,389,0.00076920
+Radix Sort,333,390,0.00074990
+Radix Sort,333,391,0.00076670
+Radix Sort,333,392,0.00075490
+Radix Sort,333,393,0.00074250
+Radix Sort,333,394,0.00075400
+Radix Sort,333,395,0.00079970
+Radix Sort,333,396,0.00074870
+Radix Sort,333,397,0.00076090
+Radix Sort,333,398,0.00075090
+Radix Sort,333,399,0.00075340
+Radix Sort,333,400,0.00075630
+Radix Sort,333,401,0.00075930
+Radix Sort,333,402,0.00075140
+Radix Sort,333,403,0.00081980
+Radix Sort,333,404,0.00079540
+Radix Sort,333,405,0.00073970
+Radix Sort,333,406,0.00075830
+Radix Sort,333,407,0.00075660
+Radix Sort,333,408,0.00076230
+Radix Sort,333,409,0.00075720
+Radix Sort,333,410,0.00080600
+Radix Sort,333,411,0.00075280
+Radix Sort,333,412,0.00076520
+Radix Sort,333,413,0.00083410
+Radix Sort,333,414,0.00075520
+Radix Sort,333,415,0.00076110
+Radix Sort,333,416,0.00073600
+Radix Sort,333,417,0.00074800
+Radix Sort,333,418,0.00084320
+Radix Sort,333,419,0.00074010
+Radix Sort,333,420,0.00075270
+Radix Sort,333,421,0.00075160
+Radix Sort,333,422,0.00080670
+Radix Sort,333,423,0.00076100
+Radix Sort,333,424,0.00076790
+Radix Sort,333,425,0.00075350
+Radix Sort,333,426,0.00079550
+Radix Sort,333,427,0.00076930
+Radix Sort,333,428,0.00076670
+Radix Sort,333,429,0.00076740
+Radix Sort,333,430,0.00077570
+Radix Sort,333,431,0.00078150
+Radix Sort,333,432,0.00076730
+Radix Sort,333,433,0.00077420
+Radix Sort,333,434,0.00078360
+Radix Sort,333,435,0.00080330
+Radix Sort,333,436,0.00076180
+Radix Sort,333,437,0.00074400
+Radix Sort,333,438,0.00078110
+Radix Sort,333,439,0.00076470
+Radix Sort,333,440,0.00079760
+Radix Sort,333,441,0.00076190
+Radix Sort,333,442,0.00076980
+Radix Sort,333,443,0.00082410
+Radix Sort,333,444,0.00077070
+Radix Sort,333,445,0.00081730
+Radix Sort,333,446,0.00078030
+Radix Sort,333,447,0.00077290
+Radix Sort,333,448,0.00079790
+Radix Sort,333,449,0.00080920
+Radix Sort,333,450,0.00077380
+Radix Sort,333,451,0.00082230
+Radix Sort,333,452,0.00075620
+Radix Sort,333,453,0.00077720
+Radix Sort,333,454,0.00081180
+Radix Sort,333,455,0.00076310
+Radix Sort,333,456,0.00104570
+Radix Sort,333,457,0.00076620
+Radix Sort,333,458,0.00082740
+Radix Sort,333,459,0.00076170
+Radix Sort,333,460,0.00075760
+Radix Sort,333,461,0.00075580
+Radix Sort,333,462,0.00077920
+Radix Sort,333,463,0.00076150
+Radix Sort,333,464,0.00148420
+Radix Sort,333,465,0.00076190
+Radix Sort,333,466,0.00076520
+Radix Sort,333,467,0.00075310
+Radix Sort,333,468,0.00076300
+Radix Sort,333,469,0.00075220
+Radix Sort,333,470,0.00076280
+Radix Sort,333,471,0.00080040
+Radix Sort,333,472,0.00075680
+Radix Sort,333,473,0.00076720
+Radix Sort,333,474,0.00076200
+Radix Sort,333,475,0.00080870
+Radix Sort,333,476,0.00075160
+Radix Sort,333,477,0.00075940
+Radix Sort,333,478,0.00071240
+Radix Sort,333,479,0.00075210
+Radix Sort,333,480,0.00075500
+Radix Sort,333,481,0.00075340
+Radix Sort,333,482,0.00075440
+Radix Sort,333,483,0.00074830
+Radix Sort,333,484,0.00075360
+Radix Sort,333,485,0.00075150
+Radix Sort,333,486,0.00254510
+Radix Sort,333,487,0.00074960
+Radix Sort,333,488,0.00076890
+Radix Sort,333,489,0.00074870
+Radix Sort,333,490,0.00075450
+Radix Sort,333,491,0.00075740
+Radix Sort,333,492,0.00075300
+Radix Sort,333,493,0.00072430
+Radix Sort,333,494,0.00074970
+Radix Sort,333,495,0.00076250
+Radix Sort,333,496,0.00075350
+Radix Sort,333,497,0.00074950
+Radix Sort,333,498,0.00068200
+Radix Sort,333,499,0.00077460
+Radix Sort,333,500,0.00077760
+Replacement Selection Sort,333,1,0.00019430
+Replacement Selection Sort,333,2,0.00018460
+Replacement Selection Sort,333,3,0.00015930
+Replacement Selection Sort,333,4,0.00017700
+Replacement Selection Sort,333,5,0.00016800
+Replacement Selection Sort,333,6,0.00019350
+Replacement Selection Sort,333,7,0.00018140
+Replacement Selection Sort,333,8,0.00019480
+Replacement Selection Sort,333,9,0.00016700
+Replacement Selection Sort,333,10,0.00016130
+Replacement Selection Sort,333,11,0.00016640
+Replacement Selection Sort,333,12,0.00017090
+Replacement Selection Sort,333,13,0.00017270
+Replacement Selection Sort,333,14,0.00015550
+Replacement Selection Sort,333,15,0.00016620
+Replacement Selection Sort,333,16,0.00018000
+Replacement Selection Sort,333,17,0.00016300
+Replacement Selection Sort,333,18,0.00016810
+Replacement Selection Sort,333,19,0.00018130
+Replacement Selection Sort,333,20,0.00016420
+Replacement Selection Sort,333,21,0.00016610
+Replacement Selection Sort,333,22,0.00017000
+Replacement Selection Sort,333,23,0.00017280
+Replacement Selection Sort,333,24,0.00017080
+Replacement Selection Sort,333,25,0.00017760
+Replacement Selection Sort,333,26,0.00016860
+Replacement Selection Sort,333,27,0.00017130
+Replacement Selection Sort,333,28,0.00015010
+Replacement Selection Sort,333,29,0.00016830
+Replacement Selection Sort,333,30,0.00015850
+Replacement Selection Sort,333,31,0.00016710
+Replacement Selection Sort,333,32,0.00016300
+Replacement Selection Sort,333,33,0.00017350
+Replacement Selection Sort,333,34,0.00016470
+Replacement Selection Sort,333,35,0.00017460
+Replacement Selection Sort,333,36,0.00014940
+Replacement Selection Sort,333,37,0.00018170
+Replacement Selection Sort,333,38,0.00015490
+Replacement Selection Sort,333,39,0.00015380
+Replacement Selection Sort,333,40,0.00015610
+Replacement Selection Sort,333,41,0.00016640
+Replacement Selection Sort,333,42,0.00016520
+Replacement Selection Sort,333,43,0.00015960
+Replacement Selection Sort,333,44,0.00016320
+Replacement Selection Sort,333,45,0.00016160
+Replacement Selection Sort,333,46,0.00015850
+Replacement Selection Sort,333,47,0.00014490
+Replacement Selection Sort,333,48,0.00017360
+Replacement Selection Sort,333,49,0.00016470
+Replacement Selection Sort,333,50,0.00016260
+Replacement Selection Sort,333,51,0.00017310
+Replacement Selection Sort,333,52,0.00016560
+Replacement Selection Sort,333,53,0.00016820
+Replacement Selection Sort,333,54,0.00017810
+Replacement Selection Sort,333,55,0.00018640
+Replacement Selection Sort,333,56,0.00015950
+Replacement Selection Sort,333,57,0.00020980
+Replacement Selection Sort,333,58,0.00017030
+Replacement Selection Sort,333,59,0.00019390
+Replacement Selection Sort,333,60,0.00017000
+Replacement Selection Sort,333,61,0.00018340
+Replacement Selection Sort,333,62,0.00017200
+Replacement Selection Sort,333,63,0.00017100
+Replacement Selection Sort,333,64,0.00017490
+Replacement Selection Sort,333,65,0.00017190
+Replacement Selection Sort,333,66,0.00016400
+Replacement Selection Sort,333,67,0.00017230
+Replacement Selection Sort,333,68,0.00015530
+Replacement Selection Sort,333,69,0.00016940
+Replacement Selection Sort,333,70,0.00016280
+Replacement Selection Sort,333,71,0.00017550
+Replacement Selection Sort,333,72,0.00016390
+Replacement Selection Sort,333,73,0.00016270
+Replacement Selection Sort,333,74,0.00016180
+Replacement Selection Sort,333,75,0.00016380
+Replacement Selection Sort,333,76,0.00016130
+Replacement Selection Sort,333,77,0.00016690
+Replacement Selection Sort,333,78,0.00015270
+Replacement Selection Sort,333,79,0.00016790
+Replacement Selection Sort,333,80,0.00016370
+Replacement Selection Sort,333,81,0.00016560
+Replacement Selection Sort,333,82,0.00016310
+Replacement Selection Sort,333,83,0.00016520
+Replacement Selection Sort,333,84,0.00015140
+Replacement Selection Sort,333,85,0.00017090
+Replacement Selection Sort,333,86,0.00016790
+Replacement Selection Sort,333,87,0.00017280
+Replacement Selection Sort,333,88,0.00015310
+Replacement Selection Sort,333,89,0.00016020
+Replacement Selection Sort,333,90,0.00016170
+Replacement Selection Sort,333,91,0.00017140
+Replacement Selection Sort,333,92,0.00016460
+Replacement Selection Sort,333,93,0.00016090
+Replacement Selection Sort,333,94,0.00014050
+Replacement Selection Sort,333,95,0.00016190
+Replacement Selection Sort,333,96,0.00017250
+Replacement Selection Sort,333,97,0.00015940
+Replacement Selection Sort,333,98,0.00016650
+Replacement Selection Sort,333,99,0.00016890
+Replacement Selection Sort,333,100,0.00017670
+Replacement Selection Sort,333,101,0.00015330
+Replacement Selection Sort,333,102,0.00017090
+Replacement Selection Sort,333,103,0.00016390
+Replacement Selection Sort,333,104,0.00022040
+Replacement Selection Sort,333,105,0.00017400
+Replacement Selection Sort,333,106,0.00017130
+Replacement Selection Sort,333,107,0.00013160
+Replacement Selection Sort,333,108,0.00015550
+Replacement Selection Sort,333,109,0.00017200
+Replacement Selection Sort,333,110,0.00018980
+Replacement Selection Sort,333,111,0.00012640
+Replacement Selection Sort,333,112,0.00018560
+Replacement Selection Sort,333,113,0.00016290
+Replacement Selection Sort,333,114,0.00016380
+Replacement Selection Sort,333,115,0.00017370
+Replacement Selection Sort,333,116,0.00014850
+Replacement Selection Sort,333,117,0.00017080
+Replacement Selection Sort,333,118,0.00018820
+Replacement Selection Sort,333,119,0.00015660
+Replacement Selection Sort,333,120,0.00014330
+Replacement Selection Sort,333,121,0.00015860
+Replacement Selection Sort,333,122,0.00017400
+Replacement Selection Sort,333,123,0.00015060
+Replacement Selection Sort,333,124,0.00015450
+Replacement Selection Sort,333,125,0.00014840
+Replacement Selection Sort,333,126,0.00016310
+Replacement Selection Sort,333,127,0.00016690
+Replacement Selection Sort,333,128,0.00019930
+Replacement Selection Sort,333,129,0.00016070
+Replacement Selection Sort,333,130,0.00015880
+Replacement Selection Sort,333,131,0.00016080
+Replacement Selection Sort,333,132,0.00016010
+Replacement Selection Sort,333,133,0.00016390
+Replacement Selection Sort,333,134,0.00015450
+Replacement Selection Sort,333,135,0.00015860
+Replacement Selection Sort,333,136,0.00015210
+Replacement Selection Sort,333,137,0.00016750
+Replacement Selection Sort,333,138,0.00015900
+Replacement Selection Sort,333,139,0.00017010
+Replacement Selection Sort,333,140,0.00016130
+Replacement Selection Sort,333,141,0.00014850
+Replacement Selection Sort,333,142,0.00016550
+Replacement Selection Sort,333,143,0.00016760
+Replacement Selection Sort,333,144,0.00016140
+Replacement Selection Sort,333,145,0.00016910
+Replacement Selection Sort,333,146,0.00016800
+Replacement Selection Sort,333,147,0.00018740
+Replacement Selection Sort,333,148,0.00014890
+Replacement Selection Sort,333,149,0.00015570
+Replacement Selection Sort,333,150,0.00016400
+Replacement Selection Sort,333,151,0.00028940
+Replacement Selection Sort,333,152,0.00015650
+Replacement Selection Sort,333,153,0.00017420
+Replacement Selection Sort,333,154,0.00016260
+Replacement Selection Sort,333,155,0.00017970
+Replacement Selection Sort,333,156,0.00017060
+Replacement Selection Sort,333,157,0.00017680
+Replacement Selection Sort,333,158,0.00016630
+Replacement Selection Sort,333,159,0.00025110
+Replacement Selection Sort,333,160,0.00014540
+Replacement Selection Sort,333,161,0.00017490
+Replacement Selection Sort,333,162,0.00016380
+Replacement Selection Sort,333,163,0.00018090
+Replacement Selection Sort,333,164,0.00014890
+Replacement Selection Sort,333,165,0.00015760
+Replacement Selection Sort,333,166,0.00016640
+Replacement Selection Sort,333,167,0.00015300
+Replacement Selection Sort,333,168,0.00018490
+Replacement Selection Sort,333,169,0.00015590
+Replacement Selection Sort,333,170,0.00017100
+Replacement Selection Sort,333,171,0.00017010
+Replacement Selection Sort,333,172,0.00020430
+Replacement Selection Sort,333,173,0.00017740
+Replacement Selection Sort,333,174,0.00015810
+Replacement Selection Sort,333,175,0.00017740
+Replacement Selection Sort,333,176,0.00020480
+Replacement Selection Sort,333,177,0.00015470
+Replacement Selection Sort,333,178,0.00017840
+Replacement Selection Sort,333,179,0.00016580
+Replacement Selection Sort,333,180,0.00017310
+Replacement Selection Sort,333,181,0.00017320
+Replacement Selection Sort,333,182,0.00016280
+Replacement Selection Sort,333,183,0.00014740
+Replacement Selection Sort,333,184,0.00015670
+Replacement Selection Sort,333,185,0.00014990
+Replacement Selection Sort,333,186,0.00016230
+Replacement Selection Sort,333,187,0.00015980
+Replacement Selection Sort,333,188,0.00016090
+Replacement Selection Sort,333,189,0.00018630
+Replacement Selection Sort,333,190,0.00015760
+Replacement Selection Sort,333,191,0.00016270
+Replacement Selection Sort,333,192,0.00016260
+Replacement Selection Sort,333,193,0.00016330
+Replacement Selection Sort,333,194,0.00016930
+Replacement Selection Sort,333,195,0.00014010
+Replacement Selection Sort,333,196,0.00016560
+Replacement Selection Sort,333,197,0.00016240
+Replacement Selection Sort,333,198,0.00019550
+Replacement Selection Sort,333,199,0.00016910
+Replacement Selection Sort,333,200,0.00016980
+Replacement Selection Sort,333,201,0.00015570
+Replacement Selection Sort,333,202,0.00016600
+Replacement Selection Sort,333,203,0.00016330
+Replacement Selection Sort,333,204,0.00027790
+Replacement Selection Sort,333,205,0.00017200
+Replacement Selection Sort,333,206,0.00016890
+Replacement Selection Sort,333,207,0.00018400
+Replacement Selection Sort,333,208,0.00017230
+Replacement Selection Sort,333,209,0.00017530
+Replacement Selection Sort,333,210,0.00017340
+Replacement Selection Sort,333,211,0.00017750
+Replacement Selection Sort,333,212,0.00016690
+Replacement Selection Sort,333,213,0.00016140
+Replacement Selection Sort,333,214,0.00012720
+Replacement Selection Sort,333,215,0.00014320
+Replacement Selection Sort,333,216,0.00017590
+Replacement Selection Sort,333,217,0.00018050
+Replacement Selection Sort,333,218,0.00016480
+Replacement Selection Sort,333,219,0.00017330
+Replacement Selection Sort,333,220,0.00017110
+Replacement Selection Sort,333,221,0.00016230
+Replacement Selection Sort,333,222,0.00018670
+Replacement Selection Sort,333,223,0.00017860
+Replacement Selection Sort,333,224,0.00016230
+Replacement Selection Sort,333,225,0.00016380
+Replacement Selection Sort,333,226,0.00016100
+Replacement Selection Sort,333,227,0.00013720
+Replacement Selection Sort,333,228,0.00016270
+Replacement Selection Sort,333,229,0.00016410
+Replacement Selection Sort,333,230,0.00017020
+Replacement Selection Sort,333,231,0.00016790
+Replacement Selection Sort,333,232,0.00017420
+Replacement Selection Sort,333,233,0.00015910
+Replacement Selection Sort,333,234,0.00020360
+Replacement Selection Sort,333,235,0.00017120
+Replacement Selection Sort,333,236,0.00016480
+Replacement Selection Sort,333,237,0.00015660
+Replacement Selection Sort,333,238,0.00016250
+Replacement Selection Sort,333,239,0.00015140
+Replacement Selection Sort,333,240,0.00015110
+Replacement Selection Sort,333,241,0.00015050
+Replacement Selection Sort,333,242,0.00014700
+Replacement Selection Sort,333,243,0.00013460
+Replacement Selection Sort,333,244,0.00017200
+Replacement Selection Sort,333,245,0.00017280
+Replacement Selection Sort,333,246,0.00016770
+Replacement Selection Sort,333,247,0.00014410
+Replacement Selection Sort,333,248,0.00015770
+Replacement Selection Sort,333,249,0.00016510
+Replacement Selection Sort,333,250,0.00016050
+Replacement Selection Sort,333,251,0.00015090
+Replacement Selection Sort,333,252,0.00016130
+Replacement Selection Sort,333,253,0.00016000
+Replacement Selection Sort,333,254,0.00016200
+Replacement Selection Sort,333,255,0.00014850
+Replacement Selection Sort,333,256,0.00016520
+Replacement Selection Sort,333,257,0.00014940
+Replacement Selection Sort,333,258,0.00013120
+Replacement Selection Sort,333,259,0.00017430
+Replacement Selection Sort,333,260,0.00015470
+Replacement Selection Sort,333,261,0.00016410
+Replacement Selection Sort,333,262,0.00015300
+Replacement Selection Sort,333,263,0.00016050
+Replacement Selection Sort,333,264,0.00016460
+Replacement Selection Sort,333,265,0.00017100
+Replacement Selection Sort,333,266,0.00016360
+Replacement Selection Sort,333,267,0.00016750
+Replacement Selection Sort,333,268,0.00015700
+Replacement Selection Sort,333,269,0.00016110
+Replacement Selection Sort,333,270,0.00014960
+Replacement Selection Sort,333,271,0.00017160
+Replacement Selection Sort,333,272,0.00015370
+Replacement Selection Sort,333,273,0.00016570
+Replacement Selection Sort,333,274,0.00015660
+Replacement Selection Sort,333,275,0.00016530
+Replacement Selection Sort,333,276,0.00016460
+Replacement Selection Sort,333,277,0.00019690
+Replacement Selection Sort,333,278,0.00016720
+Replacement Selection Sort,333,279,0.00016710
+Replacement Selection Sort,333,280,0.00018050
+Replacement Selection Sort,333,281,0.00015660
+Replacement Selection Sort,333,282,0.00016580
+Replacement Selection Sort,333,283,0.00014890
+Replacement Selection Sort,333,284,0.00016560
+Replacement Selection Sort,333,285,0.00016070
+Replacement Selection Sort,333,286,0.00018780
+Replacement Selection Sort,333,287,0.00018080
+Replacement Selection Sort,333,288,0.00016760
+Replacement Selection Sort,333,289,0.00018710
+Replacement Selection Sort,333,290,0.00017430
+Replacement Selection Sort,333,291,0.00015500
+Replacement Selection Sort,333,292,0.00016320
+Replacement Selection Sort,333,293,0.00016510
+Replacement Selection Sort,333,294,0.00018170
+Replacement Selection Sort,333,295,0.00018360
+Replacement Selection Sort,333,296,0.00016510
+Replacement Selection Sort,333,297,0.00015720
+Replacement Selection Sort,333,298,0.00015550
+Replacement Selection Sort,333,299,0.00016840
+Replacement Selection Sort,333,300,0.00015700
+Replacement Selection Sort,333,301,0.00017820
+Replacement Selection Sort,333,302,0.00015660
+Replacement Selection Sort,333,303,0.00017860
+Replacement Selection Sort,333,304,0.00017500
+Replacement Selection Sort,333,305,0.00018740
+Replacement Selection Sort,333,306,0.00013930
+Replacement Selection Sort,333,307,0.00019710
+Replacement Selection Sort,333,308,0.00020770
+Replacement Selection Sort,333,309,0.00021010
+Replacement Selection Sort,333,310,0.00018780
+Replacement Selection Sort,333,311,0.00017890
+Replacement Selection Sort,333,312,0.00019550
+Replacement Selection Sort,333,313,0.00022550
+Replacement Selection Sort,333,314,0.00016790
+Replacement Selection Sort,333,315,0.00019240
+Replacement Selection Sort,333,316,0.00018130
+Replacement Selection Sort,333,317,0.00018680
+Replacement Selection Sort,333,318,0.00018350
+Replacement Selection Sort,333,319,0.00019320
+Replacement Selection Sort,333,320,0.00017950
+Replacement Selection Sort,333,321,0.00016460
+Replacement Selection Sort,333,322,0.00015680
+Replacement Selection Sort,333,323,0.00017700
+Replacement Selection Sort,333,324,0.00016290
+Replacement Selection Sort,333,325,0.00020140
+Replacement Selection Sort,333,326,0.00014300
+Replacement Selection Sort,333,327,0.00017330
+Replacement Selection Sort,333,328,0.00014120
+Replacement Selection Sort,333,329,0.00019010
+Replacement Selection Sort,333,330,0.00015310
+Replacement Selection Sort,333,331,0.00017400
+Replacement Selection Sort,333,332,0.00017650
+Replacement Selection Sort,333,333,0.00019810
+Replacement Selection Sort,333,334,0.00020030
+Replacement Selection Sort,333,335,0.00018960
+Replacement Selection Sort,333,336,0.00020170
+Replacement Selection Sort,333,337,0.00019270
+Replacement Selection Sort,333,338,0.00021160
+Replacement Selection Sort,333,339,0.00023270
+Replacement Selection Sort,333,340,0.00017080
+Replacement Selection Sort,333,341,0.00019400
+Replacement Selection Sort,333,342,0.00020020
+Replacement Selection Sort,333,343,0.00019910
+Replacement Selection Sort,333,344,0.00019990
+Replacement Selection Sort,333,345,0.00016250
+Replacement Selection Sort,333,346,0.00027590
+Replacement Selection Sort,333,347,0.00015490
+Replacement Selection Sort,333,348,0.00019170
+Replacement Selection Sort,333,349,0.00017830
+Replacement Selection Sort,333,350,0.00022550
+Replacement Selection Sort,333,351,0.00018170
+Replacement Selection Sort,333,352,0.00017160
+Replacement Selection Sort,333,353,0.00016540
+Replacement Selection Sort,333,354,0.00021060
+Replacement Selection Sort,333,355,0.00018910
+Replacement Selection Sort,333,356,0.00016580
+Replacement Selection Sort,333,357,0.00016110
+Replacement Selection Sort,333,358,0.00016630
+Replacement Selection Sort,333,359,0.00017890
+Replacement Selection Sort,333,360,0.00017580
+Replacement Selection Sort,333,361,0.00018240
+Replacement Selection Sort,333,362,0.00015190
+Replacement Selection Sort,333,363,0.00019520
+Replacement Selection Sort,333,364,0.00019250
+Replacement Selection Sort,333,365,0.00017250
+Replacement Selection Sort,333,366,0.00017760
+Replacement Selection Sort,333,367,0.00017110
+Replacement Selection Sort,333,368,0.00018290
+Replacement Selection Sort,333,369,0.00019490
+Replacement Selection Sort,333,370,0.00015740
+Replacement Selection Sort,333,371,0.00016570
+Replacement Selection Sort,333,372,0.00015780
+Replacement Selection Sort,333,373,0.00018850
+Replacement Selection Sort,333,374,0.00016880
+Replacement Selection Sort,333,375,0.00017670
+Replacement Selection Sort,333,376,0.00016490
+Replacement Selection Sort,333,377,0.00017580
+Replacement Selection Sort,333,378,0.00016090
+Replacement Selection Sort,333,379,0.00016080
+Replacement Selection Sort,333,380,0.00017210
+Replacement Selection Sort,333,381,0.00016280
+Replacement Selection Sort,333,382,0.00015390
+Replacement Selection Sort,333,383,0.00017790
+Replacement Selection Sort,333,384,0.00012980
+Replacement Selection Sort,333,385,0.00017780
+Replacement Selection Sort,333,386,0.00016600
+Replacement Selection Sort,333,387,0.00016460
+Replacement Selection Sort,333,388,0.00015570
+Replacement Selection Sort,333,389,0.00016580
+Replacement Selection Sort,333,390,0.00015990
+Replacement Selection Sort,333,391,0.00018450
+Replacement Selection Sort,333,392,0.00014600
+Replacement Selection Sort,333,393,0.00015410
+Replacement Selection Sort,333,394,0.00016130
+Replacement Selection Sort,333,395,0.00014590
+Replacement Selection Sort,333,396,0.00016150
+Replacement Selection Sort,333,397,0.00015610
+Replacement Selection Sort,333,398,0.00016300
+Replacement Selection Sort,333,399,0.00015590
+Replacement Selection Sort,333,400,0.00016400
+Replacement Selection Sort,333,401,0.00015310
+Replacement Selection Sort,333,402,0.00014360
+Replacement Selection Sort,333,403,0.00022610
+Replacement Selection Sort,333,404,0.00016780
+Replacement Selection Sort,333,405,0.00016680
+Replacement Selection Sort,333,406,0.00017570
+Replacement Selection Sort,333,407,0.00015570
+Replacement Selection Sort,333,408,0.00014210
+Replacement Selection Sort,333,409,0.00016410
+Replacement Selection Sort,333,410,0.00015160
+Replacement Selection Sort,333,411,0.00017860
+Replacement Selection Sort,333,412,0.00015870
+Replacement Selection Sort,333,413,0.00016620
+Replacement Selection Sort,333,414,0.00016130
+Replacement Selection Sort,333,415,0.00017980
+Replacement Selection Sort,333,416,0.00016400
+Replacement Selection Sort,333,417,0.00017220
+Replacement Selection Sort,333,418,0.00013940
+Replacement Selection Sort,333,419,0.00016290
+Replacement Selection Sort,333,420,0.00017010
+Replacement Selection Sort,333,421,0.00018180
+Replacement Selection Sort,333,422,0.00016980
+Replacement Selection Sort,333,423,0.00017890
+Replacement Selection Sort,333,424,0.00015810
+Replacement Selection Sort,333,425,0.00017210
+Replacement Selection Sort,333,426,0.00017560
+Replacement Selection Sort,333,427,0.00017510
+Replacement Selection Sort,333,428,0.00015900
+Replacement Selection Sort,333,429,0.00016370
+Replacement Selection Sort,333,430,0.00025950
+Replacement Selection Sort,333,431,0.00019530
+Replacement Selection Sort,333,432,0.00016020
+Replacement Selection Sort,333,433,0.00024460
+Replacement Selection Sort,333,434,0.00015920
+Replacement Selection Sort,333,435,0.00019040
+Replacement Selection Sort,333,436,0.00018890
+Replacement Selection Sort,333,437,0.00027140
+Replacement Selection Sort,333,438,0.00019000
+Replacement Selection Sort,333,439,0.00018450
+Replacement Selection Sort,333,440,0.00017090
+Replacement Selection Sort,333,441,0.00017340
+Replacement Selection Sort,333,442,0.00017540
+Replacement Selection Sort,333,443,0.00014280
+Replacement Selection Sort,333,444,0.00017530
+Replacement Selection Sort,333,445,0.00018120
+Replacement Selection Sort,333,446,0.00018730
+Replacement Selection Sort,333,447,0.00016760
+Replacement Selection Sort,333,448,0.00015390
+Replacement Selection Sort,333,449,0.00016090
+Replacement Selection Sort,333,450,0.00016820
+Replacement Selection Sort,333,451,0.00017690
+Replacement Selection Sort,333,452,0.00015280
+Replacement Selection Sort,333,453,0.00016270
+Replacement Selection Sort,333,454,0.00016470
+Replacement Selection Sort,333,455,0.00016010
+Replacement Selection Sort,333,456,0.00016640
+Replacement Selection Sort,333,457,0.00017760
+Replacement Selection Sort,333,458,0.00016430
+Replacement Selection Sort,333,459,0.00015080
+Replacement Selection Sort,333,460,0.00017660
+Replacement Selection Sort,333,461,0.00016450
+Replacement Selection Sort,333,462,0.00016620
+Replacement Selection Sort,333,463,0.00013900
+Replacement Selection Sort,333,464,0.00014230
+Replacement Selection Sort,333,465,0.00013600
+Replacement Selection Sort,333,466,0.00017310
+Replacement Selection Sort,333,467,0.00016230
+Replacement Selection Sort,333,468,0.00016200
+Replacement Selection Sort,333,469,0.00015990
+Replacement Selection Sort,333,470,0.00015250
+Replacement Selection Sort,333,471,0.00016010
+Replacement Selection Sort,333,472,0.00013280
+Replacement Selection Sort,333,473,0.00012330
+Replacement Selection Sort,333,474,0.00015100
+Replacement Selection Sort,333,475,0.00015990
+Replacement Selection Sort,333,476,0.00015330
+Replacement Selection Sort,333,477,0.00016530
+Replacement Selection Sort,333,478,0.00015600
+Replacement Selection Sort,333,479,0.00014540
+Replacement Selection Sort,333,480,0.00015350
+Replacement Selection Sort,333,481,0.00014670
+Replacement Selection Sort,333,482,0.00014740
+Replacement Selection Sort,333,483,0.00016450
+Replacement Selection Sort,333,484,0.00015070
+Replacement Selection Sort,333,485,0.00016600
+Replacement Selection Sort,333,486,0.00016100
+Replacement Selection Sort,333,487,0.00016470
+Replacement Selection Sort,333,488,0.00013660
+Replacement Selection Sort,333,489,0.00015390
+Replacement Selection Sort,333,490,0.00013970
+Replacement Selection Sort,333,491,0.00016230
+Replacement Selection Sort,333,492,0.00020660
+Replacement Selection Sort,333,493,0.00015830
+Replacement Selection Sort,333,494,0.00015180
+Replacement Selection Sort,333,495,0.00016300
+Replacement Selection Sort,333,496,0.00015110
+Replacement Selection Sort,333,497,0.00015050
+Replacement Selection Sort,333,498,0.00014580
+Replacement Selection Sort,333,499,0.00016970
+Replacement Selection Sort,333,500,0.00015630
+Sample Sort,333,1,0.00102120
+Sample Sort,333,2,0.00111910
+Sample Sort,333,3,0.00113080
+Sample Sort,333,4,0.00114120
+Sample Sort,333,5,0.00110550
+Sample Sort,333,6,0.00120350
+Sample Sort,333,7,0.00109220
+Sample Sort,333,8,0.00109670
+Sample Sort,333,9,0.00115130
+Sample Sort,333,10,0.00112120
+Sample Sort,333,11,0.00107770
+Sample Sort,333,12,0.00116250
+Sample Sort,333,13,0.00106880
+Sample Sort,333,14,0.00108480
+Sample Sort,333,15,0.00107390
+Sample Sort,333,16,0.00109200
+Sample Sort,333,17,0.00111470
+Sample Sort,333,18,0.00101780
+Sample Sort,333,19,0.00115370
+Sample Sort,333,20,0.00109400
+Sample Sort,333,21,0.00105460
+Sample Sort,333,22,0.00106710
+Sample Sort,333,23,0.00107540
+Sample Sort,333,24,0.00111900
+Sample Sort,333,25,0.00119180
+Sample Sort,333,26,0.00106630
+Sample Sort,333,27,0.00108090
+Sample Sort,333,28,0.00105300
+Sample Sort,333,29,0.00105150
+Sample Sort,333,30,0.00106430
+Sample Sort,333,31,0.00120260
+Sample Sort,333,32,0.00105150
+Sample Sort,333,33,0.00200840
+Sample Sort,333,34,0.00105240
+Sample Sort,333,35,0.00114480
+Sample Sort,333,36,0.00108910
+Sample Sort,333,37,0.00129330
+Sample Sort,333,38,0.00100590
+Sample Sort,333,39,0.00106510
+Sample Sort,333,40,0.00107940
+Sample Sort,333,41,0.00107750
+Sample Sort,333,42,0.00109860
+Sample Sort,333,43,0.00113910
+Sample Sort,333,44,0.00105060
+Sample Sort,333,45,0.00108680
+Sample Sort,333,46,0.00110560
+Sample Sort,333,47,0.00095890
+Sample Sort,333,48,0.00116990
+Sample Sort,333,49,0.00106680
+Sample Sort,333,50,0.00157920
+Sample Sort,333,51,0.00106980
+Sample Sort,333,52,0.00101310
+Sample Sort,333,53,0.00125690
+Sample Sort,333,54,0.00110410
+Sample Sort,333,55,0.00103500
+Sample Sort,333,56,0.00162650
+Sample Sort,333,57,0.00107270
+Sample Sort,333,58,0.00108330
+Sample Sort,333,59,0.00106220
+Sample Sort,333,60,0.00114990
+Sample Sort,333,61,0.00108300
+Sample Sort,333,62,0.00107520
+Sample Sort,333,63,0.00108650
+Sample Sort,333,64,0.00106050
+Sample Sort,333,65,0.00152500
+Sample Sort,333,66,0.00115520
+Sample Sort,333,67,0.00102090
+Sample Sort,333,68,0.00108130
+Sample Sort,333,69,0.00105470
+Sample Sort,333,70,0.00103900
+Sample Sort,333,71,0.00105910
+Sample Sort,333,72,0.00101300
+Sample Sort,333,73,0.00106590
+Sample Sort,333,74,0.00104940
+Sample Sort,333,75,0.00103830
+Sample Sort,333,76,0.00111870
+Sample Sort,333,77,0.00105830
+Sample Sort,333,78,0.00112570
+Sample Sort,333,79,0.00382600
+Sample Sort,333,80,0.00123060
+Sample Sort,333,81,0.00105230
+Sample Sort,333,82,0.00113510
+Sample Sort,333,83,0.00107060
+Sample Sort,333,84,0.00108530
+Sample Sort,333,85,0.00105330
+Sample Sort,333,86,0.00106170
+Sample Sort,333,87,0.00110930
+Sample Sort,333,88,0.00108880
+Sample Sort,333,89,0.00109390
+Sample Sort,333,90,0.00108310
+Sample Sort,333,91,0.00142540
+Sample Sort,333,92,0.00114310
+Sample Sort,333,93,0.00109050
+Sample Sort,333,94,0.00110950
+Sample Sort,333,95,0.00105740
+Sample Sort,333,96,0.00104750
+Sample Sort,333,97,0.00291900
+Sample Sort,333,98,0.00113120
+Sample Sort,333,99,0.00100430
+Sample Sort,333,100,0.00110410
+Sample Sort,333,101,0.00132050
+Sample Sort,333,102,0.00104480
+Sample Sort,333,103,0.00109170
+Sample Sort,333,104,0.00096650
+Sample Sort,333,105,0.00105000
+Sample Sort,333,106,0.00104120
+Sample Sort,333,107,0.00116940
+Sample Sort,333,108,0.00086340
+Sample Sort,333,109,0.00106720
+Sample Sort,333,110,0.00103950
+Sample Sort,333,111,0.00103480
+Sample Sort,333,112,0.00117580
+Sample Sort,333,113,0.00106980
+Sample Sort,333,114,0.00091390
+Sample Sort,333,115,0.00109220
+Sample Sort,333,116,0.00104220
+Sample Sort,333,117,0.00103530
+Sample Sort,333,118,0.00096360
+Sample Sort,333,119,0.00117950
+Sample Sort,333,120,0.00106580
+Sample Sort,333,121,0.00112170
+Sample Sort,333,122,0.00101180
+Sample Sort,333,123,0.00102760
+Sample Sort,333,124,0.00106160
+Sample Sort,333,125,0.00109170
+Sample Sort,333,126,0.00117460
+Sample Sort,333,127,0.00312150
+Sample Sort,333,128,0.00104690
+Sample Sort,333,129,0.00109310
+Sample Sort,333,130,0.00112210
+Sample Sort,333,131,0.00115240
+Sample Sort,333,132,0.00103780
+Sample Sort,333,133,0.00105740
+Sample Sort,333,134,0.00105600
+Sample Sort,333,135,0.00116480
+Sample Sort,333,136,0.00092920
+Sample Sort,333,137,0.00113790
+Sample Sort,333,138,0.00106420
+Sample Sort,333,139,0.00113710
+Sample Sort,333,140,0.00105080
+Sample Sort,333,141,0.00096050
+Sample Sort,333,142,0.00139900
+Sample Sort,333,143,0.00103040
+Sample Sort,333,144,0.00147950
+Sample Sort,333,145,0.00087170
+Sample Sort,333,146,0.00105640
+Sample Sort,333,147,0.00090920
+Sample Sort,333,148,0.00131490
+Sample Sort,333,149,0.00096180
+Sample Sort,333,150,0.00113780
+Sample Sort,333,151,0.00107420
+Sample Sort,333,152,0.00096480
+Sample Sort,333,153,0.00122850
+Sample Sort,333,154,0.00094020
+Sample Sort,333,155,0.00110130
+Sample Sort,333,156,0.00115400
+Sample Sort,333,157,0.00107790
+Sample Sort,333,158,0.00114530
+Sample Sort,333,159,0.00108710
+Sample Sort,333,160,0.00108970
+Sample Sort,333,161,0.00108730
+Sample Sort,333,162,0.00121190
+Sample Sort,333,163,0.00244870
+Sample Sort,333,164,0.00108540
+Sample Sort,333,165,0.00109150
+Sample Sort,333,166,0.03294160
+Sample Sort,333,167,0.00109120
+Sample Sort,333,168,0.00106970
+Sample Sort,333,169,0.00126180
+Sample Sort,333,170,0.00105920
+Sample Sort,333,171,0.00105270
+Sample Sort,333,172,0.00105500
+Sample Sort,333,173,0.00107670
+Sample Sort,333,174,0.00109720
+Sample Sort,333,175,0.00110490
+Sample Sort,333,176,0.00109470
+Sample Sort,333,177,0.00104870
+Sample Sort,333,178,0.00108590
+Sample Sort,333,179,0.00112160
+Sample Sort,333,180,0.00106790
+Sample Sort,333,181,0.00112040
+Sample Sort,333,182,0.00117180
+Sample Sort,333,183,0.00107300
+Sample Sort,333,184,0.00111150
+Sample Sort,333,185,0.00111900
+Sample Sort,333,186,0.00106770
+Sample Sort,333,187,0.00112280
+Sample Sort,333,188,0.00122860
+Sample Sort,333,189,0.00110250
+Sample Sort,333,190,0.00111990
+Sample Sort,333,191,0.00116880
+Sample Sort,333,192,0.00122410
+Sample Sort,333,193,0.00121560
+Sample Sort,333,194,0.00107680
+Sample Sort,333,195,0.00119260
+Sample Sort,333,196,0.00110730
+Sample Sort,333,197,0.00117000
+Sample Sort,333,198,0.00114430
+Sample Sort,333,199,0.00106650
+Sample Sort,333,200,0.00106270
+Sample Sort,333,201,0.00108070
+Sample Sort,333,202,0.00106420
+Sample Sort,333,203,0.00116650
+Sample Sort,333,204,0.00112550
+Sample Sort,333,205,0.00106620
+Sample Sort,333,206,0.00107110
+Sample Sort,333,207,0.00108210
+Sample Sort,333,208,0.00112240
+Sample Sort,333,209,0.00116350
+Sample Sort,333,210,0.00107170
+Sample Sort,333,211,0.00105480
+Sample Sort,333,212,0.00106560
+Sample Sort,333,213,0.00108980
+Sample Sort,333,214,0.00112770
+Sample Sort,333,215,0.00117560
+Sample Sort,333,216,0.00107130
+Sample Sort,333,217,0.02643940
+Sample Sort,333,218,0.00107130
+Sample Sort,333,219,0.00112290
+Sample Sort,333,220,0.00111940
+Sample Sort,333,221,0.00116820
+Sample Sort,333,222,0.00105560
+Sample Sort,333,223,0.00106020
+Sample Sort,333,224,0.00110450
+Sample Sort,333,225,0.00111700
+Sample Sort,333,226,0.00116550
+Sample Sort,333,227,0.00106380
+Sample Sort,333,228,0.00106460
+Sample Sort,333,229,0.00109180
+Sample Sort,333,230,0.00113020
+Sample Sort,333,231,0.00106550
+Sample Sort,333,232,0.00116450
+Sample Sort,333,233,0.00105820
+Sample Sort,333,234,0.00108430
+Sample Sort,333,235,0.00131190
+Sample Sort,333,236,0.00105070
+Sample Sort,333,237,0.00105750
+Sample Sort,333,238,0.00155870
+Sample Sort,333,239,0.00116760
+Sample Sort,333,240,0.00107820
+Sample Sort,333,241,0.00110790
+Sample Sort,333,242,0.00097860
+Sample Sort,333,243,0.00114910
+Sample Sort,333,244,0.00119200
+Sample Sort,333,245,0.00107640
+Sample Sort,333,246,0.00099100
+Sample Sort,333,247,0.00118170
+Sample Sort,333,248,0.00115980
+Sample Sort,333,249,0.00115010
+Sample Sort,333,250,0.00123940
+Sample Sort,333,251,0.00114350
+Sample Sort,333,252,0.00105990
+Sample Sort,333,253,0.00117110
+Sample Sort,333,254,0.00111520
+Sample Sort,333,255,0.00108600
+Sample Sort,333,256,0.00102490
+Sample Sort,333,257,0.00106840
+Sample Sort,333,258,0.00114960
+Sample Sort,333,259,0.00084230
+Sample Sort,333,260,0.00103880
+Sample Sort,333,261,0.00097690
+Sample Sort,333,262,0.00107360
+Sample Sort,333,263,0.00084490
+Sample Sort,333,264,0.00115880
+Sample Sort,333,265,0.00104590
+Sample Sort,333,266,0.00098770
+Sample Sort,333,267,0.00108080
+Sample Sort,333,268,0.00108180
+Sample Sort,333,269,0.00115700
+Sample Sort,333,270,0.00115230
+Sample Sort,333,271,0.00103220
+Sample Sort,333,272,0.00107860
+Sample Sort,333,273,0.00131430
+Sample Sort,333,274,0.00115800
+Sample Sort,333,275,0.00114120
+Sample Sort,333,276,0.00134260
+Sample Sort,333,277,0.00109500
+Sample Sort,333,278,0.00106070
+Sample Sort,333,279,0.00116120
+Sample Sort,333,280,0.00108830
+Sample Sort,333,281,0.00131860
+Sample Sort,333,282,0.00107550
+Sample Sort,333,283,0.00114670
+Sample Sort,333,284,0.00115790
+Sample Sort,333,285,0.00107410
+Sample Sort,333,286,0.00106920
+Sample Sort,333,287,0.00107840
+Sample Sort,333,288,0.00108360
+Sample Sort,333,289,0.00114700
+Sample Sort,333,290,0.00107030
+Sample Sort,333,291,0.00106480
+Sample Sort,333,292,0.00164750
+Sample Sort,333,293,0.00153600
+Sample Sort,333,294,0.00112100
+Sample Sort,333,295,0.00119690
+Sample Sort,333,296,0.00114440
+Sample Sort,333,297,0.00106070
+Sample Sort,333,298,0.00083440
+Sample Sort,333,299,0.00111040
+Sample Sort,333,300,0.00120450
+Sample Sort,333,301,0.00874340
+Sample Sort,333,302,0.00132480
+Sample Sort,333,303,0.00133290
+Sample Sort,333,304,0.00089450
+Sample Sort,333,305,0.00095620
+Sample Sort,333,306,0.00115180
+Sample Sort,333,307,0.00131810
+Sample Sort,333,308,0.00109920
+Sample Sort,333,309,0.00127530
+Sample Sort,333,310,0.00102230
+Sample Sort,333,311,0.00114990
+Sample Sort,333,312,0.00108670
+Sample Sort,333,313,0.00109450
+Sample Sort,333,314,0.00091530
+Sample Sort,333,315,0.00111170
+Sample Sort,333,316,0.00109810
+Sample Sort,333,317,0.00131350
+Sample Sort,333,318,0.00114950
+Sample Sort,333,319,0.00107560
+Sample Sort,333,320,0.00109170
+Sample Sort,333,321,0.00109510
+Sample Sort,333,322,0.00110000
+Sample Sort,333,323,0.00210610
+Sample Sort,333,324,0.00114460
+Sample Sort,333,325,0.00108830
+Sample Sort,333,326,0.00107940
+Sample Sort,333,327,0.00111130
+Sample Sort,333,328,0.00109530
+Sample Sort,333,329,0.00110960
+Sample Sort,333,330,0.00115250
+Sample Sort,333,331,0.00108020
+Sample Sort,333,332,0.00106870
+Sample Sort,333,333,0.00119000
+Sample Sort,333,334,0.00108870
+Sample Sort,333,335,0.00106000
+Sample Sort,333,336,0.00105870
+Sample Sort,333,337,0.00115130
+Sample Sort,333,338,0.00107720
+Sample Sort,333,339,0.00105260
+Sample Sort,333,340,0.00155590
+Sample Sort,333,341,0.00113160
+Sample Sort,333,342,0.00108460
+Sample Sort,333,343,0.00106680
+Sample Sort,333,344,0.00111200
+Sample Sort,333,345,0.00111330
+Sample Sort,333,346,0.00115120
+Sample Sort,333,347,0.00106000
+Sample Sort,333,348,0.00107080
+Sample Sort,333,349,0.00109330
+Sample Sort,333,350,0.00108710
+Sample Sort,333,351,0.00111570
+Sample Sort,333,352,0.00107350
+Sample Sort,333,353,0.00114270
+Sample Sort,333,354,0.00105390
+Sample Sort,333,355,0.00114420
+Sample Sort,333,356,0.00113140
+Sample Sort,333,357,0.00107270
+Sample Sort,333,358,0.00107950
+Sample Sort,333,359,0.00106100
+Sample Sort,333,360,0.00105420
+Sample Sort,333,361,0.00114740
+Sample Sort,333,362,0.00111970
+Sample Sort,333,363,0.00106410
+Sample Sort,333,364,0.00106370
+Sample Sort,333,365,0.00125700
+Sample Sort,333,366,0.00115440
+Sample Sort,333,367,0.00113350
+Sample Sort,333,368,0.00099310
+Sample Sort,333,369,0.00114460
+Sample Sort,333,370,0.00118420
+Sample Sort,333,371,0.00131240
+Sample Sort,333,372,0.00120190
+Sample Sort,333,373,0.00116000
+Sample Sort,333,374,0.00108910
+Sample Sort,333,375,0.00099420
+Sample Sort,333,376,0.00116300
+Sample Sort,333,377,0.00108350
+Sample Sort,333,378,0.00112370
+Sample Sort,333,379,0.00110740
+Sample Sort,333,380,0.00098390
+Sample Sort,333,381,0.00108250
+Sample Sort,333,382,0.00115480
+Sample Sort,333,383,0.00109300
+Sample Sort,333,384,0.00113110
+Sample Sort,333,385,0.00098360
+Sample Sort,333,386,0.00112040
+Sample Sort,333,387,0.00108910
+Sample Sort,333,388,0.00121070
+Sample Sort,333,389,0.00112870
+Sample Sort,333,390,0.00109980
+Sample Sort,333,391,0.00103870
+Sample Sort,333,392,0.00108240
+Sample Sort,333,393,0.00108100
+Sample Sort,333,394,0.00106620
+Sample Sort,333,395,0.00117250
+Sample Sort,333,396,0.00105360
+Sample Sort,333,397,0.00111740
+Sample Sort,333,398,0.00106170
+Sample Sort,333,399,0.00108100
+Sample Sort,333,400,0.00108090
+Sample Sort,333,401,0.00105810
+Sample Sort,333,402,0.00119900
+Sample Sort,333,403,0.00105810
+Sample Sort,333,404,0.00105960
+Sample Sort,333,405,0.00112260
+Sample Sort,333,406,0.00107460
+Sample Sort,333,407,0.00107720
+Sample Sort,333,408,0.00105920
+Sample Sort,333,409,0.00106520
+Sample Sort,333,410,0.00120620
+Sample Sort,333,411,0.00105990
+Sample Sort,333,412,0.00107760
+Sample Sort,333,413,0.00113080
+Sample Sort,333,414,0.00108020
+Sample Sort,333,415,0.00106270
+Sample Sort,333,416,0.00107180
+Sample Sort,333,417,0.00106630
+Sample Sort,333,418,0.00121830
+Sample Sort,333,419,0.00107370
+Sample Sort,333,420,0.00113440
+Sample Sort,333,421,0.00108240
+Sample Sort,333,422,0.00105620
+Sample Sort,333,423,0.00107360
+Sample Sort,333,424,0.00105940
+Sample Sort,333,425,0.00107470
+Sample Sort,333,426,0.00116080
+Sample Sort,333,427,0.00121320
+Sample Sort,333,428,0.00107940
+Sample Sort,333,429,0.00105620
+Sample Sort,333,430,0.00112030
+Sample Sort,333,431,0.00108990
+Sample Sort,333,432,0.00162340
+Sample Sort,333,433,0.00111350
+Sample Sort,333,434,0.00108780
+Sample Sort,333,435,0.00754740
+Sample Sort,333,436,0.00105700
+Sample Sort,333,437,0.00107120
+Sample Sort,333,438,0.00106880
+Sample Sort,333,439,0.00111820
+Sample Sort,333,440,0.00107210
+Sample Sort,333,441,0.00153540
+Sample Sort,333,442,0.00108480
+Sample Sort,333,443,0.00101320
+Sample Sort,333,444,0.00111540
+Sample Sort,333,445,0.00708970
+Sample Sort,333,446,0.00106320
+Sample Sort,333,447,0.00102330
+Sample Sort,333,448,0.00108900
+Sample Sort,333,449,0.00118730
+Sample Sort,333,450,0.00106600
+Sample Sort,333,451,0.00108550
+Sample Sort,333,452,0.00104800
+Sample Sort,333,453,0.00504530
+Sample Sort,333,454,0.00118140
+Sample Sort,333,455,0.00104770
+Sample Sort,333,456,0.00110940
+Sample Sort,333,457,0.00106070
+Sample Sort,333,458,0.00146600
+Sample Sort,333,459,0.00118090
+Sample Sort,333,460,0.00105660
+Sample Sort,333,461,0.00108340
+Sample Sort,333,462,0.00105330
+Sample Sort,333,463,0.00108200
+Sample Sort,333,464,0.00117740
+Sample Sort,333,465,0.00106160
+Sample Sort,333,466,0.00214570
+Sample Sort,333,467,0.00108210
+Sample Sort,333,468,0.00105510
+Sample Sort,333,469,0.00149880
+Sample Sort,333,470,0.00106290
+Sample Sort,333,471,0.00118710
+Sample Sort,333,472,0.00107430
+Sample Sort,333,473,0.00117550
+Sample Sort,333,474,0.00157550
+Sample Sort,333,475,0.00106390
+Sample Sort,333,476,0.00117670
+Sample Sort,333,477,0.00208800
+Sample Sort,333,478,0.00107750
+Sample Sort,333,479,0.00153890
+Sample Sort,333,480,0.00112090
+Sample Sort,333,481,0.00106800
+Sample Sort,333,482,0.00109040
+Sample Sort,333,483,0.00117620
+Sample Sort,333,484,0.00107680
+Sample Sort,333,485,0.00108470
+Sample Sort,333,486,0.00156860
+Sample Sort,333,487,0.00124600
+Sample Sort,333,488,0.00156490
+Sample Sort,333,489,0.00105850
+Sample Sort,333,490,0.00118340
+Sample Sort,333,491,0.00173320
+Sample Sort,333,492,0.00149670
+Sample Sort,333,493,0.00164670
+Sample Sort,333,494,0.00105310
+Sample Sort,333,495,0.00109880
+Sample Sort,333,496,0.00120160
+Sample Sort,333,497,0.00110790
+Sample Sort,333,498,0.00107450
+Sample Sort,333,499,0.00105500
+Sample Sort,333,500,0.01255380
+Selection Sort,333,1,0.00328820
+Selection Sort,333,2,0.00339580
+Selection Sort,333,3,0.00344280
+Selection Sort,333,4,0.00672060
+Selection Sort,333,5,0.00328470
+Selection Sort,333,6,0.00389140
+Selection Sort,333,7,0.00328000
+Selection Sort,333,8,0.00337360
+Selection Sort,333,9,0.00328390
+Selection Sort,333,10,0.00331180
+Selection Sort,333,11,0.00377750
+Selection Sort,333,12,0.00326620
+Selection Sort,333,13,0.00337860
+Selection Sort,333,14,0.00428490
+Selection Sort,333,15,0.00319080
+Selection Sort,333,16,0.00332560
+Selection Sort,333,17,0.00485300
+Selection Sort,333,18,0.00327670
+Selection Sort,333,19,0.02121310
+Selection Sort,333,20,0.00339540
+Selection Sort,333,21,0.00338950
+Selection Sort,333,22,0.00377720
+Selection Sort,333,23,0.00396840
+Selection Sort,333,24,0.00479420
+Selection Sort,333,25,0.00368150
+Selection Sort,333,26,0.00893530
+Selection Sort,333,27,0.00479480
+Selection Sort,333,28,0.00328960
+Selection Sort,333,29,0.00347380
+Selection Sort,333,30,0.00392000
+Selection Sort,333,31,0.00382510
+Selection Sort,333,32,0.00365410
+Selection Sort,333,33,0.00330380
+Selection Sort,333,34,0.00381990
+Selection Sort,333,35,0.00396730
+Selection Sort,333,36,0.00392370
+Selection Sort,333,37,0.00378830
+Selection Sort,333,38,0.03078360
+Selection Sort,333,39,0.00314200
+Selection Sort,333,40,0.00325920
+Selection Sort,333,41,0.01783820
+Selection Sort,333,42,0.00453390
+Selection Sort,333,43,0.00445970
+Selection Sort,333,44,0.00358250
+Selection Sort,333,45,0.00332070
+Selection Sort,333,46,0.00415040
+Selection Sort,333,47,0.00303600
+Selection Sort,333,48,0.00375370
+Selection Sort,333,49,0.00327180
+Selection Sort,333,50,0.00294510
+Selection Sort,333,51,0.00326450
+Selection Sort,333,52,0.00443470
+Selection Sort,333,53,0.00457950
+Selection Sort,333,54,0.00288870
+Selection Sort,333,55,0.00325850
+Selection Sort,333,56,0.00497720
+Selection Sort,333,57,0.00326940
+Selection Sort,333,58,0.00317080
+Selection Sort,333,59,0.00482760
+Selection Sort,333,60,0.00318180
+Selection Sort,333,61,0.00325380
+Selection Sort,333,62,0.00327020
+Selection Sort,333,63,0.00370940
+Selection Sort,333,64,0.00450010
+Selection Sort,333,65,0.00318760
+Selection Sort,333,66,0.00313590
+Selection Sort,333,67,0.00326230
+Selection Sort,333,68,0.00328000
+Selection Sort,333,69,0.00343180
+Selection Sort,333,70,0.01016110
+Selection Sort,333,71,0.00377050
+Selection Sort,333,72,0.00322740
+Selection Sort,333,73,0.00297060
+Selection Sort,333,74,0.00392530
+Selection Sort,333,75,0.00324080
+Selection Sort,333,76,0.00340990
+Selection Sort,333,77,0.00451360
+Selection Sort,333,78,0.00351840
+Selection Sort,333,79,0.00319650
+Selection Sort,333,80,0.00387080
+Selection Sort,333,81,0.00325170
+Selection Sort,333,82,0.00326390
+Selection Sort,333,83,0.00530610
+Selection Sort,333,84,0.00431200
+Selection Sort,333,85,0.00313670
+Selection Sort,333,86,0.00318660
+Selection Sort,333,87,0.00329720
+Selection Sort,333,88,0.00325400
+Selection Sort,333,89,0.00325780
+Selection Sort,333,90,0.00443430
+Selection Sort,333,91,0.00650230
+Selection Sort,333,92,0.00333130
+Selection Sort,333,93,0.00473500
+Selection Sort,333,94,0.00330360
+Selection Sort,333,95,0.00385880
+Selection Sort,333,96,0.00326110
+Selection Sort,333,97,0.00481340
+Selection Sort,333,98,0.00325750
+Selection Sort,333,99,0.00307830
+Selection Sort,333,100,0.00333140
+Selection Sort,333,101,0.00343540
+Selection Sort,333,102,0.00338570
+Selection Sort,333,103,0.00338550
+Selection Sort,333,104,0.00397030
+Selection Sort,333,105,0.00323960
+Selection Sort,333,106,0.00356060
+Selection Sort,333,107,0.00652990
+Selection Sort,333,108,0.00386360
+Selection Sort,333,109,0.01264480
+Selection Sort,333,110,0.00326150
+Selection Sort,333,111,0.00339930
+Selection Sort,333,112,0.00312340
+Selection Sort,333,113,0.00304180
+Selection Sort,333,114,0.00420870
+Selection Sort,333,115,0.00432630
+Selection Sort,333,116,0.00414000
+Selection Sort,333,117,0.00331730
+Selection Sort,333,118,0.00324790
+Selection Sort,333,119,0.00324380
+Selection Sort,333,120,0.00290780
+Selection Sort,333,121,0.00395710
+Selection Sort,333,122,0.00331640
+Selection Sort,333,123,0.00391570
+Selection Sort,333,124,0.00403870
+Selection Sort,333,125,0.00326700
+Selection Sort,333,126,0.00326180
+Selection Sort,333,127,0.00362540
+Selection Sort,333,128,0.00399380
+Selection Sort,333,129,0.00483370
+Selection Sort,333,130,0.00341900
+Selection Sort,333,131,0.00326180
+Selection Sort,333,132,0.00331110
+Selection Sort,333,133,0.00327550
+Selection Sort,333,134,0.00471280
+Selection Sort,333,135,0.00385020
+Selection Sort,333,136,0.00391310
+Selection Sort,333,137,0.00325630
+Selection Sort,333,138,0.01209240
+Selection Sort,333,139,0.00325450
+Selection Sort,333,140,0.00319460
+Selection Sort,333,141,0.00327890
+Selection Sort,333,142,0.00406940
+Selection Sort,333,143,0.00519950
+Selection Sort,333,144,0.00330020
+Selection Sort,333,145,0.00530330
+Selection Sort,333,146,0.00311040
+Selection Sort,333,147,0.00325710
+Selection Sort,333,148,0.00335670
+Selection Sort,333,149,0.00463540
+Selection Sort,333,150,0.00326510
+Selection Sort,333,151,0.00373700
+Selection Sort,333,152,0.00332030
+Selection Sort,333,153,0.00325450
+Selection Sort,333,154,0.00594890
+Selection Sort,333,155,0.00348390
+Selection Sort,333,156,0.00454080
+Selection Sort,333,157,0.00377330
+Selection Sort,333,158,0.00326670
+Selection Sort,333,159,0.00333910
+Selection Sort,333,160,0.00351700
+Selection Sort,333,161,0.00326430
+Selection Sort,333,162,0.00330140
+Selection Sort,333,163,0.00398930
+Selection Sort,333,164,0.00527070
+Selection Sort,333,165,0.00516190
+Selection Sort,333,166,0.00340210
+Selection Sort,333,167,0.00330220
+Selection Sort,333,168,0.00343410
+Selection Sort,333,169,0.00824300
+Selection Sort,333,170,0.00406230
+Selection Sort,333,171,0.00325910
+Selection Sort,333,172,0.00411750
+Selection Sort,333,173,0.00333550
+Selection Sort,333,174,0.00327500
+Selection Sort,333,175,0.00444310
+Selection Sort,333,176,0.00325910
+Selection Sort,333,177,0.00331140
+Selection Sort,333,178,0.00395030
+Selection Sort,333,179,0.00392090
+Selection Sort,333,180,0.00332800
+Selection Sort,333,181,0.00326880
+Selection Sort,333,182,0.00329950
+Selection Sort,333,183,0.00325910
+Selection Sort,333,184,0.00440940
+Selection Sort,333,185,0.00367030
+Selection Sort,333,186,0.00326800
+Selection Sort,333,187,0.00408620
+Selection Sort,333,188,0.00359770
+Selection Sort,333,189,0.00329450
+Selection Sort,333,190,0.00329970
+Selection Sort,333,191,0.00329660
+Selection Sort,333,192,0.00325440
+Selection Sort,333,193,0.00328160
+Selection Sort,333,194,0.00336940
+Selection Sort,333,195,0.00330980
+Selection Sort,333,196,0.00366480
+Selection Sort,333,197,0.00418400
+Selection Sort,333,198,0.00417180
+Selection Sort,333,199,0.00321960
+Selection Sort,333,200,0.00325630
+Selection Sort,333,201,0.00327110
+Selection Sort,333,202,0.00326330
+Selection Sort,333,203,0.00486270
+Selection Sort,333,204,0.00335210
+Selection Sort,333,205,0.00326720
+Selection Sort,333,206,0.00328770
+Selection Sort,333,207,0.00630460
+Selection Sort,333,208,0.00339700
+Selection Sort,333,209,0.00364290
+Selection Sort,333,210,0.00326450
+Selection Sort,333,211,0.00325290
+Selection Sort,333,212,0.00279780
+Selection Sort,333,213,0.01565860
+Selection Sort,333,214,0.00325010
+Selection Sort,333,215,0.00366830
+Selection Sort,333,216,0.00325690
+Selection Sort,333,217,0.00324890
+Selection Sort,333,218,0.00373600
+Selection Sort,333,219,0.00325240
+Selection Sort,333,220,0.00346990
+Selection Sort,333,221,0.00330610
+Selection Sort,333,222,0.00325750
+Selection Sort,333,223,0.00363700
+Selection Sort,333,224,0.00326460
+Selection Sort,333,225,0.00913310
+Selection Sort,333,226,0.00329990
+Selection Sort,333,227,0.00331340
+Selection Sort,333,228,0.00448310
+Selection Sort,333,229,0.00334050
+Selection Sort,333,230,0.01303900
+Selection Sort,333,231,0.00371620
+Selection Sort,333,232,0.00320600
+Selection Sort,333,233,0.00326330
+Selection Sort,333,234,0.00327910
+Selection Sort,333,235,0.00327170
+Selection Sort,333,236,0.00579700
+Selection Sort,333,237,0.02065940
+Selection Sort,333,238,0.00382290
+Selection Sort,333,239,0.00327090
+Selection Sort,333,240,0.00328800
+Selection Sort,333,241,0.00327150
+Selection Sort,333,242,0.01385900
+Selection Sort,333,243,0.00959200
+Selection Sort,333,244,0.00355330
+Selection Sort,333,245,0.00339880
+Selection Sort,333,246,0.00328180
+Selection Sort,333,247,0.00510120
+Selection Sort,333,248,0.00331140
+Selection Sort,333,249,0.00336100
+Selection Sort,333,250,0.00407970
+Selection Sort,333,251,0.00326660
+Selection Sort,333,252,0.00862700
+Selection Sort,333,253,0.00388090
+Selection Sort,333,254,0.00401610
+Selection Sort,333,255,0.00345550
+Selection Sort,333,256,0.00335110
+Selection Sort,333,257,0.00348480
+Selection Sort,333,258,0.00328820
+Selection Sort,333,259,0.00419130
+Selection Sort,333,260,0.00331920
+Selection Sort,333,261,0.00320210
+Selection Sort,333,262,0.00368470
+Selection Sort,333,263,0.00334430
+Selection Sort,333,264,0.00326440
+Selection Sort,333,265,0.00351030
+Selection Sort,333,266,0.00567280
+Selection Sort,333,267,0.00370820
+Selection Sort,333,268,0.00331300
+Selection Sort,333,269,0.00503090
+Selection Sort,333,270,0.00380080
+Selection Sort,333,271,0.00328930
+Selection Sort,333,272,0.00326440
+Selection Sort,333,273,0.00537140
+Selection Sort,333,274,0.00342130
+Selection Sort,333,275,0.00333100
+Selection Sort,333,276,0.00367000
+Selection Sort,333,277,0.00328660
+Selection Sort,333,278,0.00329520
+Selection Sort,333,279,0.00328400
+Selection Sort,333,280,0.00444290
+Selection Sort,333,281,0.00362300
+Selection Sort,333,282,0.00326230
+Selection Sort,333,283,0.00331990
+Selection Sort,333,284,0.00344780
+Selection Sort,333,285,0.00357420
+Selection Sort,333,286,0.00327390
+Selection Sort,333,287,0.00329310
+Selection Sort,333,288,0.00346700
+Selection Sort,333,289,0.00324580
+Selection Sort,333,290,0.00546760
+Selection Sort,333,291,0.00563640
+Selection Sort,333,292,0.00334420
+Selection Sort,333,293,0.00331360
+Selection Sort,333,294,0.00326890
+Selection Sort,333,295,0.00325710
+Selection Sort,333,296,0.00329960
+Selection Sort,333,297,0.00386570
+Selection Sort,333,298,0.00365890
+Selection Sort,333,299,0.00336250
+Selection Sort,333,300,0.00331640
+Selection Sort,333,301,0.00328520
+Selection Sort,333,302,0.00327690
+Selection Sort,333,303,0.00328460
+Selection Sort,333,304,0.00330670
+Selection Sort,333,305,0.00373930
+Selection Sort,333,306,0.00360030
+Selection Sort,333,307,0.00376650
+Selection Sort,333,308,0.00337270
+Selection Sort,333,309,0.00333230
+Selection Sort,333,310,0.00327570
+Selection Sort,333,311,0.00743640
+Selection Sort,333,312,0.00337540
+Selection Sort,333,313,0.00336560
+Selection Sort,333,314,0.00520110
+Selection Sort,333,315,0.00387850
+Selection Sort,333,316,0.00341010
+Selection Sort,333,317,0.00327050
+Selection Sort,333,318,0.00471630
+Selection Sort,333,319,0.00331470
+Selection Sort,333,320,0.00468110
+Selection Sort,333,321,0.00352540
+Selection Sort,333,322,0.00346460
+Selection Sort,333,323,0.00328500
+Selection Sort,333,324,0.00415180
+Selection Sort,333,325,0.00406860
+Selection Sort,333,326,0.00344880
+Selection Sort,333,327,0.00326770
+Selection Sort,333,328,0.00333960
+Selection Sort,333,329,0.00426260
+Selection Sort,333,330,0.00339510
+Selection Sort,333,331,0.00327750
+Selection Sort,333,332,0.00414730
+Selection Sort,333,333,0.00327340
+Selection Sort,333,334,0.00347610
+Selection Sort,333,335,0.00365720
+Selection Sort,333,336,0.00326710
+Selection Sort,333,337,0.00399810
+Selection Sort,333,338,0.00336440
+Selection Sort,333,339,0.00331160
+Selection Sort,333,340,0.00412640
+Selection Sort,333,341,0.00395120
+Selection Sort,333,342,0.00328130
+Selection Sort,333,343,0.00415900
+Selection Sort,333,344,0.00349590
+Selection Sort,333,345,0.00374450
+Selection Sort,333,346,0.00333250
+Selection Sort,333,347,0.00328350
+Selection Sort,333,348,0.00379360
+Selection Sort,333,349,0.00339000
+Selection Sort,333,350,0.00333560
+Selection Sort,333,351,0.00332080
+Selection Sort,333,352,0.00460040
+Selection Sort,333,353,0.00447320
+Selection Sort,333,354,0.00330580
+Selection Sort,333,355,0.00328190
+Selection Sort,333,356,0.00346240
+Selection Sort,333,357,0.00439530
+Selection Sort,333,358,0.00366240
+Selection Sort,333,359,0.00335580
+Selection Sort,333,360,0.00337510
+Selection Sort,333,361,0.00335590
+Selection Sort,333,362,0.00327970
+Selection Sort,333,363,0.00331250
+Selection Sort,333,364,0.00327370
+Selection Sort,333,365,0.00429000
+Selection Sort,333,366,0.00358540
+Selection Sort,333,367,0.00338580
+Selection Sort,333,368,0.00325310
+Selection Sort,333,369,0.00333030
+Selection Sort,333,370,0.00362570
+Selection Sort,333,371,0.00327200
+Selection Sort,333,372,0.00329670
+Selection Sort,333,373,0.00342040
+Selection Sort,333,374,0.00329420
+Selection Sort,333,375,0.00327000
+Selection Sort,333,376,0.00362430
+Selection Sort,333,377,0.00325800
+Selection Sort,333,378,0.00326150
+Selection Sort,333,379,0.00331190
+Selection Sort,333,380,0.00411920
+Selection Sort,333,381,0.00327570
+Selection Sort,333,382,0.00359440
+Selection Sort,333,383,0.00397720
+Selection Sort,333,384,0.00372240
+Selection Sort,333,385,0.00327730
+Selection Sort,333,386,0.00330630
+Selection Sort,333,387,0.00326120
+Selection Sort,333,388,0.00328410
+Selection Sort,333,389,0.00333690
+Selection Sort,333,390,0.00331990
+Selection Sort,333,391,0.00328080
+Selection Sort,333,392,0.00343560
+Selection Sort,333,393,0.00410520
+Selection Sort,333,394,0.00381000
+Selection Sort,333,395,0.00365440
+Selection Sort,333,396,0.00327200
+Selection Sort,333,397,0.00327530
+Selection Sort,333,398,0.00325190
+Selection Sort,333,399,0.00332850
+Selection Sort,333,400,0.00435890
+Selection Sort,333,401,0.00349800
+Selection Sort,333,402,0.00368830
+Selection Sort,333,403,0.00325010
+Selection Sort,333,404,0.00345360
+Selection Sort,333,405,0.00339510
+Selection Sort,333,406,0.00408240
+Selection Sort,333,407,0.00393100
+Selection Sort,333,408,0.00333070
+Selection Sort,333,409,0.00369300
+Selection Sort,333,410,0.00527840
+Selection Sort,333,411,0.00330720
+Selection Sort,333,412,0.00418490
+Selection Sort,333,413,0.00329400
+Selection Sort,333,414,0.00329620
+Selection Sort,333,415,0.00335460
+Selection Sort,333,416,0.00331080
+Selection Sort,333,417,0.00332770
+Selection Sort,333,418,0.00370430
+Selection Sort,333,419,0.00332360
+Selection Sort,333,420,0.00435900
+Selection Sort,333,421,0.00369280
+Selection Sort,333,422,0.00343530
+Selection Sort,333,423,0.00326220
+Selection Sort,333,424,0.00331060
+Selection Sort,333,425,0.00332540
+Selection Sort,333,426,0.00484270
+Selection Sort,333,427,0.00329970
+Selection Sort,333,428,0.00641020
+Selection Sort,333,429,0.00328100
+Selection Sort,333,430,0.00316880
+Selection Sort,333,431,0.00425980
+Selection Sort,333,432,0.00335320
+Selection Sort,333,433,0.00391560
+Selection Sort,333,434,0.00329080
+Selection Sort,333,435,0.00365750
+Selection Sort,333,436,0.00333660
+Selection Sort,333,437,0.00337180
+Selection Sort,333,438,0.00336590
+Selection Sort,333,439,0.00327290
+Selection Sort,333,440,0.00458610
+Selection Sort,333,441,0.00328290
+Selection Sort,333,442,0.00332440
+Selection Sort,333,443,0.00334020
+Selection Sort,333,444,0.00332830
+Selection Sort,333,445,0.00326660
+Selection Sort,333,446,0.00328900
+Selection Sort,333,447,0.00375420
+Selection Sort,333,448,0.00478150
+Selection Sort,333,449,0.00342220
+Selection Sort,333,450,0.00359290
+Selection Sort,333,451,0.00313340
+Selection Sort,333,452,0.00337300
+Selection Sort,333,453,0.00330510
+Selection Sort,333,454,0.00522520
+Selection Sort,333,455,0.00324720
+Selection Sort,333,456,0.00346060
+Selection Sort,333,457,0.00325600
+Selection Sort,333,458,0.00378610
+Selection Sort,333,459,0.00324140
+Selection Sort,333,460,0.00340100
+Selection Sort,333,461,0.00579700
+Selection Sort,333,462,0.00316740
+Selection Sort,333,463,0.00331020
+Selection Sort,333,464,0.00327330
+Selection Sort,333,465,0.00328390
+Selection Sort,333,466,0.00586970
+Selection Sort,333,467,0.00328500
+Selection Sort,333,468,0.00326060
+Selection Sort,333,469,0.00366430
+Selection Sort,333,470,0.00328160
+Selection Sort,333,471,0.00396690
+Selection Sort,333,472,0.00322240
+Selection Sort,333,473,0.00335780
+Selection Sort,333,474,0.00333220
+Selection Sort,333,475,0.00327710
+Selection Sort,333,476,0.00330270
+Selection Sort,333,477,0.00436030
+Selection Sort,333,478,0.00324930
+Selection Sort,333,479,0.00325470
+Selection Sort,333,480,0.00349130
+Selection Sort,333,481,0.00320390
+Selection Sort,333,482,0.00434010
+Selection Sort,333,483,0.00329880
+Selection Sort,333,484,0.00379670
+Selection Sort,333,485,0.00412600
+Selection Sort,333,486,0.00357490
+Selection Sort,333,487,0.00328710
+Selection Sort,333,488,0.00337070
+Selection Sort,333,489,0.00340430
+Selection Sort,333,490,0.00371340
+Selection Sort,333,491,0.00326150
+Selection Sort,333,492,0.00327640
+Selection Sort,333,493,0.00329570
+Selection Sort,333,494,0.00334250
+Selection Sort,333,495,0.00413660
+Selection Sort,333,496,0.00331180
+Selection Sort,333,497,0.00339510
+Selection Sort,333,498,0.00346240
+Selection Sort,333,499,0.00329320
+Selection Sort,333,500,0.00390570
+Shell Sort,333,1,0.00056760
+Shell Sort,333,2,0.00059800
+Shell Sort,333,3,0.00054460
+Shell Sort,333,4,0.00054930
+Shell Sort,333,5,0.00053770
+Shell Sort,333,6,0.00057320
+Shell Sort,333,7,0.00053830
+Shell Sort,333,8,0.00047200
+Shell Sort,333,9,0.00053120
+Shell Sort,333,10,0.00053060
+Shell Sort,333,11,0.00063620
+Shell Sort,333,12,0.00053770
+Shell Sort,333,13,0.00051550
+Shell Sort,333,14,0.00055980
+Shell Sort,333,15,0.00056230
+Shell Sort,333,16,0.00056760
+Shell Sort,333,17,0.00061240
+Shell Sort,333,18,0.00059500
+Shell Sort,333,19,0.00059190
+Shell Sort,333,20,0.00054740
+Shell Sort,333,21,0.00055350
+Shell Sort,333,22,0.00054700
+Shell Sort,333,23,0.00057420
+Shell Sort,333,24,0.00055980
+Shell Sort,333,25,0.00054380
+Shell Sort,333,26,0.00053640
+Shell Sort,333,27,0.00054700
+Shell Sort,333,28,0.00052660
+Shell Sort,333,29,0.00059510
+Shell Sort,333,30,0.00056290
+Shell Sort,333,31,0.00057030
+Shell Sort,333,32,0.00055500
+Shell Sort,333,33,0.00055120
+Shell Sort,333,34,0.00055740
+Shell Sort,333,35,0.00054850
+Shell Sort,333,36,0.00056010
+Shell Sort,333,37,0.00058620
+Shell Sort,333,38,0.00058510
+Shell Sort,333,39,0.00056690
+Shell Sort,333,40,0.00059120
+Shell Sort,333,41,0.00054130
+Shell Sort,333,42,0.00062080
+Shell Sort,333,43,0.00054930
+Shell Sort,333,44,0.00058350
+Shell Sort,333,45,0.00057880
+Shell Sort,333,46,0.00053570
+Shell Sort,333,47,0.00059930
+Shell Sort,333,48,0.00057450
+Shell Sort,333,49,0.00059870
+Shell Sort,333,50,0.00053320
+Shell Sort,333,51,0.00056970
+Shell Sort,333,52,0.00052120
+Shell Sort,333,53,0.00056400
+Shell Sort,333,54,0.00052060
+Shell Sort,333,55,0.00060520
+Shell Sort,333,56,0.00060100
+Shell Sort,333,57,0.00057760
+Shell Sort,333,58,0.00058170
+Shell Sort,333,59,0.00055700
+Shell Sort,333,60,0.00056840
+Shell Sort,333,61,0.00052840
+Shell Sort,333,62,0.00057730
+Shell Sort,333,63,0.00053210
+Shell Sort,333,64,0.00055880
+Shell Sort,333,65,0.00059760
+Shell Sort,333,66,0.00058410
+Shell Sort,333,67,0.00054630
+Shell Sort,333,68,0.00056590
+Shell Sort,333,69,0.00056080
+Shell Sort,333,70,0.00056670
+Shell Sort,333,71,0.00056100
+Shell Sort,333,72,0.00051900
+Shell Sort,333,73,0.00054260
+Shell Sort,333,74,0.00052410
+Shell Sort,333,75,0.00050980
+Shell Sort,333,76,0.00054950
+Shell Sort,333,77,0.00055050
+Shell Sort,333,78,0.00055870
+Shell Sort,333,79,0.00056920
+Shell Sort,333,80,0.00055460
+Shell Sort,333,81,0.00054300
+Shell Sort,333,82,0.00057420
+Shell Sort,333,83,0.00051400
+Shell Sort,333,84,0.00052560
+Shell Sort,333,85,0.00056660
+Shell Sort,333,86,0.00055530
+Shell Sort,333,87,0.00057400
+Shell Sort,333,88,0.00059230
+Shell Sort,333,89,0.00054080
+Shell Sort,333,90,0.00056790
+Shell Sort,333,91,0.00056390
+Shell Sort,333,92,0.00055190
+Shell Sort,333,93,0.00052620
+Shell Sort,333,94,0.00059910
+Shell Sort,333,95,0.00058570
+Shell Sort,333,96,0.00055170
+Shell Sort,333,97,0.00056090
+Shell Sort,333,98,0.00059340
+Shell Sort,333,99,0.00053530
+Shell Sort,333,100,0.00055380
+Shell Sort,333,101,0.00053470
+Shell Sort,333,102,0.00060890
+Shell Sort,333,103,0.00052170
+Shell Sort,333,104,0.00056980
+Shell Sort,333,105,0.00073690
+Shell Sort,333,106,0.00053190
+Shell Sort,333,107,0.00058660
+Shell Sort,333,108,0.00056190
+Shell Sort,333,109,0.00052340
+Shell Sort,333,110,0.00055150
+Shell Sort,333,111,0.00057260
+Shell Sort,333,112,0.00055620
+Shell Sort,333,113,0.00154210
+Shell Sort,333,114,0.00053200
+Shell Sort,333,115,0.00054520
+Shell Sort,333,116,0.00054640
+Shell Sort,333,117,0.00054500
+Shell Sort,333,118,0.00053660
+Shell Sort,333,119,0.00054460
+Shell Sort,333,120,0.00053150
+Shell Sort,333,121,0.00052090
+Shell Sort,333,122,0.00058370
+Shell Sort,333,123,0.00052980
+Shell Sort,333,124,0.00053920
+Shell Sort,333,125,0.00056820
+Shell Sort,333,126,0.00054660
+Shell Sort,333,127,0.00054340
+Shell Sort,333,128,0.00057090
+Shell Sort,333,129,0.00052560
+Shell Sort,333,130,0.00055620
+Shell Sort,333,131,0.00056040
+Shell Sort,333,132,0.00055580
+Shell Sort,333,133,0.00055520
+Shell Sort,333,134,0.00053580
+Shell Sort,333,135,0.00064120
+Shell Sort,333,136,0.00055060
+Shell Sort,333,137,0.00055810
+Shell Sort,333,138,0.00055540
+Shell Sort,333,139,0.00056010
+Shell Sort,333,140,0.00057690
+Shell Sort,333,141,0.00050880
+Shell Sort,333,142,0.00059730
+Shell Sort,333,143,0.00053880
+Shell Sort,333,144,0.00070660
+Shell Sort,333,145,0.00053010
+Shell Sort,333,146,0.00050970
+Shell Sort,333,147,0.00059430
+Shell Sort,333,148,0.00057450
+Shell Sort,333,149,0.00054270
+Shell Sort,333,150,0.00054380
+Shell Sort,333,151,0.00057430
+Shell Sort,333,152,0.00054510
+Shell Sort,333,153,0.00054710
+Shell Sort,333,154,0.00054530
+Shell Sort,333,155,0.00054830
+Shell Sort,333,156,0.00047680
+Shell Sort,333,157,0.00058370
+Shell Sort,333,158,0.00058680
+Shell Sort,333,159,0.00054180
+Shell Sort,333,160,0.00055570
+Shell Sort,333,161,0.00057810
+Shell Sort,333,162,0.00056010
+Shell Sort,333,163,0.00057980
+Shell Sort,333,164,0.00053850
+Shell Sort,333,165,0.00056260
+Shell Sort,333,166,0.00054600
+Shell Sort,333,167,0.00060210
+Shell Sort,333,168,0.00057070
+Shell Sort,333,169,0.00062360
+Shell Sort,333,170,0.00055400
+Shell Sort,333,171,0.00056690
+Shell Sort,333,172,0.00056570
+Shell Sort,333,173,0.00059780
+Shell Sort,333,174,0.00057480
+Shell Sort,333,175,0.00058640
+Shell Sort,333,176,0.00054820
+Shell Sort,333,177,0.00056530
+Shell Sort,333,178,0.00059550
+Shell Sort,333,179,0.00054800
+Shell Sort,333,180,0.00063350
+Shell Sort,333,181,0.00056760
+Shell Sort,333,182,0.00055360
+Shell Sort,333,183,0.00055230
+Shell Sort,333,184,0.00058530
+Shell Sort,333,185,0.00052210
+Shell Sort,333,186,0.00056400
+Shell Sort,333,187,0.00055350
+Shell Sort,333,188,0.00056660
+Shell Sort,333,189,0.00057150
+Shell Sort,333,190,0.00055270
+Shell Sort,333,191,0.00055660
+Shell Sort,333,192,0.00055040
+Shell Sort,333,193,0.00055790
+Shell Sort,333,194,0.00053330
+Shell Sort,333,195,0.00053420
+Shell Sort,333,196,0.00049170
+Shell Sort,333,197,0.00050360
+Shell Sort,333,198,0.00056540
+Shell Sort,333,199,0.00054150
+Shell Sort,333,200,0.00053780
+Shell Sort,333,201,0.00050310
+Shell Sort,333,202,0.00053310
+Shell Sort,333,203,0.00052470
+Shell Sort,333,204,0.00055070
+Shell Sort,333,205,0.00050120
+Shell Sort,333,206,0.00057590
+Shell Sort,333,207,0.00056770
+Shell Sort,333,208,0.00055440
+Shell Sort,333,209,0.00052850
+Shell Sort,333,210,0.00058350
+Shell Sort,333,211,0.00060840
+Shell Sort,333,212,0.00055530
+Shell Sort,333,213,0.00053660
+Shell Sort,333,214,0.00052660
+Shell Sort,333,215,0.00057900
+Shell Sort,333,216,0.00054620
+Shell Sort,333,217,0.00056770
+Shell Sort,333,218,0.00052700
+Shell Sort,333,219,0.00052860
+Shell Sort,333,220,0.00056070
+Shell Sort,333,221,0.00055780
+Shell Sort,333,222,0.00055460
+Shell Sort,333,223,0.00049760
+Shell Sort,333,224,0.00062170
+Shell Sort,333,225,0.00056430
+Shell Sort,333,226,0.00055730
+Shell Sort,333,227,0.00055420
+Shell Sort,333,228,0.00056500
+Shell Sort,333,229,0.00056410
+Shell Sort,333,230,0.00056310
+Shell Sort,333,231,0.00054680
+Shell Sort,333,232,0.00055490
+Shell Sort,333,233,0.00065700
+Shell Sort,333,234,0.00055300
+Shell Sort,333,235,0.00058020
+Shell Sort,333,236,0.00058150
+Shell Sort,333,237,0.00054640
+Shell Sort,333,238,0.00057410
+Shell Sort,333,239,0.00056780
+Shell Sort,333,240,0.00057510
+Shell Sort,333,241,0.00056010
+Shell Sort,333,242,0.00052840
+Shell Sort,333,243,0.00053070
+Shell Sort,333,244,0.00060160
+Shell Sort,333,245,0.00052060
+Shell Sort,333,246,0.00059480
+Shell Sort,333,247,0.00054050
+Shell Sort,333,248,0.00055530
+Shell Sort,333,249,0.00055390
+Shell Sort,333,250,0.00057720
+Shell Sort,333,251,0.00064550
+Shell Sort,333,252,0.00058050
+Shell Sort,333,253,0.00050730
+Shell Sort,333,254,0.00053480
+Shell Sort,333,255,0.00059990
+Shell Sort,333,256,0.00051720
+Shell Sort,333,257,0.00059170
+Shell Sort,333,258,0.00054330
+Shell Sort,333,259,0.00055920
+Shell Sort,333,260,0.00056080
+Shell Sort,333,261,0.00057280
+Shell Sort,333,262,0.00053610
+Shell Sort,333,263,0.00058470
+Shell Sort,333,264,0.00055270
+Shell Sort,333,265,0.00055640
+Shell Sort,333,266,0.00058620
+Shell Sort,333,267,0.00056450
+Shell Sort,333,268,0.00055940
+Shell Sort,333,269,0.00058680
+Shell Sort,333,270,0.00054910
+Shell Sort,333,271,0.00055890
+Shell Sort,333,272,0.00055340
+Shell Sort,333,273,0.00055350
+Shell Sort,333,274,0.00044140
+Shell Sort,333,275,0.00062090
+Shell Sort,333,276,0.00060290
+Shell Sort,333,277,0.00053890
+Shell Sort,333,278,0.00059480
+Shell Sort,333,279,0.00057280
+Shell Sort,333,280,0.00056790
+Shell Sort,333,281,0.00057810
+Shell Sort,333,282,0.00054390
+Shell Sort,333,283,0.00059930
+Shell Sort,333,284,0.00052800
+Shell Sort,333,285,0.00055020
+Shell Sort,333,286,0.00055390
+Shell Sort,333,287,0.00054770
+Shell Sort,333,288,0.00055200
+Shell Sort,333,289,0.00057090
+Shell Sort,333,290,0.00057190
+Shell Sort,333,291,0.00052430
+Shell Sort,333,292,0.00052980
+Shell Sort,333,293,0.00052430
+Shell Sort,333,294,0.00054100
+Shell Sort,333,295,0.00055220
+Shell Sort,333,296,0.00056490
+Shell Sort,333,297,0.00054680
+Shell Sort,333,298,0.00055920
+Shell Sort,333,299,0.00057830
+Shell Sort,333,300,0.00055630
+Shell Sort,333,301,0.00052030
+Shell Sort,333,302,0.00052530
+Shell Sort,333,303,0.00056030
+Shell Sort,333,304,0.00057690
+Shell Sort,333,305,0.00057990
+Shell Sort,333,306,0.00055180
+Shell Sort,333,307,0.00054170
+Shell Sort,333,308,0.00043540
+Shell Sort,333,309,0.00048360
+Shell Sort,333,310,0.00052410
+Shell Sort,333,311,0.00060770
+Shell Sort,333,312,0.00058770
+Shell Sort,333,313,0.00055550
+Shell Sort,333,314,0.00053480
+Shell Sort,333,315,0.00055650
+Shell Sort,333,316,0.00049670
+Shell Sort,333,317,0.00055080
+Shell Sort,333,318,0.00055850
+Shell Sort,333,319,0.00055320
+Shell Sort,333,320,0.00055300
+Shell Sort,333,321,0.00053860
+Shell Sort,333,322,0.00057310
+Shell Sort,333,323,0.00052220
+Shell Sort,333,324,0.00054800
+Shell Sort,333,325,0.00055310
+Shell Sort,333,326,0.00056350
+Shell Sort,333,327,0.00058080
+Shell Sort,333,328,0.00052280
+Shell Sort,333,329,0.00059090
+Shell Sort,333,330,0.00047310
+Shell Sort,333,331,0.00056270
+Shell Sort,333,332,0.00055760
+Shell Sort,333,333,0.00052230
+Shell Sort,333,334,0.00056490
+Shell Sort,333,335,0.00052900
+Shell Sort,333,336,0.00061040
+Shell Sort,333,337,0.00057610
+Shell Sort,333,338,0.00050940
+Shell Sort,333,339,0.00059880
+Shell Sort,333,340,0.00050520
+Shell Sort,333,341,0.00052970
+Shell Sort,333,342,0.00047360
+Shell Sort,333,343,0.00050080
+Shell Sort,333,344,0.00056350
+Shell Sort,333,345,0.00054200
+Shell Sort,333,346,0.00090490
+Shell Sort,333,347,0.00054180
+Shell Sort,333,348,0.00052850
+Shell Sort,333,349,0.00053160
+Shell Sort,333,350,0.00058060
+Shell Sort,333,351,0.00055530
+Shell Sort,333,352,0.00054420
+Shell Sort,333,353,0.00049000
+Shell Sort,333,354,0.00054530
+Shell Sort,333,355,0.00053970
+Shell Sort,333,356,0.00058540
+Shell Sort,333,357,0.00054420
+Shell Sort,333,358,0.00053160
+Shell Sort,333,359,0.00056310
+Shell Sort,333,360,0.00051080
+Shell Sort,333,361,0.00053440
+Shell Sort,333,362,0.00062850
+Shell Sort,333,363,0.00054260
+Shell Sort,333,364,0.00053700
+Shell Sort,333,365,0.00054080
+Shell Sort,333,366,0.00050800
+Shell Sort,333,367,0.00057020
+Shell Sort,333,368,0.00054960
+Shell Sort,333,369,0.00052550
+Shell Sort,333,370,0.00058280
+Shell Sort,333,371,0.00050080
+Shell Sort,333,372,0.00060020
+Shell Sort,333,373,0.00054690
+Shell Sort,333,374,0.00057740
+Shell Sort,333,375,0.00054730
+Shell Sort,333,376,0.00059030
+Shell Sort,333,377,0.00057990
+Shell Sort,333,378,0.00056430
+Shell Sort,333,379,0.00055400
+Shell Sort,333,380,0.00050610
+Shell Sort,333,381,0.00055000
+Shell Sort,333,382,0.00054100
+Shell Sort,333,383,0.00058860
+Shell Sort,333,384,0.00056470
+Shell Sort,333,385,0.00058910
+Shell Sort,333,386,0.00057450
+Shell Sort,333,387,0.00055920
+Shell Sort,333,388,0.00055290
+Shell Sort,333,389,0.00055080
+Shell Sort,333,390,0.00058230
+Shell Sort,333,391,0.00056340
+Shell Sort,333,392,0.00053740
+Shell Sort,333,393,0.00054620
+Shell Sort,333,394,0.00056800
+Shell Sort,333,395,0.00054080
+Shell Sort,333,396,0.00056020
+Shell Sort,333,397,0.00056610
+Shell Sort,333,398,0.00060010
+Shell Sort,333,399,0.00057860
+Shell Sort,333,400,0.00056100
+Shell Sort,333,401,0.00059800
+Shell Sort,333,402,0.00055900
+Shell Sort,333,403,0.00056870
+Shell Sort,333,404,0.00056200
+Shell Sort,333,405,0.00057140
+Shell Sort,333,406,0.00052430
+Shell Sort,333,407,0.00056000
+Shell Sort,333,408,0.00052880
+Shell Sort,333,409,0.00053240
+Shell Sort,333,410,0.00054950
+Shell Sort,333,411,0.00054860
+Shell Sort,333,412,0.00057290
+Shell Sort,333,413,0.00055530
+Shell Sort,333,414,0.00055650
+Shell Sort,333,415,0.00053370
+Shell Sort,333,416,0.00061690
+Shell Sort,333,417,0.00060430
+Shell Sort,333,418,0.00058680
+Shell Sort,333,419,0.00058030
+Shell Sort,333,420,0.00054670
+Shell Sort,333,421,0.00051530
+Shell Sort,333,422,0.00057020
+Shell Sort,333,423,0.00060260
+Shell Sort,333,424,0.00051330
+Shell Sort,333,425,0.00054560
+Shell Sort,333,426,0.00058670
+Shell Sort,333,427,0.00060480
+Shell Sort,333,428,0.00055240
+Shell Sort,333,429,0.00053010
+Shell Sort,333,430,0.00054860
+Shell Sort,333,431,0.00058760
+Shell Sort,333,432,0.00056020
+Shell Sort,333,433,0.00054230
+Shell Sort,333,434,0.00066190
+Shell Sort,333,435,0.00058630
+Shell Sort,333,436,0.00058600
+Shell Sort,333,437,0.00056810
+Shell Sort,333,438,0.00057930
+Shell Sort,333,439,0.00053870
+Shell Sort,333,440,0.00052220
+Shell Sort,333,441,0.00055290
+Shell Sort,333,442,0.00056820
+Shell Sort,333,443,0.00057960
+Shell Sort,333,444,0.00055830
+Shell Sort,333,445,0.00056250
+Shell Sort,333,446,0.00053910
+Shell Sort,333,447,0.00053870
+Shell Sort,333,448,0.00052770
+Shell Sort,333,449,0.00051720
+Shell Sort,333,450,0.00053110
+Shell Sort,333,451,0.00052530
+Shell Sort,333,452,0.00055040
+Shell Sort,333,453,0.00052880
+Shell Sort,333,454,0.00058020
+Shell Sort,333,455,0.00051490
+Shell Sort,333,456,0.00058600
+Shell Sort,333,457,0.00066490
+Shell Sort,333,458,0.00056700
+Shell Sort,333,459,0.00055900
+Shell Sort,333,460,0.00056420
+Shell Sort,333,461,0.00056740
+Shell Sort,333,462,0.00054780
+Shell Sort,333,463,0.00058070
+Shell Sort,333,464,0.00054900
+Shell Sort,333,465,0.00053740
+Shell Sort,333,466,0.00054320
+Shell Sort,333,467,0.00055550
+Shell Sort,333,468,0.00054580
+Shell Sort,333,469,0.00055960
+Shell Sort,333,470,0.00055390
+Shell Sort,333,471,0.00058210
+Shell Sort,333,472,0.00055040
+Shell Sort,333,473,0.00052580
+Shell Sort,333,474,0.00056530
+Shell Sort,333,475,0.00053520
+Shell Sort,333,476,0.00054320
+Shell Sort,333,477,0.00054330
+Shell Sort,333,478,0.00055190
+Shell Sort,333,479,0.00056130
+Shell Sort,333,480,0.00058230
+Shell Sort,333,481,0.00057490
+Shell Sort,333,482,0.00054450
+Shell Sort,333,483,0.00059340
+Shell Sort,333,484,0.00053810
+Shell Sort,333,485,0.00055250
+Shell Sort,333,486,0.00053420
+Shell Sort,333,487,0.00056680
+Shell Sort,333,488,0.00048000
+Shell Sort,333,489,0.00051320
+Shell Sort,333,490,0.00056130
+Shell Sort,333,491,0.00055340
+Shell Sort,333,492,0.00057510
+Shell Sort,333,493,0.00057060
+Shell Sort,333,494,0.00057250
+Shell Sort,333,495,0.00058920
+Shell Sort,333,496,0.00051470
+Shell Sort,333,497,0.00056700
+Shell Sort,333,498,0.00056610
+Shell Sort,333,499,0.00056470
+Shell Sort,333,500,0.00056950
+Sleep Sort,333,1,2.07012620
+Sleep Sort,333,2,2.08336860
+Sleep Sort,333,3,2.09115940
+Sleep Sort,333,4,2.05070480
+Sleep Sort,333,5,2.07102730
+Sleep Sort,333,6,2.05591440
+Sleep Sort,333,7,2.06510470
+Sleep Sort,333,8,2.04126370
+Sleep Sort,333,9,2.06055930
+Sleep Sort,333,10,2.06382660
+Sleep Sort,333,11,2.07286070
+Sleep Sort,333,12,2.05117440
+Sleep Sort,333,13,2.04189700
+Sleep Sort,333,14,2.05146260
+Sleep Sort,333,15,2.02537410
+Sleep Sort,333,16,2.00991090
+Sleep Sort,333,17,2.02965340
+Sleep Sort,333,18,2.02225220
+Sleep Sort,333,19,2.01225970
+Sleep Sort,333,20,2.03692850
+Sleep Sort,333,21,2.01102250
+Sleep Sort,333,22,2.02280070
+Sleep Sort,333,23,2.03186370
+Sleep Sort,333,24,2.04000910
+Sleep Sort,333,25,2.04244830
+Sleep Sort,333,26,2.03718870
+Sleep Sort,333,27,1.98693680
+Sleep Sort,333,28,2.04109410
+Sleep Sort,333,29,2.02687200
+Sleep Sort,333,30,2.01860310
+Sleep Sort,333,31,2.02568190
+Sleep Sort,333,32,1.99601460
+Sleep Sort,333,33,2.03883210
+Sleep Sort,333,34,2.02750520
+Sleep Sort,333,35,2.04322260
+Sleep Sort,333,36,2.01074160
+Sleep Sort,333,37,2.01906130
+Sleep Sort,333,38,2.04689030
+Sleep Sort,333,39,2.01881990
+Sleep Sort,333,40,2.02288560
+Sleep Sort,333,41,2.03816380
+Sleep Sort,333,42,2.02369880
+Sleep Sort,333,43,2.02302710
+Sleep Sort,333,44,2.00169390
+Sleep Sort,333,45,2.04258170
+Sleep Sort,333,46,2.02306940
+Sleep Sort,333,47,2.02092260
+Sleep Sort,333,48,2.01911710
+Sleep Sort,333,49,2.02370930
+Sleep Sort,333,50,2.02370700
+Sleep Sort,333,51,2.02563480
+Sleep Sort,333,52,2.01847520
+Sleep Sort,333,53,2.03743040
+Sleep Sort,333,54,2.03909070
+Sleep Sort,333,55,2.01658810
+Sleep Sort,333,56,2.02177100
+Sleep Sort,333,57,2.03768170
+Sleep Sort,333,58,2.02221560
+Sleep Sort,333,59,2.01191730
+Sleep Sort,333,60,2.03857530
+Sleep Sort,333,61,2.00311890
+Sleep Sort,333,62,2.02890970
+Sleep Sort,333,63,2.03099360
+Sleep Sort,333,64,2.03065270
+Sleep Sort,333,65,2.01835370
+Sleep Sort,333,66,2.01362020
+Sleep Sort,333,67,2.01597390
+Sleep Sort,333,68,2.01480320
+Sleep Sort,333,69,2.04050340
+Sleep Sort,333,70,2.02648480
+Sleep Sort,333,71,2.00142330
+Sleep Sort,333,72,2.03696440
+Sleep Sort,333,73,2.00349890
+Sleep Sort,333,74,2.01275820
+Sleep Sort,333,75,2.04250140
+Sleep Sort,333,76,2.00794680
+Sleep Sort,333,77,2.01383810
+Sleep Sort,333,78,2.00611460
+Sleep Sort,333,79,2.02398020
+Sleep Sort,333,80,2.02787560
+Sleep Sort,333,81,2.04102320
+Sleep Sort,333,82,2.03678080
+Sleep Sort,333,83,2.02131220
+Sleep Sort,333,84,2.00587860
+Sleep Sort,333,85,2.02044530
+Sleep Sort,333,86,2.00801010
+Sleep Sort,333,87,2.00995500
+Sleep Sort,333,88,2.04129200
+Sleep Sort,333,89,2.00482550
+Sleep Sort,333,90,2.01047360
+Sleep Sort,333,91,2.02458650
+Sleep Sort,333,92,2.03147800
+Sleep Sort,333,93,2.01040320
+Sleep Sort,333,94,2.01306040
+Sleep Sort,333,95,2.04425610
+Sleep Sort,333,96,2.00755270
+Sleep Sort,333,97,2.03274770
+Sleep Sort,333,98,1.99796100
+Sleep Sort,333,99,1.99118760
+Sleep Sort,333,100,2.02677280
+Sleep Sort,333,101,2.02853460
+Sleep Sort,333,102,2.04043560
+Sleep Sort,333,103,2.03938180
+Sleep Sort,333,104,2.02984790
+Sleep Sort,333,105,2.03706960
+Sleep Sort,333,106,2.02824700
+Sleep Sort,333,107,2.02038490
+Sleep Sort,333,108,2.03635040
+Sleep Sort,333,109,2.02133830
+Sleep Sort,333,110,2.03566200
+Sleep Sort,333,111,2.04108880
+Sleep Sort,333,112,2.02624410
+Sleep Sort,333,113,2.01159900
+Sleep Sort,333,114,1.99391280
+Sleep Sort,333,115,2.01948010
+Sleep Sort,333,116,2.03709580
+Sleep Sort,333,117,2.01953580
+Sleep Sort,333,118,2.02129810
+Sleep Sort,333,119,2.02915890
+Sleep Sort,333,120,2.01226770
+Sleep Sort,333,121,2.02384850
+Sleep Sort,333,122,2.01814010
+Sleep Sort,333,123,2.01721660
+Sleep Sort,333,124,2.02868560
+Sleep Sort,333,125,2.04035310
+Sleep Sort,333,126,2.04098280
+Sleep Sort,333,127,2.01331260
+Sleep Sort,333,128,2.02141380
+Sleep Sort,333,129,2.01439110
+Sleep Sort,333,130,2.03597970
+Sleep Sort,333,131,2.01742660
+Sleep Sort,333,132,2.00939220
+Sleep Sort,333,133,2.02108910
+Sleep Sort,333,134,2.03637200
+Sleep Sort,333,135,2.02803340
+Sleep Sort,333,136,2.00577850
+Sleep Sort,333,137,2.04124700
+Sleep Sort,333,138,2.03092490
+Sleep Sort,333,139,2.03084500
+Sleep Sort,333,140,2.01739720
+Sleep Sort,333,141,2.03058490
+Sleep Sort,333,142,2.03339240
+Sleep Sort,333,143,2.01225210
+Sleep Sort,333,144,1.99979470
+Sleep Sort,333,145,2.04551910
+Sleep Sort,333,146,2.00182780
+Sleep Sort,333,147,2.01886960
+Sleep Sort,333,148,2.03615800
+Sleep Sort,333,149,1.99931040
+Sleep Sort,333,150,2.03327380
+Sleep Sort,333,151,2.00785240
+Sleep Sort,333,152,2.03367040
+Sleep Sort,333,153,2.03429020
+Sleep Sort,333,154,2.00289880
+Sleep Sort,333,155,2.01085810
+Sleep Sort,333,156,2.00633620
+Sleep Sort,333,157,2.02066040
+Sleep Sort,333,158,2.04409210
+Sleep Sort,333,159,2.01947700
+Sleep Sort,333,160,2.00923490
+Sleep Sort,333,161,2.02590420
+Sleep Sort,333,162,1.99877340
+Sleep Sort,333,163,2.03253400
+Sleep Sort,333,164,2.01981210
+Sleep Sort,333,165,2.01517300
+Sleep Sort,333,166,2.01776070
+Sleep Sort,333,167,2.02204470
+Sleep Sort,333,168,2.03308600
+Sleep Sort,333,169,1.99058550
+Sleep Sort,333,170,2.02561140
+Sleep Sort,333,171,2.01186420
+Sleep Sort,333,172,2.01167470
+Sleep Sort,333,173,2.02504220
+Sleep Sort,333,174,2.03000800
+Sleep Sort,333,175,2.03823950
+Sleep Sort,333,176,2.02069410
+Sleep Sort,333,177,2.01037020
+Sleep Sort,333,178,2.02214240
+Sleep Sort,333,179,2.02241130
+Sleep Sort,333,180,2.00153780
+Sleep Sort,333,181,2.03222490
+Sleep Sort,333,182,2.01233770
+Sleep Sort,333,183,2.02172260
+Sleep Sort,333,184,2.02781460
+Sleep Sort,333,185,2.00792040
+Sleep Sort,333,186,2.04199010
+Sleep Sort,333,187,2.02667380
+Sleep Sort,333,188,2.02271520
+Sleep Sort,333,189,2.01804100
+Sleep Sort,333,190,2.03033680
+Sleep Sort,333,191,2.02709510
+Sleep Sort,333,192,2.02994480
+Sleep Sort,333,193,2.01718090
+Sleep Sort,333,194,2.02033470
+Sleep Sort,333,195,2.01362700
+Sleep Sort,333,196,2.04587290
+Sleep Sort,333,197,2.03679950
+Sleep Sort,333,198,2.02942850
+Sleep Sort,333,199,2.01598490
+Sleep Sort,333,200,2.02087560
+Sleep Sort,333,201,2.02547610
+Sleep Sort,333,202,2.00865880
+Sleep Sort,333,203,2.02000280
+Sleep Sort,333,204,2.04061650
+Sleep Sort,333,205,2.02052520
+Sleep Sort,333,206,2.01558680
+Sleep Sort,333,207,2.03700030
+Sleep Sort,333,208,2.01664080
+Sleep Sort,333,209,2.00614180
+Sleep Sort,333,210,2.00381640
+Sleep Sort,333,211,2.02979810
+Sleep Sort,333,212,2.01590940
+Sleep Sort,333,213,2.01469050
+Sleep Sort,333,214,2.03662150
+Sleep Sort,333,215,2.03871820
+Sleep Sort,333,216,1.98725220
+Sleep Sort,333,217,2.03164750
+Sleep Sort,333,218,2.01404500
+Sleep Sort,333,219,2.00943740
+Sleep Sort,333,220,1.99108400
+Sleep Sort,333,221,1.99983960
+Sleep Sort,333,222,2.03934350
+Sleep Sort,333,223,2.00920720
+Sleep Sort,333,224,2.03565990
+Sleep Sort,333,225,2.02846220
+Sleep Sort,333,226,2.01534080
+Sleep Sort,333,227,2.00161570
+Sleep Sort,333,228,2.03024690
+Sleep Sort,333,229,2.01463960
+Sleep Sort,333,230,2.02289860
+Sleep Sort,333,231,2.02810000
+Sleep Sort,333,232,2.02827190
+Sleep Sort,333,233,2.01131680
+Sleep Sort,333,234,2.02194780
+Sleep Sort,333,235,2.03330770
+Sleep Sort,333,236,2.02441070
+Sleep Sort,333,237,2.03449070
+Sleep Sort,333,238,2.02193700
+Sleep Sort,333,239,1.99423280
+Sleep Sort,333,240,2.02191680
+Sleep Sort,333,241,2.01844270
+Sleep Sort,333,242,2.02103190
+Sleep Sort,333,243,2.00839900
+Sleep Sort,333,244,2.01815000
+Sleep Sort,333,245,2.03880320
+Sleep Sort,333,246,2.02832720
+Sleep Sort,333,247,2.01092320
+Sleep Sort,333,248,2.04161320
+Sleep Sort,333,249,2.02842480
+Sleep Sort,333,250,2.02391560
+Sleep Sort,333,251,2.01944600
+Sleep Sort,333,252,2.01101310
+Sleep Sort,333,253,2.01915050
+Sleep Sort,333,254,1.99267650
+Sleep Sort,333,255,2.03996000
+Sleep Sort,333,256,2.03413060
+Sleep Sort,333,257,2.02485680
+Sleep Sort,333,258,2.03740770
+Sleep Sort,333,259,2.03137220
+Sleep Sort,333,260,2.03362920
+Sleep Sort,333,261,2.01050090
+Sleep Sort,333,262,2.01886740
+Sleep Sort,333,263,2.02132850
+Sleep Sort,333,264,2.01949620
+Sleep Sort,333,265,2.01221210
+Sleep Sort,333,266,1.99807270
+Sleep Sort,333,267,2.01367930
+Sleep Sort,333,268,2.03184540
+Sleep Sort,333,269,2.01844990
+Sleep Sort,333,270,2.01819510
+Sleep Sort,333,271,2.03454380
+Sleep Sort,333,272,2.03909960
+Sleep Sort,333,273,2.02176120
+Sleep Sort,333,274,2.00521050
+Sleep Sort,333,275,2.01541370
+Sleep Sort,333,276,2.01032850
+Sleep Sort,333,277,1.99798430
+Sleep Sort,333,278,2.02914340
+Sleep Sort,333,279,2.00697790
+Sleep Sort,333,280,2.02940150
+Sleep Sort,333,281,2.00979630
+Sleep Sort,333,282,2.02128050
+Sleep Sort,333,283,2.01940550
+Sleep Sort,333,284,2.03380820
+Sleep Sort,333,285,2.03613990
+Sleep Sort,333,286,2.01296620
+Sleep Sort,333,287,2.03360600
+Sleep Sort,333,288,2.04409120
+Sleep Sort,333,289,2.02935650
+Sleep Sort,333,290,2.01149320
+Sleep Sort,333,291,2.01644030
+Sleep Sort,333,292,2.00886010
+Sleep Sort,333,293,2.02401270
+Sleep Sort,333,294,2.03498670
+Sleep Sort,333,295,2.03261960
+Sleep Sort,333,296,1.99680430
+Sleep Sort,333,297,1.99504880
+Sleep Sort,333,298,2.03105990
+Sleep Sort,333,299,2.02258290
+Sleep Sort,333,300,2.03264540
+Sleep Sort,333,301,2.02092710
+Sleep Sort,333,302,2.02793260
+Sleep Sort,333,303,2.02940060
+Sleep Sort,333,304,2.01919700
+Sleep Sort,333,305,2.03635020
+Sleep Sort,333,306,2.04329770
+Sleep Sort,333,307,2.00175260
+Sleep Sort,333,308,1.99756620
+Sleep Sort,333,309,2.02148420
+Sleep Sort,333,310,2.01344920
+Sleep Sort,333,311,2.02740530
+Sleep Sort,333,312,2.01626110
+Sleep Sort,333,313,2.01511440
+Sleep Sort,333,314,2.03005200
+Sleep Sort,333,315,2.02545820
+Sleep Sort,333,316,2.00464040
+Sleep Sort,333,317,2.03111230
+Sleep Sort,333,318,2.03246860
+Sleep Sort,333,319,2.01906550
+Sleep Sort,333,320,2.02907220
+Sleep Sort,333,321,2.03293830
+Sleep Sort,333,322,2.03383100
+Sleep Sort,333,323,2.01693990
+Sleep Sort,333,324,2.02644990
+Sleep Sort,333,325,2.02600520
+Sleep Sort,333,326,2.03219260
+Sleep Sort,333,327,2.01489250
+Sleep Sort,333,328,2.02197210
+Sleep Sort,333,329,2.04154140
+Sleep Sort,333,330,2.01942180
+Sleep Sort,333,331,2.02880880
+Sleep Sort,333,332,2.02021460
+Sleep Sort,333,333,2.02355990
+Sleep Sort,333,334,2.00861160
+Sleep Sort,333,335,2.03708780
+Sleep Sort,333,336,2.03904180
+Sleep Sort,333,337,2.03864510
+Sleep Sort,333,338,2.00471350
+Sleep Sort,333,339,2.00954450
+Sleep Sort,333,340,2.03328370
+Sleep Sort,333,341,2.02441030
+Sleep Sort,333,342,2.03765790
+Sleep Sort,333,343,1.99628150
+Sleep Sort,333,344,2.01407270
+Sleep Sort,333,345,2.03903600
+Sleep Sort,333,346,2.01660230
+Sleep Sort,333,347,1.99642710
+Sleep Sort,333,348,2.02917620
+Sleep Sort,333,349,2.02285470
+Sleep Sort,333,350,2.00870190
+Sleep Sort,333,351,2.02831870
+Sleep Sort,333,352,2.03982040
+Sleep Sort,333,353,2.01686590
+Sleep Sort,333,354,2.01466890
+Sleep Sort,333,355,2.00048340
+Sleep Sort,333,356,2.03366020
+Sleep Sort,333,357,2.02420840
+Sleep Sort,333,358,2.03161920
+Sleep Sort,333,359,2.04353940
+Sleep Sort,333,360,2.02921370
+Sleep Sort,333,361,2.04420350
+Sleep Sort,333,362,2.01241410
+Sleep Sort,333,363,2.04017630
+Sleep Sort,333,364,2.02351520
+Sleep Sort,333,365,2.02242590
+Sleep Sort,333,366,2.02549320
+Sleep Sort,333,367,2.00899630
+Sleep Sort,333,368,2.02766460
+Sleep Sort,333,369,2.03081840
+Sleep Sort,333,370,2.02162260
+Sleep Sort,333,371,2.04486300
+Sleep Sort,333,372,2.02482340
+Sleep Sort,333,373,2.02719940
+Sleep Sort,333,374,2.01512850
+Sleep Sort,333,375,2.03864070
+Sleep Sort,333,376,2.03442800
+Sleep Sort,333,377,2.00114590
+Sleep Sort,333,378,2.02052800
+Sleep Sort,333,379,2.00628380
+Sleep Sort,333,380,1.99311050
+Sleep Sort,333,381,2.01160150
+Sleep Sort,333,382,2.02522060
+Sleep Sort,333,383,2.01926040
+Sleep Sort,333,384,2.03738400
+Sleep Sort,333,385,2.02812700
+Sleep Sort,333,386,2.02896990
+Sleep Sort,333,387,2.03520780
+Sleep Sort,333,388,2.03134340
+Sleep Sort,333,389,2.02707500
+Sleep Sort,333,390,2.03359740
+Sleep Sort,333,391,2.00875300
+Sleep Sort,333,392,2.01812170
+Sleep Sort,333,393,2.01391110
+Sleep Sort,333,394,2.02670060
+Sleep Sort,333,395,2.01108810
+Sleep Sort,333,396,2.01303410
+Sleep Sort,333,397,2.02332760
+Sleep Sort,333,398,2.01002880
+Sleep Sort,333,399,1.99653160
+Sleep Sort,333,400,1.98145650
+Sleep Sort,333,401,2.04250190
+Sleep Sort,333,402,2.03329260
+Sleep Sort,333,403,2.03771240
+Sleep Sort,333,404,2.01063220
+Sleep Sort,333,405,2.01810690
+Sleep Sort,333,406,2.03724590
+Sleep Sort,333,407,2.04345430
+Sleep Sort,333,408,2.00289340
+Sleep Sort,333,409,2.01472270
+Sleep Sort,333,410,2.03530760
+Sleep Sort,333,411,2.01784600
+Sleep Sort,333,412,2.04098410
+Sleep Sort,333,413,2.02208330
+Sleep Sort,333,414,2.03481450
+Sleep Sort,333,415,2.04267010
+Sleep Sort,333,416,2.02887570
+Sleep Sort,333,417,2.04318940
+Sleep Sort,333,418,2.02118190
+Sleep Sort,333,419,2.01542030
+Sleep Sort,333,420,2.01480140
+Sleep Sort,333,421,2.03279200
+Sleep Sort,333,422,2.01705670
+Sleep Sort,333,423,2.01658310
+Sleep Sort,333,424,2.02164840
+Sleep Sort,333,425,2.03841150
+Sleep Sort,333,426,2.01034810
+Sleep Sort,333,427,1.99541570
+Sleep Sort,333,428,2.00222900
+Sleep Sort,333,429,2.01087910
+Sleep Sort,333,430,2.02360390
+Sleep Sort,333,431,2.02670130
+Sleep Sort,333,432,2.01075630
+Sleep Sort,333,433,2.03798550
+Sleep Sort,333,434,1.99940080
+Sleep Sort,333,435,2.01547830
+Sleep Sort,333,436,1.99505330
+Sleep Sort,333,437,2.00884120
+Sleep Sort,333,438,2.00041360
+Sleep Sort,333,439,2.03869750
+Sleep Sort,333,440,2.03671700
+Sleep Sort,333,441,2.00904480
+Sleep Sort,333,442,2.04205920
+Sleep Sort,333,443,2.03043200
+Sleep Sort,333,444,2.04472350
+Sleep Sort,333,445,2.01033930
+Sleep Sort,333,446,2.02754580
+Sleep Sort,333,447,2.03237610
+Sleep Sort,333,448,2.02979930
+Sleep Sort,333,449,2.04020890
+Sleep Sort,333,450,2.03924880
+Sleep Sort,333,451,2.01613090
+Sleep Sort,333,452,2.02363310
+Sleep Sort,333,453,2.03818540
+Sleep Sort,333,454,2.02021220
+Sleep Sort,333,455,2.01601380
+Sleep Sort,333,456,2.01528610
+Sleep Sort,333,457,2.03114270
+Sleep Sort,333,458,2.02676710
+Sleep Sort,333,459,2.04106630
+Sleep Sort,333,460,2.03854410
+Sleep Sort,333,461,2.00564060
+Sleep Sort,333,462,2.00352540
+Sleep Sort,333,463,2.01746870
+Sleep Sort,333,464,1.97907920
+Sleep Sort,333,465,2.01784240
+Sleep Sort,333,466,2.01907190
+Sleep Sort,333,467,2.02955990
+Sleep Sort,333,468,2.02345650
+Sleep Sort,333,469,2.02468900
+Sleep Sort,333,470,2.01924540
+Sleep Sort,333,471,2.03369740
+Sleep Sort,333,472,2.00613570
+Sleep Sort,333,473,2.02563900
+Sleep Sort,333,474,2.01309810
+Sleep Sort,333,475,2.00291940
+Sleep Sort,333,476,2.03325950
+Sleep Sort,333,477,2.01063420
+Sleep Sort,333,478,2.01453460
+Sleep Sort,333,479,2.03727060
+Sleep Sort,333,480,2.04206710
+Sleep Sort,333,481,2.01699830
+Sleep Sort,333,482,2.02842560
+Sleep Sort,333,483,2.03059100
+Sleep Sort,333,484,2.04111320
+Sleep Sort,333,485,2.03055790
+Sleep Sort,333,486,2.04399710
+Sleep Sort,333,487,2.00665780
+Sleep Sort,333,488,2.03593120
+Sleep Sort,333,489,2.01370070
+Sleep Sort,333,490,2.01676040
+Sleep Sort,333,491,2.04310370
+Sleep Sort,333,492,2.01701240
+Sleep Sort,333,493,2.01158600
+Sleep Sort,333,494,2.01938990
+Sleep Sort,333,495,2.00429170
+Sleep Sort,333,496,2.02390090
+Sleep Sort,333,497,2.02281950
+Sleep Sort,333,498,2.00689960
+Sleep Sort,333,499,2.03260720
+Sleep Sort,333,500,2.02871320
+Slowsort,333,1,1876.16044820
+Slowsort,333,2,1880.23352810
+Slowsort,333,3,1880.68322770
+Slowsort,333,4,2237.74447190
+Slowsort,333,5,1881.07128900
+Slowsort,333,6,2233.39122140
+Slowsort,333,7,1880.71309700
+Slowsort,333,8,2236.89100390
+Slowsort,333,9,2224.68084760
+Slowsort,333,10,2230.62962370
+Slowsort,333,11,2230.98882350
+Slowsort,333,12,2236.58930670
+Slowsort,333,13,1883.97487440
+Slowsort,333,14,2233.61422780
+Slowsort,333,15,1864.62264960
+Slowsort,333,16,1868.21141890
+Slowsort,333,17,1868.67402740
+Slowsort,333,18,1867.37146470
+Slowsort,333,19,1867.93057210
+Slowsort,333,20,1868.39388880
+Slowsort,333,21,2172.23305150
+Slowsort,333,22,2174.56048090
+Slowsort,333,23,2175.24699970
+Slowsort,333,24,2178.64340920
+Slowsort,333,25,2180.51714570
+Slowsort,333,26,2186.39455950
+Slowsort,333,27,2180.82063070
+Slowsort,333,28,2178.85617030
+Slowsort,333,29,1768.49215250
+Slowsort,333,30,1771.98329320
+Slowsort,333,31,1773.02436490
+Slowsort,333,32,1770.63236120
+Slowsort,333,33,1770.23465610
+Slowsort,333,34,1771.59634590
+Slowsort,333,35,2089.11781890
+Slowsort,333,36,2094.31369300
+Slowsort,333,37,2096.69814390
+Slowsort,333,38,2095.26741080
+Slowsort,333,39,2099.14960100
+Slowsort,333,40,2099.19484480
+Slowsort,333,41,2100.41154910
+Slowsort,333,42,2104.87459250
+Slowsort,333,43,1773.62176470
+Slowsort,333,44,1778.42711250
+Slowsort,333,45,1774.81294290
+Slowsort,333,46,1777.15912960
+Slowsort,333,47,1778.94049490
+Slowsort,333,48,1779.01433700
+Slowsort,333,49,2090.71095380
+Slowsort,333,50,2094.65044450
+Slowsort,333,51,2096.93789210
+Slowsort,333,52,2097.86157700
+Slowsort,333,53,2097.64399110
+Slowsort,333,54,2099.57114630
+Slowsort,333,55,2102.16341100
+Slowsort,333,56,2107.58652740
+Slowsort,333,57,1773.62211570
+Slowsort,333,58,1774.45268620
+Slowsort,333,59,1775.23595740
+Slowsort,333,60,1776.11093010
+Slowsort,333,61,1778.08876640
+Slowsort,333,62,1777.25321590
+Slowsort,333,63,2087.00232180
+Slowsort,333,64,2091.17785650
+Slowsort,333,65,2093.42359980
+Slowsort,333,66,2095.72715360
+Slowsort,333,67,2096.36006580
+Slowsort,333,68,2097.33571110
+Slowsort,333,69,2097.37494600
+Slowsort,333,70,2104.95601180
+Slowsort,333,71,1784.28996030
+Slowsort,333,72,1784.93647440
+Slowsort,333,73,1785.70866090
+Slowsort,333,74,1786.97634410
+Slowsort,333,75,1787.51708730
+Slowsort,333,76,1789.53529060
+Slowsort,333,77,2090.25132180
+Slowsort,333,78,2093.22979320
+Slowsort,333,79,2093.84355660
+Slowsort,333,80,2098.41130110
+Slowsort,333,81,2099.63018310
+Slowsort,333,82,2098.37882680
+Slowsort,333,83,2100.64865690
+Slowsort,333,84,2106.75780090
+Slowsort,333,85,1785.10043120
+Slowsort,333,86,1788.00535600
+Slowsort,333,87,1787.43266160
+Slowsort,333,88,1788.00592150
+Slowsort,333,89,1788.56495990
+Slowsort,333,90,1789.80168780
+Slowsort,333,91,1770.82168980
+Slowsort,333,92,1774.39964890
+Slowsort,333,93,1773.01132460
+Slowsort,333,94,1776.41816330
+Slowsort,333,95,1778.17750790
+Slowsort,333,96,1777.40778840
+Slowsort,333,97,2085.01745920
+Slowsort,333,98,2091.39224180
+Slowsort,333,99,2092.03037070
+Slowsort,333,100,2094.31716100
+Slowsort,333,101,2093.99991680
+Slowsort,333,102,2094.87730020
+Slowsort,333,103,2097.01841050
+Slowsort,333,104,2102.72425940
+Slowsort,333,105,1769.96589070
+Slowsort,333,106,1771.44766750
+Slowsort,333,107,1770.74614990
+Slowsort,333,108,1774.11338360
+Slowsort,333,109,1774.66016790
+Slowsort,333,110,1772.66429140
+Slowsort,333,111,2087.95467950
+Slowsort,333,112,2094.24968150
+Slowsort,333,113,2094.33872790
+Slowsort,333,114,2097.49020110
+Slowsort,333,115,2096.66058120
+Slowsort,333,116,2098.46758820
+Slowsort,333,117,2100.56163020
+Slowsort,333,118,2102.39785030
+Slowsort,333,119,1774.44521150
+Slowsort,333,120,1776.94866980
+Slowsort,333,121,1775.93593360
+Slowsort,333,122,1778.31346220
+Slowsort,333,123,1778.16311870
+Slowsort,333,124,1779.00356480
+Slowsort,333,125,2099.89018040
+Slowsort,333,126,2102.10664350
+Slowsort,333,127,2104.43589310
+Slowsort,333,128,2107.77210580
+Slowsort,333,129,2109.34793310
+Slowsort,333,130,2109.61952500
+Slowsort,333,131,2111.51426780
+Slowsort,333,132,2116.48471450
+Slowsort,333,133,1767.90806130
+Slowsort,333,134,1771.21099740
+Slowsort,333,135,1769.34351370
+Slowsort,333,136,1771.71936130
+Slowsort,333,137,1772.61334820
+Slowsort,333,138,1771.99909130
+Slowsort,333,139,2094.73258430
+Slowsort,333,140,2106.75590540
+Slowsort,333,141,2107.89232590
+Slowsort,333,142,2114.61007810
+Slowsort,333,143,2113.96999860
+Slowsort,333,144,2118.04581820
+Slowsort,333,145,2117.01873190
+Slowsort,333,146,2122.39602640
+Slowsort,333,147,1782.29397210
+Slowsort,333,148,1786.01471110
+Slowsort,333,149,1786.79105310
+Slowsort,333,150,1788.13990480
+Slowsort,333,151,1786.44391860
+Slowsort,333,152,1786.03311690
+Slowsort,333,153,2290.30372720
+Slowsort,333,154,2303.60777640
+Slowsort,333,155,2293.87331850
+Slowsort,333,156,2312.55803230
+Slowsort,333,157,2315.24119450
+Slowsort,333,158,2309.15002600
+Slowsort,333,159,2315.45809050
+Slowsort,333,160,2336.62718990
+Slowsort,333,161,1964.65383060
+Slowsort,333,162,1983.56035590
+Slowsort,333,163,1982.15826620
+Slowsort,333,164,1983.29059680
+Slowsort,333,165,1981.13263300
+Slowsort,333,166,1989.12982500
+Slowsort,333,167,1597.77251110
+Slowsort,333,168,1594.39619250
+Slowsort,333,169,1593.27649070
+Slowsort,333,170,1594.73672140
+Slowsort,333,171,1589.95724960
+Slowsort,333,172,1592.32636110
+Slowsort,333,173,1593.85449220
+Slowsort,333,174,1603.42358460
+Slowsort,333,175,1610.62646230
+Slowsort,333,176,1611.85674050
+Slowsort,333,177,1611.84511900
+Slowsort,333,178,1612.41684510
+Slowsort,333,179,1612.13861720
+Slowsort,333,180,1613.97252990
+Slowsort,333,181,1612.33740980
+Slowsort,333,182,1619.92699700
+Slowsort,333,183,1479.35877260
+Slowsort,333,184,1466.29584730
+Slowsort,333,185,1469.99242260
+Slowsort,333,186,1471.16506750
+Slowsort,333,187,1469.21902500
+Slowsort,333,188,1472.84511540
+Slowsort,333,189,1470.38244930
+Slowsort,333,190,1467.96711620
+Slowsort,333,191,1539.09357110
+Slowsort,333,192,1542.73434420
+Slowsort,333,193,1541.57200900
+Slowsort,333,194,1542.89285580
+Slowsort,333,195,1545.23601390
+Slowsort,333,196,1544.72736270
+Slowsort,333,197,1546.63291810
+Slowsort,333,198,1554.10531250
+Slowsort,333,199,1577.32089390
+Slowsort,333,200,1580.76874620
+Slowsort,333,201,1578.33269040
+Slowsort,333,202,1579.43256970
+Slowsort,333,203,1580.99720810
+Slowsort,333,204,1580.54189080
+Slowsort,333,205,1580.65018230
+Slowsort,333,206,1588.27538390
+Slowsort,333,207,1578.28048710
+Slowsort,333,208,1579.12356190
+Slowsort,333,209,1578.76511660
+Slowsort,333,210,1578.74161670
+Slowsort,333,211,1581.05247770
+Slowsort,333,212,1581.88259650
+Slowsort,333,213,1581.56025650
+Slowsort,333,214,1588.25854540
+Slowsort,333,215,1548.78043680
+Slowsort,333,216,1550.52327840
+Slowsort,333,217,1552.07780750
+Slowsort,333,218,1551.07266730
+Slowsort,333,219,1553.57912230
+Slowsort,333,220,1554.51120170
+Slowsort,333,221,1553.97630960
+Slowsort,333,222,1561.03131620
+Slowsort,333,223,1497.70655030
+Slowsort,333,224,1498.90156910
+Slowsort,333,225,1499.11009150
+Slowsort,333,226,1499.06590210
+Slowsort,333,227,1499.40423000
+Slowsort,333,228,1501.98110790
+Slowsort,333,229,1500.38586660
+Slowsort,333,230,1505.77142270
+Slowsort,333,231,1572.06407200
+Slowsort,333,232,1575.82767440
+Slowsort,333,233,1576.58225330
+Slowsort,333,234,1577.43148820
+Slowsort,333,235,1580.18006540
+Slowsort,333,236,1580.05589900
+Slowsort,333,237,1580.77550390
+Slowsort,333,238,1590.80134840
+Slowsort,333,239,1589.29188140
+Slowsort,333,240,1589.99191140
+Slowsort,333,241,1592.00217820
+Slowsort,333,242,1592.88129920
+Slowsort,333,243,1594.44198230
+Slowsort,333,244,1594.65804390
+Slowsort,333,245,1594.10839430
+Slowsort,333,246,1598.78334790
+Slowsort,333,247,1587.74346400
+Slowsort,333,248,1590.17762190
+Slowsort,333,249,1589.70927960
+Slowsort,333,250,1591.89509520
+Slowsort,333,251,1593.74531570
+Slowsort,333,252,1593.36765140
+Slowsort,333,253,1593.73372950
+Slowsort,333,254,1600.28218520
+Slowsort,333,255,1590.01408720
+Slowsort,333,256,1591.32740900
+Slowsort,333,257,1591.48624060
+Slowsort,333,258,1591.78541400
+Slowsort,333,259,1595.09745720
+Slowsort,333,260,1596.28284410
+Slowsort,333,261,1595.68770730
+Slowsort,333,262,1600.90349000
+Slowsort,333,263,1589.59485260
+Slowsort,333,264,1592.16960660
+Slowsort,333,265,1591.91313940
+Slowsort,333,266,1595.20559240
+Slowsort,333,267,1598.16649130
+Slowsort,333,268,1599.58569730
+Slowsort,333,269,1596.48326950
+Slowsort,333,270,1602.46197350
+Slowsort,333,271,1613.14350290
+Slowsort,333,272,1614.81152640
+Slowsort,333,273,1614.58600580
+Slowsort,333,274,1615.06428510
+Slowsort,333,275,1621.31808100
+Slowsort,333,276,1619.00728780
+Slowsort,333,277,1619.83063400
+Slowsort,333,278,1625.48821650
+Slowsort,333,279,1525.74224710
+Slowsort,333,280,1526.50173430
+Slowsort,333,281,1527.04800380
+Slowsort,333,282,1528.44001150
+Slowsort,333,283,1531.73065270
+Slowsort,333,284,1528.84201520
+Slowsort,333,285,1530.90184210
+Slowsort,333,286,1532.25273730
+Slowsort,333,287,1499.89041110
+Slowsort,333,288,1499.67810950
+Slowsort,333,289,1499.61745590
+Slowsort,333,290,1499.80910370
+Slowsort,333,291,1502.37889470
+Slowsort,333,292,1505.48578880
+Slowsort,333,293,1499.00234250
+Slowsort,333,294,1499.98686220
+Slowsort,333,295,1398.28338350
+Slowsort,333,296,1391.39631750
+Slowsort,333,297,1395.21291050
+Slowsort,333,298,1393.02500840
+Slowsort,333,299,1397.98448620
+Slowsort,333,300,1390.33307090
+Slowsort,333,301,1398.03493660
+Slowsort,333,302,1400.41181620
+Slowsort,333,303,1377.85028130
+Slowsort,333,304,1380.90840040
+Slowsort,333,305,1384.21483640
+Slowsort,333,306,1381.11319030
+Slowsort,333,307,1379.56638440
+Slowsort,333,308,1383.02401930
+Slowsort,333,309,1391.43002790
+Slowsort,333,310,1392.32851170
+Slowsort,333,311,1381.03738060
+Slowsort,333,312,1381.35590500
+Slowsort,333,313,1383.53716870
+Slowsort,333,314,1383.78084760
+Slowsort,333,315,1385.12123940
+Slowsort,333,316,1386.49799820
+Slowsort,333,317,1389.29063800
+Slowsort,333,318,1391.90886380
+Slowsort,333,319,1380.71927960
+Slowsort,333,320,1383.12989670
+Slowsort,333,321,1380.61011160
+Slowsort,333,322,1381.31268290
+Slowsort,333,323,1380.01117620
+Slowsort,333,324,1380.50610660
+Slowsort,333,325,1382.74981990
+Slowsort,333,326,1392.17973490
+Slowsort,333,327,1379.73767320
+Slowsort,333,328,1373.88688260
+Slowsort,333,329,1371.68163740
+Slowsort,333,330,1374.31523720
+Slowsort,333,331,1371.08044520
+Slowsort,333,332,1376.37944380
+Slowsort,333,333,1379.98118520
+Slowsort,333,334,1375.72381070
+Slowsort,333,335,1313.37698220
+Slowsort,333,336,1307.32171310
+Slowsort,333,337,1313.68793590
+Slowsort,333,338,1307.24928220
+Slowsort,333,339,1306.83590400
+Slowsort,333,340,1319.50995760
+Slowsort,333,341,1319.69058530
+Slowsort,333,342,1324.04437330
+Slowsort,333,343,2022.86914840
+Slowsort,333,344,1732.77759420
+Slowsort,333,345,1734.18303230
+Slowsort,333,346,1732.19617410
+Slowsort,333,347,1733.49281040
+Slowsort,333,348,1737.29380670
+Slowsort,333,349,1731.21649440
+Slowsort,333,350,1735.65898100
+Slowsort,333,351,1734.21253830
+Slowsort,333,352,1742.52627580
+Slowsort,333,353,1736.69598990
+Slowsort,333,354,1730.14329810
+Slowsort,333,355,1735.14896050
+Slowsort,333,356,1729.96284920
+Slowsort,333,357,1729.31284910
+Slowsort,333,358,1734.64809820
+Slowsort,333,359,1734.29766930
+Slowsort,333,360,1732.49694830
+Slowsort,333,361,1732.49562910
+Slowsort,333,362,1733.18865500
+Slowsort,333,363,1731.97024540
+Slowsort,333,364,1732.47084030
+Slowsort,333,365,1736.68523590
+Slowsort,333,366,1731.63133210
+Slowsort,333,367,1736.60455660
+Slowsort,333,368,1728.50701150
+Slowsort,333,369,1741.90303060
+Slowsort,333,370,2028.06165310
+Slowsort,333,371,1722.26452250
+Slowsort,333,372,1724.54436480
+Slowsort,333,373,1726.72950660
+Slowsort,333,374,1723.22530780
+Slowsort,333,375,1724.15310260
+Slowsort,333,376,1722.50586460
+Slowsort,333,377,1724.79223710
+Slowsort,333,378,1729.82154130
+Slowsort,333,379,1725.72632500
+Slowsort,333,380,1726.56876770
+Slowsort,333,381,1725.46206610
+Slowsort,333,382,1727.94313850
+Slowsort,333,383,1734.51695000
+Slowsort,333,384,2029.77125000
+Slowsort,333,385,1718.18543520
+Slowsort,333,386,1717.92679970
+Slowsort,333,387,1719.81931920
+Slowsort,333,388,1717.58720640
+Slowsort,333,389,1718.34728720
+Slowsort,333,390,1721.14314620
+Slowsort,333,391,1720.84610820
+Slowsort,333,392,1720.93210500
+Slowsort,333,393,1721.91748250
+Slowsort,333,394,1719.59072330
+Slowsort,333,395,1719.13935630
+Slowsort,333,396,1722.96148500
+Slowsort,333,397,1729.69409560
+Slowsort,333,398,2035.50920480
+Slowsort,333,399,1725.93341870
+Slowsort,333,400,1726.92077710
+Slowsort,333,401,1728.45858990
+Slowsort,333,402,1729.11739550
+Slowsort,333,403,1728.03561890
+Slowsort,333,404,1729.70372240
+Slowsort,333,405,1727.86362260
+Slowsort,333,406,1731.55872360
+Slowsort,333,407,1731.50358250
+Slowsort,333,408,1729.97841230
+Slowsort,333,409,1731.25084960
+Slowsort,333,410,1735.00624420
+Slowsort,333,411,1739.24803610
+Slowsort,333,412,2026.01144410
+Slowsort,333,413,1718.63686020
+Slowsort,333,414,1720.93583230
+Slowsort,333,415,1719.77092610
+Slowsort,333,416,1717.56481850
+Slowsort,333,417,1721.61008000
+Slowsort,333,418,1720.56189440
+Slowsort,333,419,1721.64173550
+Slowsort,333,420,1723.71424180
+Slowsort,333,421,1717.85032310
+Slowsort,333,422,1722.55821720
+Slowsort,333,423,1723.08157230
+Slowsort,333,424,1724.45711520
+Slowsort,333,425,1730.37339620
+Slowsort,333,426,2016.68374540
+Slowsort,333,427,1723.20961850
+Slowsort,333,428,1724.25936520
+Slowsort,333,429,1725.75943710
+Slowsort,333,430,1724.87319910
+Slowsort,333,431,1724.25837040
+Slowsort,333,432,1727.30342230
+Slowsort,333,433,1728.70573440
+Slowsort,333,434,1723.41138930
+Slowsort,333,435,1727.32164450
+Slowsort,333,436,1728.61523430
+Slowsort,333,437,1729.07793880
+Slowsort,333,438,1729.92664710
+Slowsort,333,439,1736.16528120
+Slowsort,333,440,1737.14116280
+Slowsort,333,441,1737.22184840
+Slowsort,333,442,1741.03194010
+Slowsort,333,443,1740.17419600
+Slowsort,333,444,1737.42904660
+Slowsort,333,445,1738.30094500
+Slowsort,333,446,1743.70402340
+Slowsort,333,447,1741.68364370
+Slowsort,333,448,1743.19627380
+Slowsort,333,449,1742.22878720
+Slowsort,333,450,1738.27339740
+Slowsort,333,451,1743.76314890
+Slowsort,333,452,1750.21674490
+Slowsort,333,453,2021.90962830
+Slowsort,333,454,1723.57608990
+Slowsort,333,455,1723.89990100
+Slowsort,333,456,1726.75384520
+Slowsort,333,457,1725.71333760
+Slowsort,333,458,1726.31561330
+Slowsort,333,459,1728.16175030
+Slowsort,333,460,1726.86046910
+Slowsort,333,461,1728.91490120
+Slowsort,333,462,1727.54806390
+Slowsort,333,463,1727.08528380
+Slowsort,333,464,1730.05317770
+Slowsort,333,465,1728.90636600
+Slowsort,333,466,1736.27390380
+Slowsort,333,467,2010.38165730
+Slowsort,333,468,1722.81825720
+Slowsort,333,469,1721.03514540
+Slowsort,333,470,1725.30009340
+Slowsort,333,471,1724.34813750
+Slowsort,333,472,1724.35983020
+Slowsort,333,473,1727.18643530
+Slowsort,333,474,1726.94283240
+Slowsort,333,475,1727.17029890
+Slowsort,333,476,1725.20672300
+Slowsort,333,477,1725.14553200
+Slowsort,333,478,1727.54329170
+Slowsort,333,479,1729.31435010
+Slowsort,333,480,1734.45600100
+Slowsort,333,481,2014.36287140
+Slowsort,333,482,1726.08387580
+Slowsort,333,483,1726.46933260
+Slowsort,333,484,1725.75991130
+Slowsort,333,485,1726.11731350
+Slowsort,333,486,1727.52957640
+Slowsort,333,487,1728.92760800
+Slowsort,333,488,1728.47286190
+Slowsort,333,489,1729.76249100
+Slowsort,333,490,1726.58933250
+Slowsort,333,491,1726.99199040
+Slowsort,333,492,1728.89492160
+Slowsort,333,493,1731.75274370
+Slowsort,333,494,1734.73418050
+Slowsort,333,495,1658.02545080
+Slowsort,333,496,1173.15732290
+Slowsort,333,497,1171.90648620
+Slowsort,333,498,1166.28962550
+Slowsort,333,499,1169.12155820
+Slowsort,333,500,1167.56819420
+Smooth Sort,333,1,0.00815780
+Smooth Sort,333,2,0.01022530
+Smooth Sort,333,3,0.00942900
+Smooth Sort,333,4,0.00932820
+Smooth Sort,333,5,0.01052060
+Smooth Sort,333,6,0.00936720
+Smooth Sort,333,7,0.01007970
+Smooth Sort,333,8,0.01106100
+Smooth Sort,333,9,0.01077370
+Smooth Sort,333,10,0.01080410
+Smooth Sort,333,11,0.01086650
+Smooth Sort,333,12,0.01088260
+Smooth Sort,333,13,0.01193400
+Smooth Sort,333,14,0.01023780
+Smooth Sort,333,15,0.01084360
+Smooth Sort,333,16,0.01028100
+Smooth Sort,333,17,0.01051450
+Smooth Sort,333,18,0.01021460
+Smooth Sort,333,19,0.01035350
+Smooth Sort,333,20,0.01030250
+Smooth Sort,333,21,0.00946350
+Smooth Sort,333,22,0.00996840
+Smooth Sort,333,23,0.01024180
+Smooth Sort,333,24,0.01144960
+Smooth Sort,333,25,0.01058430
+Smooth Sort,333,26,0.01152840
+Smooth Sort,333,27,0.01279920
+Smooth Sort,333,28,0.01093030
+Smooth Sort,333,29,0.01072980
+Smooth Sort,333,30,0.01008930
+Smooth Sort,333,31,0.01091110
+Smooth Sort,333,32,0.01021040
+Smooth Sort,333,33,0.00981790
+Smooth Sort,333,34,0.01052920
+Smooth Sort,333,35,0.01049790
+Smooth Sort,333,36,0.00943970
+Smooth Sort,333,37,0.00832420
+Smooth Sort,333,38,0.01013680
+Smooth Sort,333,39,0.00878000
+Smooth Sort,333,40,0.01134950
+Smooth Sort,333,41,0.01051930
+Smooth Sort,333,42,0.01055380
+Smooth Sort,333,43,0.01126030
+Smooth Sort,333,44,0.01098480
+Smooth Sort,333,45,0.01120460
+Smooth Sort,333,46,0.01080730
+Smooth Sort,333,47,0.01065050
+Smooth Sort,333,48,0.01141840
+Smooth Sort,333,49,0.01127410
+Smooth Sort,333,50,0.01075100
+Smooth Sort,333,51,0.01089080
+Smooth Sort,333,52,0.01103130
+Smooth Sort,333,53,0.01078590
+Smooth Sort,333,54,0.01044790
+Smooth Sort,333,55,0.01010460
+Smooth Sort,333,56,0.01118150
+Smooth Sort,333,57,0.01904010
+Smooth Sort,333,58,0.01333080
+Smooth Sort,333,59,0.01197230
+Smooth Sort,333,60,0.01024830
+Smooth Sort,333,61,0.01078520
+Smooth Sort,333,62,0.01076550
+Smooth Sort,333,63,0.01033920
+Smooth Sort,333,64,0.00937120
+Smooth Sort,333,65,0.00680610
+Smooth Sort,333,66,0.00766750
+Smooth Sort,333,67,0.01022480
+Smooth Sort,333,68,0.01024610
+Smooth Sort,333,69,0.01041760
+Smooth Sort,333,70,0.01065510
+Smooth Sort,333,71,0.01122470
+Smooth Sort,333,72,0.01073210
+Smooth Sort,333,73,0.01087540
+Smooth Sort,333,74,0.01400680
+Smooth Sort,333,75,0.01067710
+Smooth Sort,333,76,0.01039470
+Smooth Sort,333,77,0.01071180
+Smooth Sort,333,78,0.00912010
+Smooth Sort,333,79,0.00939310
+Smooth Sort,333,80,0.01113640
+Smooth Sort,333,81,0.01012220
+Smooth Sort,333,82,0.01046050
+Smooth Sort,333,83,0.01052190
+Smooth Sort,333,84,0.01076410
+Smooth Sort,333,85,0.01084570
+Smooth Sort,333,86,0.00895740
+Smooth Sort,333,87,0.01023390
+Smooth Sort,333,88,0.01047750
+Smooth Sort,333,89,0.01131020
+Smooth Sort,333,90,0.01120390
+Smooth Sort,333,91,0.01063990
+Smooth Sort,333,92,0.01120020
+Smooth Sort,333,93,0.01038060
+Smooth Sort,333,94,0.01073180
+Smooth Sort,333,95,0.01048980
+Smooth Sort,333,96,0.01046940
+Smooth Sort,333,97,0.01027390
+Smooth Sort,333,98,0.00968280
+Smooth Sort,333,99,0.00954310
+Smooth Sort,333,100,0.01098480
+Smooth Sort,333,101,0.01123220
+Smooth Sort,333,102,0.01046190
+Smooth Sort,333,103,0.01076310
+Smooth Sort,333,104,0.01310440
+Smooth Sort,333,105,0.00996190
+Smooth Sort,333,106,0.00973400
+Smooth Sort,333,107,0.00858780
+Smooth Sort,333,108,0.00707100
+Smooth Sort,333,109,0.01014540
+Smooth Sort,333,110,0.01080200
+Smooth Sort,333,111,0.01031990
+Smooth Sort,333,112,0.01007130
+Smooth Sort,333,113,0.01074820
+Smooth Sort,333,114,0.01046060
+Smooth Sort,333,115,0.00965860
+Smooth Sort,333,116,0.01062240
+Smooth Sort,333,117,0.01084110
+Smooth Sort,333,118,0.01105690
+Smooth Sort,333,119,0.00982340
+Smooth Sort,333,120,0.01117740
+Smooth Sort,333,121,0.01094230
+Smooth Sort,333,122,0.00977640
+Smooth Sort,333,123,0.01091160
+Smooth Sort,333,124,0.01056800
+Smooth Sort,333,125,0.01093680
+Smooth Sort,333,126,0.01060400
+Smooth Sort,333,127,0.01039370
+Smooth Sort,333,128,0.01123140
+Smooth Sort,333,129,0.01104020
+Smooth Sort,333,130,0.01100620
+Smooth Sort,333,131,0.01082430
+Smooth Sort,333,132,0.01102410
+Smooth Sort,333,133,0.01127410
+Smooth Sort,333,134,0.01083360
+Smooth Sort,333,135,0.00968440
+Smooth Sort,333,136,0.01097560
+Smooth Sort,333,137,0.01067110
+Smooth Sort,333,138,0.01039990
+Smooth Sort,333,139,0.01013940
+Smooth Sort,333,140,0.01006020
+Smooth Sort,333,141,0.01064310
+Smooth Sort,333,142,0.01067020
+Smooth Sort,333,143,0.01073030
+Smooth Sort,333,144,0.01064220
+Smooth Sort,333,145,0.01084850
+Smooth Sort,333,146,0.01092140
+Smooth Sort,333,147,0.01090540
+Smooth Sort,333,148,0.01095810
+Smooth Sort,333,149,0.01054420
+Smooth Sort,333,150,0.01760530
+Smooth Sort,333,151,0.01107140
+Smooth Sort,333,152,0.01084490
+Smooth Sort,333,153,0.01588340
+Smooth Sort,333,154,0.01065610
+Smooth Sort,333,155,0.01012290
+Smooth Sort,333,156,0.01147540
+Smooth Sort,333,157,0.01020080
+Smooth Sort,333,158,0.01071210
+Smooth Sort,333,159,0.01113460
+Smooth Sort,333,160,0.01198840
+Smooth Sort,333,161,0.01069330
+Smooth Sort,333,162,0.01083570
+Smooth Sort,333,163,0.01115340
+Smooth Sort,333,164,0.01024120
+Smooth Sort,333,165,0.01088430
+Smooth Sort,333,166,0.01147790
+Smooth Sort,333,167,0.01137250
+Smooth Sort,333,168,0.01128810
+Smooth Sort,333,169,0.01130460
+Smooth Sort,333,170,0.01012930
+Smooth Sort,333,171,0.00958840
+Smooth Sort,333,172,0.01018640
+Smooth Sort,333,173,0.01153380
+Smooth Sort,333,174,0.01043960
+Smooth Sort,333,175,0.01074980
+Smooth Sort,333,176,0.01095400
+Smooth Sort,333,177,0.01031370
+Smooth Sort,333,178,0.01077060
+Smooth Sort,333,179,0.01082580
+Smooth Sort,333,180,0.01077470
+Smooth Sort,333,181,0.01091640
+Smooth Sort,333,182,0.01133460
+Smooth Sort,333,183,0.00910730
+Smooth Sort,333,184,0.00983070
+Smooth Sort,333,185,0.01130220
+Smooth Sort,333,186,0.01050090
+Smooth Sort,333,187,0.01065120
+Smooth Sort,333,188,0.01103490
+Smooth Sort,333,189,0.01049780
+Smooth Sort,333,190,0.01111420
+Smooth Sort,333,191,0.01068310
+Smooth Sort,333,192,0.01067290
+Smooth Sort,333,193,0.01069530
+Smooth Sort,333,194,0.01210570
+Smooth Sort,333,195,0.01521960
+Smooth Sort,333,196,0.01098960
+Smooth Sort,333,197,0.01059760
+Smooth Sort,333,198,0.01116890
+Smooth Sort,333,199,0.01031110
+Smooth Sort,333,200,0.00701600
+Smooth Sort,333,201,0.01035540
+Smooth Sort,333,202,0.01004520
+Smooth Sort,333,203,0.01063490
+Smooth Sort,333,204,0.00939860
+Smooth Sort,333,205,0.01115360
+Smooth Sort,333,206,0.01010510
+Smooth Sort,333,207,0.00925820
+Smooth Sort,333,208,0.01098140
+Smooth Sort,333,209,0.01086480
+Smooth Sort,333,210,0.01034510
+Smooth Sort,333,211,0.01058390
+Smooth Sort,333,212,0.01105830
+Smooth Sort,333,213,0.01054350
+Smooth Sort,333,214,0.01040610
+Smooth Sort,333,215,0.01096630
+Smooth Sort,333,216,0.00982900
+Smooth Sort,333,217,0.01036880
+Smooth Sort,333,218,0.01004170
+Smooth Sort,333,219,0.01093920
+Smooth Sort,333,220,0.01044980
+Smooth Sort,333,221,0.01096210
+Smooth Sort,333,222,0.01023850
+Smooth Sort,333,223,0.01006460
+Smooth Sort,333,224,0.01117570
+Smooth Sort,333,225,0.01105740
+Smooth Sort,333,226,0.01021310
+Smooth Sort,333,227,0.01005500
+Smooth Sort,333,228,0.01064480
+Smooth Sort,333,229,0.01043310
+Smooth Sort,333,230,0.01082790
+Smooth Sort,333,231,0.01024980
+Smooth Sort,333,232,0.01040820
+Smooth Sort,333,233,0.01051490
+Smooth Sort,333,234,0.00862070
+Smooth Sort,333,235,0.01082770
+Smooth Sort,333,236,0.01047920
+Smooth Sort,333,237,0.01101080
+Smooth Sort,333,238,0.01039880
+Smooth Sort,333,239,0.01129090
+Smooth Sort,333,240,0.01200920
+Smooth Sort,333,241,0.01088940
+Smooth Sort,333,242,0.01450480
+Smooth Sort,333,243,0.01051270
+Smooth Sort,333,244,0.01501950
+Smooth Sort,333,245,0.01087270
+Smooth Sort,333,246,0.01033460
+Smooth Sort,333,247,0.01023830
+Smooth Sort,333,248,0.01072830
+Smooth Sort,333,249,0.01133820
+Smooth Sort,333,250,0.01078310
+Smooth Sort,333,251,0.01111760
+Smooth Sort,333,252,0.01099940
+Smooth Sort,333,253,0.01003940
+Smooth Sort,333,254,0.01050300
+Smooth Sort,333,255,0.01266200
+Smooth Sort,333,256,0.01319320
+Smooth Sort,333,257,0.01489700
+Smooth Sort,333,258,0.01183760
+Smooth Sort,333,259,0.01059560
+Smooth Sort,333,260,0.01050690
+Smooth Sort,333,261,0.01067080
+Smooth Sort,333,262,0.01160220
+Smooth Sort,333,263,0.01088490
+Smooth Sort,333,264,0.01061990
+Smooth Sort,333,265,0.01021350
+Smooth Sort,333,266,0.01097410
+Smooth Sort,333,267,0.01080140
+Smooth Sort,333,268,0.01054570
+Smooth Sort,333,269,0.01120210
+Smooth Sort,333,270,0.00980170
+Smooth Sort,333,271,0.01146230
+Smooth Sort,333,272,0.01165780
+Smooth Sort,333,273,0.01197420
+Smooth Sort,333,274,0.01014760
+Smooth Sort,333,275,0.01147180
+Smooth Sort,333,276,0.00977080
+Smooth Sort,333,277,0.01093250
+Smooth Sort,333,278,0.00982130
+Smooth Sort,333,279,0.00995220
+Smooth Sort,333,280,0.00746050
+Smooth Sort,333,281,0.01040910
+Smooth Sort,333,282,0.00985070
+Smooth Sort,333,283,0.01141110
+Smooth Sort,333,284,0.00866230
+Smooth Sort,333,285,0.01021670
+Smooth Sort,333,286,0.01458440
+Smooth Sort,333,287,0.01302990
+Smooth Sort,333,288,0.01287890
+Smooth Sort,333,289,0.01128100
+Smooth Sort,333,290,0.00873190
+Smooth Sort,333,291,0.00782270
+Smooth Sort,333,292,0.01051220
+Smooth Sort,333,293,0.01054590
+Smooth Sort,333,294,0.01078610
+Smooth Sort,333,295,0.00744620
+Smooth Sort,333,296,0.01066470
+Smooth Sort,333,297,0.01014310
+Smooth Sort,333,298,0.01082310
+Smooth Sort,333,299,0.01066050
+Smooth Sort,333,300,0.01177760
+Smooth Sort,333,301,0.01046840
+Smooth Sort,333,302,0.01075600
+Smooth Sort,333,303,0.01095080
+Smooth Sort,333,304,0.01049530
+Smooth Sort,333,305,0.01138080
+Smooth Sort,333,306,0.01069510
+Smooth Sort,333,307,0.01056960
+Smooth Sort,333,308,0.01074660
+Smooth Sort,333,309,0.01083700
+Smooth Sort,333,310,0.00940670
+Smooth Sort,333,311,0.01072540
+Smooth Sort,333,312,0.01129760
+Smooth Sort,333,313,0.01094920
+Smooth Sort,333,314,0.00738320
+Smooth Sort,333,315,0.01114510
+Smooth Sort,333,316,0.01018880
+Smooth Sort,333,317,0.01036190
+Smooth Sort,333,318,0.01082800
+Smooth Sort,333,319,0.01124570
+Smooth Sort,333,320,0.01068200
+Smooth Sort,333,321,0.01098570
+Smooth Sort,333,322,0.00901540
+Smooth Sort,333,323,0.01084070
+Smooth Sort,333,324,0.00835800
+Smooth Sort,333,325,0.00631730
+Smooth Sort,333,326,0.01071550
+Smooth Sort,333,327,0.01068120
+Smooth Sort,333,328,0.01051240
+Smooth Sort,333,329,0.01025210
+Smooth Sort,333,330,0.01008740
+Smooth Sort,333,331,0.00919090
+Smooth Sort,333,332,0.01093600
+Smooth Sort,333,333,0.01125260
+Smooth Sort,333,334,0.01457840
+Smooth Sort,333,335,0.01045310
+Smooth Sort,333,336,0.01094760
+Smooth Sort,333,337,0.01067560
+Smooth Sort,333,338,0.01058930
+Smooth Sort,333,339,0.00997990
+Smooth Sort,333,340,0.01078810
+Smooth Sort,333,341,0.01107060
+Smooth Sort,333,342,0.00862710
+Smooth Sort,333,343,0.01007960
+Smooth Sort,333,344,0.01023640
+Smooth Sort,333,345,0.01068270
+Smooth Sort,333,346,0.01101680
+Smooth Sort,333,347,0.01045580
+Smooth Sort,333,348,0.01055720
+Smooth Sort,333,349,0.01122120
+Smooth Sort,333,350,0.01049940
+Smooth Sort,333,351,0.01070690
+Smooth Sort,333,352,0.01065910
+Smooth Sort,333,353,0.01042930
+Smooth Sort,333,354,0.00987420
+Smooth Sort,333,355,0.00674060
+Smooth Sort,333,356,0.01039660
+Smooth Sort,333,357,0.01132760
+Smooth Sort,333,358,0.01048530
+Smooth Sort,333,359,0.01101280
+Smooth Sort,333,360,0.00948630
+Smooth Sort,333,361,0.01068610
+Smooth Sort,333,362,0.01046980
+Smooth Sort,333,363,0.00959420
+Smooth Sort,333,364,0.01036140
+Smooth Sort,333,365,0.01076860
+Smooth Sort,333,366,0.01298020
+Smooth Sort,333,367,0.01006270
+Smooth Sort,333,368,0.01311390
+Smooth Sort,333,369,0.00986750
+Smooth Sort,333,370,0.00991540
+Smooth Sort,333,371,0.00922570
+Smooth Sort,333,372,0.00735120
+Smooth Sort,333,373,0.00711940
+Smooth Sort,333,374,0.01062550
+Smooth Sort,333,375,0.00906480
+Smooth Sort,333,376,0.01072880
+Smooth Sort,333,377,0.01077490
+Smooth Sort,333,378,0.01043960
+Smooth Sort,333,379,0.01305540
+Smooth Sort,333,380,0.01178030
+Smooth Sort,333,381,0.01389830
+Smooth Sort,333,382,0.01495850
+Smooth Sort,333,383,0.01185590
+Smooth Sort,333,384,0.01281900
+Smooth Sort,333,385,0.00987100
+Smooth Sort,333,386,0.00885330
+Smooth Sort,333,387,0.01076810
+Smooth Sort,333,388,0.00752040
+Smooth Sort,333,389,0.01058700
+Smooth Sort,333,390,0.00972130
+Smooth Sort,333,391,0.00927980
+Smooth Sort,333,392,0.00913650
+Smooth Sort,333,393,0.01057690
+Smooth Sort,333,394,0.00832130
+Smooth Sort,333,395,0.01021100
+Smooth Sort,333,396,0.00975980
+Smooth Sort,333,397,0.01071790
+Smooth Sort,333,398,0.01029140
+Smooth Sort,333,399,0.01073870
+Smooth Sort,333,400,0.01047780
+Smooth Sort,333,401,0.01027340
+Smooth Sort,333,402,0.01029450
+Smooth Sort,333,403,0.01034160
+Smooth Sort,333,404,0.01070450
+Smooth Sort,333,405,0.01076440
+Smooth Sort,333,406,0.01103330
+Smooth Sort,333,407,0.01027410
+Smooth Sort,333,408,0.01003620
+Smooth Sort,333,409,0.01040950
+Smooth Sort,333,410,0.00849580
+Smooth Sort,333,411,0.01121140
+Smooth Sort,333,412,0.01060120
+Smooth Sort,333,413,0.01058640
+Smooth Sort,333,414,0.01320910
+Smooth Sort,333,415,0.01072620
+Smooth Sort,333,416,0.01276300
+Smooth Sort,333,417,0.01080810
+Smooth Sort,333,418,0.01121990
+Smooth Sort,333,419,0.01100240
+Smooth Sort,333,420,0.01067430
+Smooth Sort,333,421,0.01049780
+Smooth Sort,333,422,0.01039350
+Smooth Sort,333,423,0.01045610
+Smooth Sort,333,424,0.01101690
+Smooth Sort,333,425,0.01091320
+Smooth Sort,333,426,0.01047080
+Smooth Sort,333,427,0.00695730
+Smooth Sort,333,428,0.01124890
+Smooth Sort,333,429,0.01055220
+Smooth Sort,333,430,0.01080380
+Smooth Sort,333,431,0.01073680
+Smooth Sort,333,432,0.01028300
+Smooth Sort,333,433,0.01041530
+Smooth Sort,333,434,0.01112310
+Smooth Sort,333,435,0.01028310
+Smooth Sort,333,436,0.01079730
+Smooth Sort,333,437,0.01091730
+Smooth Sort,333,438,0.01015420
+Smooth Sort,333,439,0.01005780
+Smooth Sort,333,440,0.01116700
+Smooth Sort,333,441,0.01080130
+Smooth Sort,333,442,0.01153320
+Smooth Sort,333,443,0.01020120
+Smooth Sort,333,444,0.01001220
+Smooth Sort,333,445,0.01125560
+Smooth Sort,333,446,0.01110450
+Smooth Sort,333,447,0.01076900
+Smooth Sort,333,448,0.01068790
+Smooth Sort,333,449,0.01058930
+Smooth Sort,333,450,0.01006210
+Smooth Sort,333,451,0.01036080
+Smooth Sort,333,452,0.01048370
+Smooth Sort,333,453,0.01130640
+Smooth Sort,333,454,0.00825350
+Smooth Sort,333,455,0.01104300
+Smooth Sort,333,456,0.00807030
+Smooth Sort,333,457,0.01047110
+Smooth Sort,333,458,0.00972140
+Smooth Sort,333,459,0.01088260
+Smooth Sort,333,460,0.01016150
+Smooth Sort,333,461,0.01119050
+Smooth Sort,333,462,0.01078000
+Smooth Sort,333,463,0.01140210
+Smooth Sort,333,464,0.01088030
+Smooth Sort,333,465,0.01074540
+Smooth Sort,333,466,0.01104730
+Smooth Sort,333,467,0.01135190
+Smooth Sort,333,468,0.01120100
+Smooth Sort,333,469,0.01105740
+Smooth Sort,333,470,0.01080150
+Smooth Sort,333,471,0.01120800
+Smooth Sort,333,472,0.01068500
+Smooth Sort,333,473,0.01099760
+Smooth Sort,333,474,0.00996340
+Smooth Sort,333,475,0.01096470
+Smooth Sort,333,476,0.01128630
+Smooth Sort,333,477,0.01033460
+Smooth Sort,333,478,0.01119200
+Smooth Sort,333,479,0.01015530
+Smooth Sort,333,480,0.01044780
+Smooth Sort,333,481,0.01078130
+Smooth Sort,333,482,0.01105330
+Smooth Sort,333,483,0.01064140
+Smooth Sort,333,484,0.01049440
+Smooth Sort,333,485,0.01053980
+Smooth Sort,333,486,0.01078840
+Smooth Sort,333,487,0.00867570
+Smooth Sort,333,488,0.01086200
+Smooth Sort,333,489,0.00945710
+Smooth Sort,333,490,0.01111970
+Smooth Sort,333,491,0.00984710
+Smooth Sort,333,492,0.00853950
+Smooth Sort,333,493,0.01077560
+Smooth Sort,333,494,0.00936110
+Smooth Sort,333,495,0.00801810
+Smooth Sort,333,496,0.00933270
+Smooth Sort,333,497,0.00964570
+Smooth Sort,333,498,0.01119090
+Smooth Sort,333,499,0.01100740
+Smooth Sort,333,500,0.01041960
+Sorting Network,333,1,0.00279350
+Sorting Network,333,2,0.00372970
+Sorting Network,333,3,0.00309330
+Sorting Network,333,4,0.00385150
+Sorting Network,333,5,0.00375150
+Sorting Network,333,6,0.00373470
+Sorting Network,333,7,0.00385550
+Sorting Network,333,8,0.00375440
+Sorting Network,333,9,0.00383580
+Sorting Network,333,10,0.00375040
+Sorting Network,333,11,0.00377050
+Sorting Network,333,12,0.00381130
+Sorting Network,333,13,0.00376830
+Sorting Network,333,14,0.00379560
+Sorting Network,333,15,0.00370130
+Sorting Network,333,16,0.00374380
+Sorting Network,333,17,0.00372860
+Sorting Network,333,18,0.00374970
+Sorting Network,333,19,0.00378720
+Sorting Network,333,20,0.00374190
+Sorting Network,333,21,0.00375120
+Sorting Network,333,22,0.00373910
+Sorting Network,333,23,0.00373480
+Sorting Network,333,24,0.00374880
+Sorting Network,333,25,0.00379140
+Sorting Network,333,26,0.00375760
+Sorting Network,333,27,0.00378020
+Sorting Network,333,28,0.00379060
+Sorting Network,333,29,0.00373670
+Sorting Network,333,30,0.00422780
+Sorting Network,333,31,0.00373150
+Sorting Network,333,32,0.00372350
+Sorting Network,333,33,0.00374910
+Sorting Network,333,34,0.00373800
+Sorting Network,333,35,0.00383010
+Sorting Network,333,36,0.00292780
+Sorting Network,333,37,0.00372050
+Sorting Network,333,38,0.00253450
+Sorting Network,333,39,0.00371270
+Sorting Network,333,40,0.00244960
+Sorting Network,333,41,0.00313400
+Sorting Network,333,42,0.00380390
+Sorting Network,333,43,0.00380040
+Sorting Network,333,44,0.00394050
+Sorting Network,333,45,0.00389030
+Sorting Network,333,46,0.00380390
+Sorting Network,333,47,0.00385340
+Sorting Network,333,48,0.00380750
+Sorting Network,333,49,0.00386440
+Sorting Network,333,50,0.00381650
+Sorting Network,333,51,0.00400940
+Sorting Network,333,52,0.00399220
+Sorting Network,333,53,0.00375950
+Sorting Network,333,54,0.00372560
+Sorting Network,333,55,0.00372320
+Sorting Network,333,56,0.00375360
+Sorting Network,333,57,0.00264950
+Sorting Network,333,58,0.00378120
+Sorting Network,333,59,0.00308770
+Sorting Network,333,60,0.00374030
+Sorting Network,333,61,0.00319310
+Sorting Network,333,62,0.00375330
+Sorting Network,333,63,0.00393600
+Sorting Network,333,64,0.00375710
+Sorting Network,333,65,0.00305290
+Sorting Network,333,66,0.00236830
+Sorting Network,333,67,0.00377370
+Sorting Network,333,68,0.00374560
+Sorting Network,333,69,0.00382140
+Sorting Network,333,70,0.00374490
+Sorting Network,333,71,0.00380810
+Sorting Network,333,72,0.00377580
+Sorting Network,333,73,0.00378320
+Sorting Network,333,74,0.00370640
+Sorting Network,333,75,0.00389550
+Sorting Network,333,76,0.00375540
+Sorting Network,333,77,0.00376610
+Sorting Network,333,78,0.00375070
+Sorting Network,333,79,0.00377280
+Sorting Network,333,80,0.00395770
+Sorting Network,333,81,0.00376480
+Sorting Network,333,82,0.00413250
+Sorting Network,333,83,0.00380480
+Sorting Network,333,84,0.00406690
+Sorting Network,333,85,0.00386460
+Sorting Network,333,86,0.00407350
+Sorting Network,333,87,0.00376050
+Sorting Network,333,88,0.00399640
+Sorting Network,333,89,0.00409120
+Sorting Network,333,90,0.00393240
+Sorting Network,333,91,0.00396300
+Sorting Network,333,92,0.00395590
+Sorting Network,333,93,0.00396390
+Sorting Network,333,94,0.00391910
+Sorting Network,333,95,0.00375930
+Sorting Network,333,96,0.00391690
+Sorting Network,333,97,0.00399320
+Sorting Network,333,98,0.00401190
+Sorting Network,333,99,0.00394340
+Sorting Network,333,100,0.00397710
+Sorting Network,333,101,0.00372620
+Sorting Network,333,102,0.00391700
+Sorting Network,333,103,0.00384740
+Sorting Network,333,104,0.00386300
+Sorting Network,333,105,0.00372500
+Sorting Network,333,106,0.00383660
+Sorting Network,333,107,0.00372680
+Sorting Network,333,108,0.00390680
+Sorting Network,333,109,0.00373300
+Sorting Network,333,110,0.00295800
+Sorting Network,333,111,0.00381860
+Sorting Network,333,112,0.00384670
+Sorting Network,333,113,0.00377720
+Sorting Network,333,114,0.00380490
+Sorting Network,333,115,0.00375030
+Sorting Network,333,116,0.00380080
+Sorting Network,333,117,0.00371660
+Sorting Network,333,118,0.00380280
+Sorting Network,333,119,0.00373730
+Sorting Network,333,120,0.00380830
+Sorting Network,333,121,0.00374510
+Sorting Network,333,122,0.00382590
+Sorting Network,333,123,0.00375720
+Sorting Network,333,124,0.00380110
+Sorting Network,333,125,0.00373820
+Sorting Network,333,126,0.00385910
+Sorting Network,333,127,0.00376560
+Sorting Network,333,128,0.00383030
+Sorting Network,333,129,0.00371690
+Sorting Network,333,130,0.00384110
+Sorting Network,333,131,0.00371370
+Sorting Network,333,132,0.00383010
+Sorting Network,333,133,0.00372590
+Sorting Network,333,134,0.00384030
+Sorting Network,333,135,0.00383380
+Sorting Network,333,136,0.00383410
+Sorting Network,333,137,0.00370820
+Sorting Network,333,138,0.00384350
+Sorting Network,333,139,0.00370170
+Sorting Network,333,140,0.00370100
+Sorting Network,333,141,0.00380530
+Sorting Network,333,142,0.00275630
+Sorting Network,333,143,0.00388920
+Sorting Network,333,144,0.00214410
+Sorting Network,333,145,0.00386390
+Sorting Network,333,146,0.00212530
+Sorting Network,333,147,0.00214490
+Sorting Network,333,148,0.00386640
+Sorting Network,333,149,0.00210940
+Sorting Network,333,150,0.00374920
+Sorting Network,333,151,0.00230290
+Sorting Network,333,152,0.00304060
+Sorting Network,333,153,0.00370800
+Sorting Network,333,154,0.00276200
+Sorting Network,333,155,0.00384210
+Sorting Network,333,156,0.00235510
+Sorting Network,333,157,0.00238220
+Sorting Network,333,158,0.00383100
+Sorting Network,333,159,0.00232240
+Sorting Network,333,160,0.00380760
+Sorting Network,333,161,0.00313830
+Sorting Network,333,162,0.00377570
+Sorting Network,333,163,0.00377000
+Sorting Network,333,164,0.00353050
+Sorting Network,333,165,0.00369560
+Sorting Network,333,166,0.00376790
+Sorting Network,333,167,0.00371150
+Sorting Network,333,168,0.00350850
+Sorting Network,333,169,0.00373520
+Sorting Network,333,170,0.00244070
+Sorting Network,333,171,0.00370410
+Sorting Network,333,172,0.00233120
+Sorting Network,333,173,0.00370670
+Sorting Network,333,174,0.00224360
+Sorting Network,333,175,0.00229460
+Sorting Network,333,176,0.00371310
+Sorting Network,333,177,0.00228810
+Sorting Network,333,178,0.00371300
+Sorting Network,333,179,0.00375950
+Sorting Network,333,180,0.00377530
+Sorting Network,333,181,0.00385260
+Sorting Network,333,182,0.00384500
+Sorting Network,333,183,0.00385310
+Sorting Network,333,184,0.00381930
+Sorting Network,333,185,0.00395100
+Sorting Network,333,186,0.00382770
+Sorting Network,333,187,0.00385450
+Sorting Network,333,188,0.00382780
+Sorting Network,333,189,0.00442770
+Sorting Network,333,190,0.00381130
+Sorting Network,333,191,0.00385270
+Sorting Network,333,192,0.00378840
+Sorting Network,333,193,0.00515920
+Sorting Network,333,194,0.00376660
+Sorting Network,333,195,0.00402270
+Sorting Network,333,196,0.00375220
+Sorting Network,333,197,0.00404520
+Sorting Network,333,198,0.00375120
+Sorting Network,333,199,0.00390690
+Sorting Network,333,200,0.00375330
+Sorting Network,333,201,0.00395260
+Sorting Network,333,202,0.00375070
+Sorting Network,333,203,0.00383510
+Sorting Network,333,204,0.00373470
+Sorting Network,333,205,0.00371100
+Sorting Network,333,206,0.00384690
+Sorting Network,333,207,0.00372750
+Sorting Network,333,208,0.00384340
+Sorting Network,333,209,0.00372770
+Sorting Network,333,210,0.00384300
+Sorting Network,333,211,0.00369770
+Sorting Network,333,212,0.00382430
+Sorting Network,333,213,0.00356050
+Sorting Network,333,214,0.00383450
+Sorting Network,333,215,0.00312060
+Sorting Network,333,216,0.00381730
+Sorting Network,333,217,0.00370920
+Sorting Network,333,218,0.00385670
+Sorting Network,333,219,0.00371220
+Sorting Network,333,220,0.00386530
+Sorting Network,333,221,0.00375540
+Sorting Network,333,222,0.00408520
+Sorting Network,333,223,0.00379650
+Sorting Network,333,224,0.00387790
+Sorting Network,333,225,0.00379690
+Sorting Network,333,226,0.00388560
+Sorting Network,333,227,0.00378920
+Sorting Network,333,228,0.00387660
+Sorting Network,333,229,0.00379530
+Sorting Network,333,230,0.00352000
+Sorting Network,333,231,0.00372960
+Sorting Network,333,232,0.00244290
+Sorting Network,333,233,0.00373390
+Sorting Network,333,234,0.00249590
+Sorting Network,333,235,0.00296210
+Sorting Network,333,236,0.00376670
+Sorting Network,333,237,0.00398590
+Sorting Network,333,238,0.00383480
+Sorting Network,333,239,0.00322150
+Sorting Network,333,240,0.00377030
+Sorting Network,333,241,0.00215440
+Sorting Network,333,242,0.00375030
+Sorting Network,333,243,0.00209950
+Sorting Network,333,244,0.00215150
+Sorting Network,333,245,0.00376350
+Sorting Network,333,246,0.00211170
+Sorting Network,333,247,0.00225900
+Sorting Network,333,248,0.00380670
+Sorting Network,333,249,0.00236420
+Sorting Network,333,250,0.00375130
+Sorting Network,333,251,0.00231300
+Sorting Network,333,252,0.00375000
+Sorting Network,333,253,0.00384320
+Sorting Network,333,254,0.00371470
+Sorting Network,333,255,0.00376140
+Sorting Network,333,256,0.00378690
+Sorting Network,333,257,0.00348730
+Sorting Network,333,258,0.00376850
+Sorting Network,333,259,0.00377120
+Sorting Network,333,260,0.00376600
+Sorting Network,333,261,0.00378190
+Sorting Network,333,262,0.00378120
+Sorting Network,333,263,0.00384730
+Sorting Network,333,264,0.00383980
+Sorting Network,333,265,0.00373960
+Sorting Network,333,266,0.00379970
+Sorting Network,333,267,0.00373980
+Sorting Network,333,268,0.00447920
+Sorting Network,333,269,0.00393790
+Sorting Network,333,270,0.00409950
+Sorting Network,333,271,0.00384200
+Sorting Network,333,272,0.00375840
+Sorting Network,333,273,0.00418670
+Sorting Network,333,274,0.00379390
+Sorting Network,333,275,0.00371130
+Sorting Network,333,276,0.00373250
+Sorting Network,333,277,0.00372760
+Sorting Network,333,278,0.00372910
+Sorting Network,333,279,0.00353180
+Sorting Network,333,280,0.00372720
+Sorting Network,333,281,0.00368810
+Sorting Network,333,282,0.00390530
+Sorting Network,333,283,0.00382850
+Sorting Network,333,284,0.00380320
+Sorting Network,333,285,0.00381440
+Sorting Network,333,286,0.00374610
+Sorting Network,333,287,0.00533470
+Sorting Network,333,288,0.00372770
+Sorting Network,333,289,0.00387240
+Sorting Network,333,290,0.00372090
+Sorting Network,333,291,0.00371300
+Sorting Network,333,292,0.00373890
+Sorting Network,333,293,0.00324470
+Sorting Network,333,294,0.00370690
+Sorting Network,333,295,0.00375050
+Sorting Network,333,296,0.00370420
+Sorting Network,333,297,0.00375500
+Sorting Network,333,298,0.00371700
+Sorting Network,333,299,0.00374000
+Sorting Network,333,300,0.00371320
+Sorting Network,333,301,0.00289350
+Sorting Network,333,302,0.00374260
+Sorting Network,333,303,0.00216590
+Sorting Network,333,304,0.00218640
+Sorting Network,333,305,0.00373160
+Sorting Network,333,306,0.00217940
+Sorting Network,333,307,0.00374010
+Sorting Network,333,308,0.00290980
+Sorting Network,333,309,0.00375360
+Sorting Network,333,310,0.00378150
+Sorting Network,333,311,0.00371410
+Sorting Network,333,312,0.00371990
+Sorting Network,333,313,0.00371040
+Sorting Network,333,314,0.00371460
+Sorting Network,333,315,0.00372390
+Sorting Network,333,316,0.00299330
+Sorting Network,333,317,0.00379880
+Sorting Network,333,318,0.00260840
+Sorting Network,333,319,0.00274910
+Sorting Network,333,320,0.00370950
+Sorting Network,333,321,0.00268750
+Sorting Network,333,322,0.00371710
+Sorting Network,333,323,0.00248140
+Sorting Network,333,324,0.00373720
+Sorting Network,333,325,0.00372040
+Sorting Network,333,326,0.00369860
+Sorting Network,333,327,0.00372660
+Sorting Network,333,328,0.00324460
+Sorting Network,333,329,0.00373210
+Sorting Network,333,330,0.00372530
+Sorting Network,333,331,0.00372250
+Sorting Network,333,332,0.00374790
+Sorting Network,333,333,0.00374480
+Sorting Network,333,334,0.00387210
+Sorting Network,333,335,0.00382300
+Sorting Network,333,336,0.00398220
+Sorting Network,333,337,0.00378370
+Sorting Network,333,338,0.00400330
+Sorting Network,333,339,0.00381490
+Sorting Network,333,340,0.00447980
+Sorting Network,333,341,0.00396870
+Sorting Network,333,342,0.00403560
+Sorting Network,333,343,0.00477770
+Sorting Network,333,344,0.00406580
+Sorting Network,333,345,0.00375430
+Sorting Network,333,346,0.00374710
+Sorting Network,333,347,0.00376110
+Sorting Network,333,348,0.00376410
+Sorting Network,333,349,0.00379900
+Sorting Network,333,350,0.00377810
+Sorting Network,333,351,0.00372220
+Sorting Network,333,352,0.00348840
+Sorting Network,333,353,0.00374260
+Sorting Network,333,354,0.00376270
+Sorting Network,333,355,0.00373030
+Sorting Network,333,356,0.00306430
+Sorting Network,333,357,0.00373760
+Sorting Network,333,358,0.00381770
+Sorting Network,333,359,0.00372320
+Sorting Network,333,360,0.00371120
+Sorting Network,333,361,0.00372200
+Sorting Network,333,362,0.00374420
+Sorting Network,333,363,0.00373350
+Sorting Network,333,364,0.00374660
+Sorting Network,333,365,0.00389090
+Sorting Network,333,366,0.00376520
+Sorting Network,333,367,0.00372610
+Sorting Network,333,368,0.00376010
+Sorting Network,333,369,0.00380500
+Sorting Network,333,370,0.00376570
+Sorting Network,333,371,0.00418580
+Sorting Network,333,372,0.00373410
+Sorting Network,333,373,0.00372670
+Sorting Network,333,374,0.00373470
+Sorting Network,333,375,0.00429100
+Sorting Network,333,376,0.00373380
+Sorting Network,333,377,0.00395840
+Sorting Network,333,378,0.00375030
+Sorting Network,333,379,0.00376170
+Sorting Network,333,380,0.00374200
+Sorting Network,333,381,0.00294770
+Sorting Network,333,382,0.00374940
+Sorting Network,333,383,0.00380660
+Sorting Network,333,384,0.00375280
+Sorting Network,333,385,0.00377210
+Sorting Network,333,386,0.00375100
+Sorting Network,333,387,0.00373980
+Sorting Network,333,388,0.00372810
+Sorting Network,333,389,0.00373990
+Sorting Network,333,390,0.00371970
+Sorting Network,333,391,0.00301030
+Sorting Network,333,392,0.00372040
+Sorting Network,333,393,0.00395500
+Sorting Network,333,394,0.00371450
+Sorting Network,333,395,0.00331030
+Sorting Network,333,396,0.00373550
+Sorting Network,333,397,0.00263690
+Sorting Network,333,398,0.00372520
+Sorting Network,333,399,0.00370380
+Sorting Network,333,400,0.00372030
+Sorting Network,333,401,0.00374440
+Sorting Network,333,402,0.00372100
+Sorting Network,333,403,0.00298890
+Sorting Network,333,404,0.00223890
+Sorting Network,333,405,0.00372280
+Sorting Network,333,406,0.00214510
+Sorting Network,333,407,0.00373420
+Sorting Network,333,408,0.00238080
+Sorting Network,333,409,0.00376420
+Sorting Network,333,410,0.00371340
+Sorting Network,333,411,0.00363580
+Sorting Network,333,412,0.00367180
+Sorting Network,333,413,0.00331630
+Sorting Network,333,414,0.00339280
+Sorting Network,333,415,0.00225660
+Sorting Network,333,416,0.00375330
+Sorting Network,333,417,0.00210390
+Sorting Network,333,418,0.00216280
+Sorting Network,333,419,0.00374590
+Sorting Network,333,420,0.00361150
+Sorting Network,333,421,0.00250100
+Sorting Network,333,422,0.00373670
+Sorting Network,333,423,0.00378040
+Sorting Network,333,424,0.00371590
+Sorting Network,333,425,0.00377380
+Sorting Network,333,426,0.00383740
+Sorting Network,333,427,0.00376260
+Sorting Network,333,428,0.00335410
+Sorting Network,333,429,0.00378040
+Sorting Network,333,430,0.00322620
+Sorting Network,333,431,0.00378250
+Sorting Network,333,432,0.00216590
+Sorting Network,333,433,0.00373960
+Sorting Network,333,434,0.00212910
+Sorting Network,333,435,0.00218590
+Sorting Network,333,436,0.00318720
+Sorting Network,333,437,0.00256390
+Sorting Network,333,438,0.00371160
+Sorting Network,333,439,0.00388780
+Sorting Network,333,440,0.00372870
+Sorting Network,333,441,0.00390410
+Sorting Network,333,442,0.00372080
+Sorting Network,333,443,0.00385570
+Sorting Network,333,444,0.00382720
+Sorting Network,333,445,0.00379380
+Sorting Network,333,446,0.00373070
+Sorting Network,333,447,0.00376340
+Sorting Network,333,448,0.00368780
+Sorting Network,333,449,0.00373370
+Sorting Network,333,450,0.00373340
+Sorting Network,333,451,0.00372080
+Sorting Network,333,452,0.00375800
+Sorting Network,333,453,0.00375190
+Sorting Network,333,454,0.00373350
+Sorting Network,333,455,0.00378880
+Sorting Network,333,456,0.00373680
+Sorting Network,333,457,0.00378710
+Sorting Network,333,458,0.00377570
+Sorting Network,333,459,0.00379550
+Sorting Network,333,460,0.00877190
+Sorting Network,333,461,0.00375220
+Sorting Network,333,462,0.00541350
+Sorting Network,333,463,0.00451140
+Sorting Network,333,464,0.00266380
+Sorting Network,333,465,0.00375570
+Sorting Network,333,466,0.00310360
+Sorting Network,333,467,0.00372850
+Sorting Network,333,468,0.00374710
+Sorting Network,333,469,0.00373790
+Sorting Network,333,470,0.00371250
+Sorting Network,333,471,0.00374320
+Sorting Network,333,472,0.00370580
+Sorting Network,333,473,0.00387740
+Sorting Network,333,474,0.00378940
+Sorting Network,333,475,0.00373190
+Sorting Network,333,476,0.00373500
+Sorting Network,333,477,0.00375020
+Sorting Network,333,478,0.00372910
+Sorting Network,333,479,0.00384620
+Sorting Network,333,480,0.00347510
+Sorting Network,333,481,0.00213600
+Sorting Network,333,482,0.00378580
+Sorting Network,333,483,0.00339020
+Sorting Network,333,484,0.00372660
+Sorting Network,333,485,0.00280010
+Sorting Network,333,486,0.00375820
+Sorting Network,333,487,0.00382290
+Sorting Network,333,488,0.00373600
+Sorting Network,333,489,0.00384120
+Sorting Network,333,490,0.00375830
+Sorting Network,333,491,0.00382380
+Sorting Network,333,492,0.00375340
+Sorting Network,333,493,0.00380210
+Sorting Network,333,494,0.00373480
+Sorting Network,333,495,0.00375210
+Sorting Network,333,496,0.00373730
+Sorting Network,333,497,0.00383320
+Sorting Network,333,498,0.00373130
+Sorting Network,333,499,0.00381830
+Sorting Network,333,500,0.00376290
+Spaghetti Sort,333,1,0.00128890
+Spaghetti Sort,333,2,0.00127450
+Spaghetti Sort,333,3,0.00102410
+Spaghetti Sort,333,4,0.00129250
+Spaghetti Sort,333,5,0.00071230
+Spaghetti Sort,333,6,0.00127470
+Spaghetti Sort,333,7,0.00073880
+Spaghetti Sort,333,8,0.00075170
+Spaghetti Sort,333,9,0.00125980
+Spaghetti Sort,333,10,0.00070900
+Spaghetti Sort,333,11,0.00075030
+Spaghetti Sort,333,12,0.00127920
+Spaghetti Sort,333,13,0.00083470
+Spaghetti Sort,333,14,0.00126460
+Spaghetti Sort,333,15,0.00126880
+Spaghetti Sort,333,16,0.00138550
+Spaghetti Sort,333,17,0.00130250
+Spaghetti Sort,333,18,0.00087450
+Spaghetti Sort,333,19,0.00131850
+Spaghetti Sort,333,20,0.00083560
+Spaghetti Sort,333,21,0.00128520
+Spaghetti Sort,333,22,0.00108240
+Spaghetti Sort,333,23,0.00130330
+Spaghetti Sort,333,24,0.00109010
+Spaghetti Sort,333,25,0.00126720
+Spaghetti Sort,333,26,0.00091950
+Spaghetti Sort,333,27,0.00128590
+Spaghetti Sort,333,28,0.00129860
+Spaghetti Sort,333,29,0.00075920
+Spaghetti Sort,333,30,0.00127140
+Spaghetti Sort,333,31,0.00071230
+Spaghetti Sort,333,32,0.00128760
+Spaghetti Sort,333,33,0.00075220
+Spaghetti Sort,333,34,0.00083450
+Spaghetti Sort,333,35,0.00134580
+Spaghetti Sort,333,36,0.00142510
+Spaghetti Sort,333,37,0.00104770
+Spaghetti Sort,333,38,0.00134110
+Spaghetti Sort,333,39,0.00070250
+Spaghetti Sort,333,40,0.00130700
+Spaghetti Sort,333,41,0.00136680
+Spaghetti Sort,333,42,0.00072000
+Spaghetti Sort,333,43,0.00130010
+Spaghetti Sort,333,44,0.00099910
+Spaghetti Sort,333,45,0.00127450
+Spaghetti Sort,333,46,0.00073500
+Spaghetti Sort,333,47,0.00129650
+Spaghetti Sort,333,48,0.00075920
+Spaghetti Sort,333,49,0.00073090
+Spaghetti Sort,333,50,0.00126780
+Spaghetti Sort,333,51,0.00070180
+Spaghetti Sort,333,52,0.00083330
+Spaghetti Sort,333,53,0.00127600
+Spaghetti Sort,333,54,0.00074410
+Spaghetti Sort,333,55,0.00125500
+Spaghetti Sort,333,56,0.00069740
+Spaghetti Sort,333,57,0.00073380
+Spaghetti Sort,333,58,0.00127230
+Spaghetti Sort,333,59,0.00069880
+Spaghetti Sort,333,60,0.00127420
+Spaghetti Sort,333,61,0.00116020
+Spaghetti Sort,333,62,0.00125230
+Spaghetti Sort,333,63,0.00124310
+Spaghetti Sort,333,64,0.00127680
+Spaghetti Sort,333,65,0.00134980
+Spaghetti Sort,333,66,0.00127920
+Spaghetti Sort,333,67,0.00128980
+Spaghetti Sort,333,68,0.00129390
+Spaghetti Sort,333,69,0.00128710
+Spaghetti Sort,333,70,0.00131680
+Spaghetti Sort,333,71,0.00128420
+Spaghetti Sort,333,72,0.00131300
+Spaghetti Sort,333,73,0.00128260
+Spaghetti Sort,333,74,0.00130370
+Spaghetti Sort,333,75,0.00126440
+Spaghetti Sort,333,76,0.00130640
+Spaghetti Sort,333,77,0.00130840
+Spaghetti Sort,333,78,0.00129930
+Spaghetti Sort,333,79,0.00131110
+Spaghetti Sort,333,80,0.00129200
+Spaghetti Sort,333,81,0.00132110
+Spaghetti Sort,333,82,0.00130970
+Spaghetti Sort,333,83,0.00124210
+Spaghetti Sort,333,84,0.00126990
+Spaghetti Sort,333,85,0.00131310
+Spaghetti Sort,333,86,0.00127710
+Spaghetti Sort,333,87,0.00128350
+Spaghetti Sort,333,88,0.00128340
+Spaghetti Sort,333,89,0.00127720
+Spaghetti Sort,333,90,0.00126370
+Spaghetti Sort,333,91,0.00132780
+Spaghetti Sort,333,92,0.00130770
+Spaghetti Sort,333,93,0.00147310
+Spaghetti Sort,333,94,0.00127080
+Spaghetti Sort,333,95,0.00116620
+Spaghetti Sort,333,96,0.00130270
+Spaghetti Sort,333,97,0.00138800
+Spaghetti Sort,333,98,0.00132330
+Spaghetti Sort,333,99,0.00144930
+Spaghetti Sort,333,100,0.00131010
+Spaghetti Sort,333,101,0.00127690
+Spaghetti Sort,333,102,0.00128290
+Spaghetti Sort,333,103,0.00127600
+Spaghetti Sort,333,104,0.00127980
+Spaghetti Sort,333,105,0.00129920
+Spaghetti Sort,333,106,0.00127230
+Spaghetti Sort,333,107,0.00124550
+Spaghetti Sort,333,108,0.00127400
+Spaghetti Sort,333,109,0.00125750
+Spaghetti Sort,333,110,0.00127610
+Spaghetti Sort,333,111,0.00129350
+Spaghetti Sort,333,112,0.00129540
+Spaghetti Sort,333,113,0.00127240
+Spaghetti Sort,333,114,0.00132960
+Spaghetti Sort,333,115,0.00130740
+Spaghetti Sort,333,116,0.00131140
+Spaghetti Sort,333,117,0.00129380
+Spaghetti Sort,333,118,0.00132360
+Spaghetti Sort,333,119,0.00143000
+Spaghetti Sort,333,120,0.00130350
+Spaghetti Sort,333,121,0.00133560
+Spaghetti Sort,333,122,0.00128690
+Spaghetti Sort,333,123,0.00130730
+Spaghetti Sort,333,124,0.00128830
+Spaghetti Sort,333,125,0.00132450
+Spaghetti Sort,333,126,0.00128480
+Spaghetti Sort,333,127,0.00119010
+Spaghetti Sort,333,128,0.00128740
+Spaghetti Sort,333,129,0.00127330
+Spaghetti Sort,333,130,0.00128270
+Spaghetti Sort,333,131,0.00127650
+Spaghetti Sort,333,132,0.00127120
+Spaghetti Sort,333,133,0.00127610
+Spaghetti Sort,333,134,0.00128300
+Spaghetti Sort,333,135,0.00128170
+Spaghetti Sort,333,136,0.00132690
+Spaghetti Sort,333,137,0.00130220
+Spaghetti Sort,333,138,0.00132280
+Spaghetti Sort,333,139,0.00092710
+Spaghetti Sort,333,140,0.00127110
+Spaghetti Sort,333,141,0.00080530
+Spaghetti Sort,333,142,0.00129770
+Spaghetti Sort,333,143,0.00071140
+Spaghetti Sort,333,144,0.00078730
+Spaghetti Sort,333,145,0.00128380
+Spaghetti Sort,333,146,0.00080460
+Spaghetti Sort,333,147,0.00091380
+Spaghetti Sort,333,148,0.00132720
+Spaghetti Sort,333,149,0.00074760
+Spaghetti Sort,333,150,0.00129310
+Spaghetti Sort,333,151,0.00068510
+Spaghetti Sort,333,152,0.00075670
+Spaghetti Sort,333,153,0.00130540
+Spaghetti Sort,333,154,0.00069630
+Spaghetti Sort,333,155,0.00128170
+Spaghetti Sort,333,156,0.00127730
+Spaghetti Sort,333,157,0.00128160
+Spaghetti Sort,333,158,0.00129560
+Spaghetti Sort,333,159,0.00130720
+Spaghetti Sort,333,160,0.00129020
+Spaghetti Sort,333,161,0.00135550
+Spaghetti Sort,333,162,0.00126860
+Spaghetti Sort,333,163,0.00079250
+Spaghetti Sort,333,164,0.00129720
+Spaghetti Sort,333,165,0.00128590
+Spaghetti Sort,333,166,0.00119790
+Spaghetti Sort,333,167,0.00128290
+Spaghetti Sort,333,168,0.00113310
+Spaghetti Sort,333,169,0.00126360
+Spaghetti Sort,333,170,0.00086720
+Spaghetti Sort,333,171,0.00130700
+Spaghetti Sort,333,172,0.00126210
+Spaghetti Sort,333,173,0.00127720
+Spaghetti Sort,333,174,0.00127920
+Spaghetti Sort,333,175,0.00131080
+Spaghetti Sort,333,176,0.00127620
+Spaghetti Sort,333,177,0.00128380
+Spaghetti Sort,333,178,0.00126350
+Spaghetti Sort,333,179,0.00128460
+Spaghetti Sort,333,180,0.00129760
+Spaghetti Sort,333,181,0.00137330
+Spaghetti Sort,333,182,0.00130710
+Spaghetti Sort,333,183,0.00122460
+Spaghetti Sort,333,184,0.00143260
+Spaghetti Sort,333,185,0.00120710
+Spaghetti Sort,333,186,0.00123370
+Spaghetti Sort,333,187,0.00127590
+Spaghetti Sort,333,188,0.00136040
+Spaghetti Sort,333,189,0.00130260
+Spaghetti Sort,333,190,0.00136940
+Spaghetti Sort,333,191,0.00130670
+Spaghetti Sort,333,192,0.00132000
+Spaghetti Sort,333,193,0.00129320
+Spaghetti Sort,333,194,0.00137590
+Spaghetti Sort,333,195,0.00130980
+Spaghetti Sort,333,196,0.00130950
+Spaghetti Sort,333,197,0.00096190
+Spaghetti Sort,333,198,0.00131720
+Spaghetti Sort,333,199,0.00097900
+Spaghetti Sort,333,200,0.00127960
+Spaghetti Sort,333,201,0.00130650
+Spaghetti Sort,333,202,0.00129750
+Spaghetti Sort,333,203,0.00130420
+Spaghetti Sort,333,204,0.00126950
+Spaghetti Sort,333,205,0.00126270
+Spaghetti Sort,333,206,0.00129400
+Spaghetti Sort,333,207,0.00127160
+Spaghetti Sort,333,208,0.00127610
+Spaghetti Sort,333,209,0.00127130
+Spaghetti Sort,333,210,0.00130970
+Spaghetti Sort,333,211,0.00129910
+Spaghetti Sort,333,212,0.00127300
+Spaghetti Sort,333,213,0.00128040
+Spaghetti Sort,333,214,0.00129450
+Spaghetti Sort,333,215,0.00129630
+Spaghetti Sort,333,216,0.00126480
+Spaghetti Sort,333,217,0.00127170
+Spaghetti Sort,333,218,0.00130050
+Spaghetti Sort,333,219,0.00126660
+Spaghetti Sort,333,220,0.00132280
+Spaghetti Sort,333,221,0.00131310
+Spaghetti Sort,333,222,0.00131920
+Spaghetti Sort,333,223,0.00125850
+Spaghetti Sort,333,224,0.00132150
+Spaghetti Sort,333,225,0.00127900
+Spaghetti Sort,333,226,0.00130420
+Spaghetti Sort,333,227,0.00130010
+Spaghetti Sort,333,228,0.00127420
+Spaghetti Sort,333,229,0.00129730
+Spaghetti Sort,333,230,0.00129000
+Spaghetti Sort,333,231,0.00128770
+Spaghetti Sort,333,232,0.00128240
+Spaghetti Sort,333,233,0.00128540
+Spaghetti Sort,333,234,0.00129160
+Spaghetti Sort,333,235,0.00127690
+Spaghetti Sort,333,236,0.00129030
+Spaghetti Sort,333,237,0.00129430
+Spaghetti Sort,333,238,0.00128960
+Spaghetti Sort,333,239,0.00128970
+Spaghetti Sort,333,240,0.00127590
+Spaghetti Sort,333,241,0.00125920
+Spaghetti Sort,333,242,0.00129090
+Spaghetti Sort,333,243,0.00122630
+Spaghetti Sort,333,244,0.00123210
+Spaghetti Sort,333,245,0.00126920
+Spaghetti Sort,333,246,0.00125650
+Spaghetti Sort,333,247,0.00131710
+Spaghetti Sort,333,248,0.00127540
+Spaghetti Sort,333,249,0.00128150
+Spaghetti Sort,333,250,0.00129300
+Spaghetti Sort,333,251,0.00125860
+Spaghetti Sort,333,252,0.00130010
+Spaghetti Sort,333,253,0.01358780
+Spaghetti Sort,333,254,0.00155500
+Spaghetti Sort,333,255,0.00127920
+Spaghetti Sort,333,256,0.00135740
+Spaghetti Sort,333,257,0.00131040
+Spaghetti Sort,333,258,0.00125580
+Spaghetti Sort,333,259,0.00130200
+Spaghetti Sort,333,260,0.00128030
+Spaghetti Sort,333,261,0.00130040
+Spaghetti Sort,333,262,0.00124800
+Spaghetti Sort,333,263,0.00127200
+Spaghetti Sort,333,264,0.00128230
+Spaghetti Sort,333,265,0.00127530
+Spaghetti Sort,333,266,0.00128870
+Spaghetti Sort,333,267,0.00132520
+Spaghetti Sort,333,268,0.00127090
+Spaghetti Sort,333,269,0.00126670
+Spaghetti Sort,333,270,0.00127330
+Spaghetti Sort,333,271,0.00131760
+Spaghetti Sort,333,272,0.00128550
+Spaghetti Sort,333,273,0.00127330
+Spaghetti Sort,333,274,0.00128080
+Spaghetti Sort,333,275,0.00125360
+Spaghetti Sort,333,276,0.00127530
+Spaghetti Sort,333,277,0.00127770
+Spaghetti Sort,333,278,0.00126640
+Spaghetti Sort,333,279,0.00127680
+Spaghetti Sort,333,280,0.00128190
+Spaghetti Sort,333,281,0.00128360
+Spaghetti Sort,333,282,0.00127560
+Spaghetti Sort,333,283,0.00127070
+Spaghetti Sort,333,284,0.00127810
+Spaghetti Sort,333,285,0.00130240
+Spaghetti Sort,333,286,0.00128650
+Spaghetti Sort,333,287,0.00142600
+Spaghetti Sort,333,288,0.00129920
+Spaghetti Sort,333,289,0.00210490
+Spaghetti Sort,333,290,0.00284440
+Spaghetti Sort,333,291,0.00135660
+Spaghetti Sort,333,292,0.00126210
+Spaghetti Sort,333,293,0.00335290
+Spaghetti Sort,333,294,0.00125940
+Spaghetti Sort,333,295,0.00135300
+Spaghetti Sort,333,296,0.00137890
+Spaghetti Sort,333,297,0.00128430
+Spaghetti Sort,333,298,0.00188510
+Spaghetti Sort,333,299,0.00130230
+Spaghetti Sort,333,300,0.00130670
+Spaghetti Sort,333,301,0.00128940
+Spaghetti Sort,333,302,0.00130020
+Spaghetti Sort,333,303,0.00129390
+Spaghetti Sort,333,304,0.00129890
+Spaghetti Sort,333,305,0.00239830
+Spaghetti Sort,333,306,0.00130630
+Spaghetti Sort,333,307,0.00132070
+Spaghetti Sort,333,308,0.00141620
+Spaghetti Sort,333,309,0.00135740
+Spaghetti Sort,333,310,0.00135330
+Spaghetti Sort,333,311,0.00131570
+Spaghetti Sort,333,312,0.00134950
+Spaghetti Sort,333,313,0.00125790
+Spaghetti Sort,333,314,0.00197680
+Spaghetti Sort,333,315,0.00128510
+Spaghetti Sort,333,316,0.00128410
+Spaghetti Sort,333,317,0.00242850
+Spaghetti Sort,333,318,0.00134550
+Spaghetti Sort,333,319,0.00194660
+Spaghetti Sort,333,320,0.00161330
+Spaghetti Sort,333,321,0.00128610
+Spaghetti Sort,333,322,0.00130440
+Spaghetti Sort,333,323,0.00128060
+Spaghetti Sort,333,324,0.00130250
+Spaghetti Sort,333,325,0.00131270
+Spaghetti Sort,333,326,0.00188460
+Spaghetti Sort,333,327,0.00126600
+Spaghetti Sort,333,328,0.00130100
+Spaghetti Sort,333,329,0.00143840
+Spaghetti Sort,333,330,0.00129220
+Spaghetti Sort,333,331,0.00144890
+Spaghetti Sort,333,332,0.00129980
+Spaghetti Sort,333,333,0.00126640
+Spaghetti Sort,333,334,0.00145110
+Spaghetti Sort,333,335,0.00125910
+Spaghetti Sort,333,336,0.00164800
+Spaghetti Sort,333,337,0.00129530
+Spaghetti Sort,333,338,0.00130800
+Spaghetti Sort,333,339,0.00125280
+Spaghetti Sort,333,340,0.00126340
+Spaghetti Sort,333,341,0.00126850
+Spaghetti Sort,333,342,0.00127350
+Spaghetti Sort,333,343,0.00150380
+Spaghetti Sort,333,344,0.00125090
+Spaghetti Sort,333,345,0.00141110
+Spaghetti Sort,333,346,0.00126770
+Spaghetti Sort,333,347,0.00127380
+Spaghetti Sort,333,348,0.00131280
+Spaghetti Sort,333,349,0.00131130
+Spaghetti Sort,333,350,0.00126190
+Spaghetti Sort,333,351,0.00128030
+Spaghetti Sort,333,352,0.00116750
+Spaghetti Sort,333,353,0.00133260
+Spaghetti Sort,333,354,0.00116800
+Spaghetti Sort,333,355,0.00139920
+Spaghetti Sort,333,356,0.00127340
+Spaghetti Sort,333,357,0.00250950
+Spaghetti Sort,333,358,0.00167830
+Spaghetti Sort,333,359,0.00130320
+Spaghetti Sort,333,360,0.00132100
+Spaghetti Sort,333,361,0.00127700
+Spaghetti Sort,333,362,0.00263600
+Spaghetti Sort,333,363,0.00134030
+Spaghetti Sort,333,364,0.00130160
+Spaghetti Sort,333,365,0.00124740
+Spaghetti Sort,333,366,0.00163670
+Spaghetti Sort,333,367,0.00125990
+Spaghetti Sort,333,368,0.00128990
+Spaghetti Sort,333,369,0.00132740
+Spaghetti Sort,333,370,0.00128410
+Spaghetti Sort,333,371,0.00147600
+Spaghetti Sort,333,372,0.00127650
+Spaghetti Sort,333,373,0.00130310
+Spaghetti Sort,333,374,0.00124000
+Spaghetti Sort,333,375,0.00133150
+Spaghetti Sort,333,376,0.00128790
+Spaghetti Sort,333,377,0.00130170
+Spaghetti Sort,333,378,0.00127430
+Spaghetti Sort,333,379,0.00125800
+Spaghetti Sort,333,380,0.00125860
+Spaghetti Sort,333,381,0.00127140
+Spaghetti Sort,333,382,0.00127490
+Spaghetti Sort,333,383,0.00125380
+Spaghetti Sort,333,384,0.00125170
+Spaghetti Sort,333,385,0.00127090
+Spaghetti Sort,333,386,0.00133400
+Spaghetti Sort,333,387,0.00129010
+Spaghetti Sort,333,388,0.00136980
+Spaghetti Sort,333,389,0.00129070
+Spaghetti Sort,333,390,0.00125790
+Spaghetti Sort,333,391,0.00231450
+Spaghetti Sort,333,392,0.00128330
+Spaghetti Sort,333,393,0.00130210
+Spaghetti Sort,333,394,0.00131590
+Spaghetti Sort,333,395,0.00127490
+Spaghetti Sort,333,396,0.00127490
+Spaghetti Sort,333,397,0.00128910
+Spaghetti Sort,333,398,0.00155820
+Spaghetti Sort,333,399,0.00131160
+Spaghetti Sort,333,400,0.00153490
+Spaghetti Sort,333,401,0.00128390
+Spaghetti Sort,333,402,0.00143990
+Spaghetti Sort,333,403,0.00128960
+Spaghetti Sort,333,404,0.00131530
+Spaghetti Sort,333,405,0.00131080
+Spaghetti Sort,333,406,0.00132410
+Spaghetti Sort,333,407,0.00128880
+Spaghetti Sort,333,408,0.00127360
+Spaghetti Sort,333,409,0.00129740
+Spaghetti Sort,333,410,0.00126230
+Spaghetti Sort,333,411,0.00132350
+Spaghetti Sort,333,412,0.00131220
+Spaghetti Sort,333,413,0.00138460
+Spaghetti Sort,333,414,0.00128500
+Spaghetti Sort,333,415,0.00129420
+Spaghetti Sort,333,416,0.00129890
+Spaghetti Sort,333,417,0.00131830
+Spaghetti Sort,333,418,0.00130550
+Spaghetti Sort,333,419,0.00128550
+Spaghetti Sort,333,420,0.00129330
+Spaghetti Sort,333,421,0.00129620
+Spaghetti Sort,333,422,0.00126710
+Spaghetti Sort,333,423,0.00127260
+Spaghetti Sort,333,424,0.00128900
+Spaghetti Sort,333,425,0.00128890
+Spaghetti Sort,333,426,0.00127780
+Spaghetti Sort,333,427,0.00131710
+Spaghetti Sort,333,428,0.00128820
+Spaghetti Sort,333,429,0.00128420
+Spaghetti Sort,333,430,0.00128970
+Spaghetti Sort,333,431,0.00127610
+Spaghetti Sort,333,432,0.00127990
+Spaghetti Sort,333,433,0.00127800
+Spaghetti Sort,333,434,0.00128720
+Spaghetti Sort,333,435,0.00127840
+Spaghetti Sort,333,436,0.00127660
+Spaghetti Sort,333,437,0.00127960
+Spaghetti Sort,333,438,0.00127370
+Spaghetti Sort,333,439,0.00128270
+Spaghetti Sort,333,440,0.00128380
+Spaghetti Sort,333,441,0.00128040
+Spaghetti Sort,333,442,0.00129860
+Spaghetti Sort,333,443,0.00127240
+Spaghetti Sort,333,444,0.00128350
+Spaghetti Sort,333,445,0.00130700
+Spaghetti Sort,333,446,0.00129340
+Spaghetti Sort,333,447,0.00130000
+Spaghetti Sort,333,448,0.00142830
+Spaghetti Sort,333,449,0.00125130
+Spaghetti Sort,333,450,0.00142770
+Spaghetti Sort,333,451,0.00125050
+Spaghetti Sort,333,452,0.00144310
+Spaghetti Sort,333,453,0.00125870
+Spaghetti Sort,333,454,0.00120720
+Spaghetti Sort,333,455,0.00128880
+Spaghetti Sort,333,456,0.00132140
+Spaghetti Sort,333,457,0.00130880
+Spaghetti Sort,333,458,0.00127950
+Spaghetti Sort,333,459,0.00127570
+Spaghetti Sort,333,460,0.00131520
+Spaghetti Sort,333,461,0.00130530
+Spaghetti Sort,333,462,0.00130330
+Spaghetti Sort,333,463,0.00131010
+Spaghetti Sort,333,464,0.00109580
+Spaghetti Sort,333,465,0.00131650
+Spaghetti Sort,333,466,0.00137310
+Spaghetti Sort,333,467,0.00143660
+Spaghetti Sort,333,468,0.00126560
+Spaghetti Sort,333,469,0.00143340
+Spaghetti Sort,333,470,0.00129410
+Spaghetti Sort,333,471,0.00141940
+Spaghetti Sort,333,472,0.00127120
+Spaghetti Sort,333,473,0.00146670
+Spaghetti Sort,333,474,0.00140030
+Spaghetti Sort,333,475,0.00139940
+Spaghetti Sort,333,476,0.00127840
+Spaghetti Sort,333,477,0.00127160
+Spaghetti Sort,333,478,0.00146290
+Spaghetti Sort,333,479,0.00129480
+Spaghetti Sort,333,480,0.00121030
+Spaghetti Sort,333,481,0.00124200
+Spaghetti Sort,333,482,0.00140400
+Spaghetti Sort,333,483,0.00125350
+Spaghetti Sort,333,484,0.00650550
+Spaghetti Sort,333,485,0.00120810
+Spaghetti Sort,333,486,0.00127220
+Spaghetti Sort,333,487,0.00122530
+Spaghetti Sort,333,488,0.00130270
+Spaghetti Sort,333,489,0.00142430
+Spaghetti Sort,333,490,0.00133330
+Spaghetti Sort,333,491,0.00141310
+Spaghetti Sort,333,492,0.00131570
+Spaghetti Sort,333,493,0.00139720
+Spaghetti Sort,333,494,0.00131080
+Spaghetti Sort,333,495,0.00141880
+Spaghetti Sort,333,496,0.00131420
+Spaghetti Sort,333,497,0.00129360
+Spaghetti Sort,333,498,0.00133060
+Spaghetti Sort,333,499,0.00133120
+Spaghetti Sort,333,500,0.00128760
+Spreadsort,333,1,0.00031010
+Spreadsort,333,2,0.00030020
+Spreadsort,333,3,0.00029850
+Spreadsort,333,4,0.00029330
+Spreadsort,333,5,0.00030220
+Spreadsort,333,6,0.00028320
+Spreadsort,333,7,0.00030000
+Spreadsort,333,8,0.00029250
+Spreadsort,333,9,0.00029990
+Spreadsort,333,10,0.00028610
+Spreadsort,333,11,0.00029110
+Spreadsort,333,12,0.00028330
+Spreadsort,333,13,0.00031970
+Spreadsort,333,14,0.00028400
+Spreadsort,333,15,0.00028650
+Spreadsort,333,16,0.00028640
+Spreadsort,333,17,0.00029030
+Spreadsort,333,18,0.00029410
+Spreadsort,333,19,0.00029680
+Spreadsort,333,20,0.00029200
+Spreadsort,333,21,0.00028830
+Spreadsort,333,22,0.00028610
+Spreadsort,333,23,0.00028860
+Spreadsort,333,24,0.00028550
+Spreadsort,333,25,0.00028790
+Spreadsort,333,26,0.00028660
+Spreadsort,333,27,0.00028690
+Spreadsort,333,28,0.00028450
+Spreadsort,333,29,0.00034530
+Spreadsort,333,30,0.00029130
+Spreadsort,333,31,0.00028520
+Spreadsort,333,32,0.00028080
+Spreadsort,333,33,0.00028460
+Spreadsort,333,34,0.00028410
+Spreadsort,333,35,0.00028500
+Spreadsort,333,36,0.00029640
+Spreadsort,333,37,0.00031660
+Spreadsort,333,38,0.00030340
+Spreadsort,333,39,0.00028820
+Spreadsort,333,40,0.00028940
+Spreadsort,333,41,0.00028680
+Spreadsort,333,42,0.00028030
+Spreadsort,333,43,0.00028870
+Spreadsort,333,44,0.00028200
+Spreadsort,333,45,0.00028290
+Spreadsort,333,46,0.00028070
+Spreadsort,333,47,0.00029040
+Spreadsort,333,48,0.00029020
+Spreadsort,333,49,0.00029140
+Spreadsort,333,50,0.00028720
+Spreadsort,333,51,0.00028430
+Spreadsort,333,52,0.00028040
+Spreadsort,333,53,0.00028940
+Spreadsort,333,54,0.00028310
+Spreadsort,333,55,0.00028170
+Spreadsort,333,56,0.00027940
+Spreadsort,333,57,0.00030570
+Spreadsort,333,58,0.00027990
+Spreadsort,333,59,0.00028370
+Spreadsort,333,60,0.00028120
+Spreadsort,333,61,0.00028520
+Spreadsort,333,62,0.00028270
+Spreadsort,333,63,0.00028630
+Spreadsort,333,64,0.00028260
+Spreadsort,333,65,0.00028070
+Spreadsort,333,66,0.00027580
+Spreadsort,333,67,0.00029200
+Spreadsort,333,68,0.00028880
+Spreadsort,333,69,0.00028320
+Spreadsort,333,70,0.00028420
+Spreadsort,333,71,0.00028260
+Spreadsort,333,72,0.00028400
+Spreadsort,333,73,0.00028300
+Spreadsort,333,74,0.00028110
+Spreadsort,333,75,0.00028540
+Spreadsort,333,76,0.00027990
+Spreadsort,333,77,0.00028460
+Spreadsort,333,78,0.00028360
+Spreadsort,333,79,0.00028130
+Spreadsort,333,80,0.00027940
+Spreadsort,333,81,0.00028540
+Spreadsort,333,82,0.00028450
+Spreadsort,333,83,0.00028260
+Spreadsort,333,84,0.00028190
+Spreadsort,333,85,0.00028370
+Spreadsort,333,86,0.00028170
+Spreadsort,333,87,0.00028250
+Spreadsort,333,88,0.00028020
+Spreadsort,333,89,0.00028560
+Spreadsort,333,90,0.00028020
+Spreadsort,333,91,0.00028510
+Spreadsort,333,92,0.00029710
+Spreadsort,333,93,0.00028450
+Spreadsort,333,94,0.00028280
+Spreadsort,333,95,0.00028550
+Spreadsort,333,96,0.00028700
+Spreadsort,333,97,0.00028140
+Spreadsort,333,98,0.00028000
+Spreadsort,333,99,0.00028200
+Spreadsort,333,100,0.00028110
+Spreadsort,333,101,0.00028330
+Spreadsort,333,102,0.00028220
+Spreadsort,333,103,0.00029280
+Spreadsort,333,104,0.00028940
+Spreadsort,333,105,0.00029080
+Spreadsort,333,106,0.00028810
+Spreadsort,333,107,0.00028340
+Spreadsort,333,108,0.00028380
+Spreadsort,333,109,0.00028230
+Spreadsort,333,110,0.00028210
+Spreadsort,333,111,0.00029160
+Spreadsort,333,112,0.00028540
+Spreadsort,333,113,0.00028390
+Spreadsort,333,114,0.00028170
+Spreadsort,333,115,0.00028350
+Spreadsort,333,116,0.00028610
+Spreadsort,333,117,0.00028360
+Spreadsort,333,118,0.00028220
+Spreadsort,333,119,0.00028610
+Spreadsort,333,120,0.00028540
+Spreadsort,333,121,0.00028040
+Spreadsort,333,122,0.00028210
+Spreadsort,333,123,0.00028500
+Spreadsort,333,124,0.00028490
+Spreadsort,333,125,0.00028430
+Spreadsort,333,126,0.00028120
+Spreadsort,333,127,0.00028350
+Spreadsort,333,128,0.00027880
+Spreadsort,333,129,0.00030490
+Spreadsort,333,130,0.00028990
+Spreadsort,333,131,0.00028400
+Spreadsort,333,132,0.00029310
+Spreadsort,333,133,0.00029180
+Spreadsort,333,134,0.00029130
+Spreadsort,333,135,0.00028100
+Spreadsort,333,136,0.00028050
+Spreadsort,333,137,0.00028250
+Spreadsort,333,138,0.00023200
+Spreadsort,333,139,0.00023380
+Spreadsort,333,140,0.00028180
+Spreadsort,333,141,0.00027640
+Spreadsort,333,142,0.00161170
+Spreadsort,333,143,0.00027200
+Spreadsort,333,144,0.00029160
+Spreadsort,333,145,0.00031460
+Spreadsort,333,146,0.00028680
+Spreadsort,333,147,0.00027990
+Spreadsort,333,148,0.00032720
+Spreadsort,333,149,0.00030030
+Spreadsort,333,150,0.00029490
+Spreadsort,333,151,0.00029460
+Spreadsort,333,152,0.00028900
+Spreadsort,333,153,0.00028750
+Spreadsort,333,154,0.00077580
+Spreadsort,333,155,0.00027980
+Spreadsort,333,156,0.00030740
+Spreadsort,333,157,0.00030080
+Spreadsort,333,158,0.00030230
+Spreadsort,333,159,0.00030000
+Spreadsort,333,160,0.00030470
+Spreadsort,333,161,0.00029800
+Spreadsort,333,162,0.00030020
+Spreadsort,333,163,0.00048350
+Spreadsort,333,164,0.00029140
+Spreadsort,333,165,0.00028110
+Spreadsort,333,166,0.00029220
+Spreadsort,333,167,0.00029850
+Spreadsort,333,168,0.00030160
+Spreadsort,333,169,0.00030430
+Spreadsort,333,170,0.00032690
+Spreadsort,333,171,0.00028630
+Spreadsort,333,172,0.00028360
+Spreadsort,333,173,0.00028390
+Spreadsort,333,174,0.00017200
+Spreadsort,333,175,0.00028610
+Spreadsort,333,176,0.00031430
+Spreadsort,333,177,0.00028160
+Spreadsort,333,178,0.00028480
+Spreadsort,333,179,0.00028800
+Spreadsort,333,180,0.00028260
+Spreadsort,333,181,0.00028250
+Spreadsort,333,182,0.00028180
+Spreadsort,333,183,0.00028550
+Spreadsort,333,184,0.00040590
+Spreadsort,333,185,0.00028340
+Spreadsort,333,186,0.00028690
+Spreadsort,333,187,0.00028430
+Spreadsort,333,188,0.00029720
+Spreadsort,333,189,0.00028370
+Spreadsort,333,190,0.00028080
+Spreadsort,333,191,0.00029180
+Spreadsort,333,192,0.00028620
+Spreadsort,333,193,0.00018610
+Spreadsort,333,194,0.00030390
+Spreadsort,333,195,0.00028410
+Spreadsort,333,196,0.00029710
+Spreadsort,333,197,0.00029950
+Spreadsort,333,198,0.00028310
+Spreadsort,333,199,0.00028050
+Spreadsort,333,200,0.00028010
+Spreadsort,333,201,0.00016900
+Spreadsort,333,202,0.00027880
+Spreadsort,333,203,0.00028840
+Spreadsort,333,204,0.00028410
+Spreadsort,333,205,0.00031340
+Spreadsort,333,206,0.00029140
+Spreadsort,333,207,0.00029970
+Spreadsort,333,208,0.00028290
+Spreadsort,333,209,0.00029540
+Spreadsort,333,210,0.00028690
+Spreadsort,333,211,0.00029110
+Spreadsort,333,212,0.00028430
+Spreadsort,333,213,0.00029570
+Spreadsort,333,214,0.00028530
+Spreadsort,333,215,0.00028930
+Spreadsort,333,216,0.00029260
+Spreadsort,333,217,0.00028960
+Spreadsort,333,218,0.00028550
+Spreadsort,333,219,0.00028400
+Spreadsort,333,220,0.00028880
+Spreadsort,333,221,0.00027630
+Spreadsort,333,222,0.00028490
+Spreadsort,333,223,0.00033310
+Spreadsort,333,224,0.00030230
+Spreadsort,333,225,0.00022080
+Spreadsort,333,226,0.00029970
+Spreadsort,333,227,0.00020430
+Spreadsort,333,228,0.00028900
+Spreadsort,333,229,0.00023130
+Spreadsort,333,230,0.00031820
+Spreadsort,333,231,0.00026350
+Spreadsort,333,232,0.00029330
+Spreadsort,333,233,0.00028100
+Spreadsort,333,234,0.00028960
+Spreadsort,333,235,0.00025910
+Spreadsort,333,236,0.00029620
+Spreadsort,333,237,0.00029060
+Spreadsort,333,238,0.00029090
+Spreadsort,333,239,0.00026290
+Spreadsort,333,240,0.00029460
+Spreadsort,333,241,0.00026740
+Spreadsort,333,242,0.00029220
+Spreadsort,333,243,0.00027480
+Spreadsort,333,244,0.00028780
+Spreadsort,333,245,0.00027420
+Spreadsort,333,246,0.00029870
+Spreadsort,333,247,0.00029990
+Spreadsort,333,248,0.00029160
+Spreadsort,333,249,0.00028720
+Spreadsort,333,250,0.00029680
+Spreadsort,333,251,0.00028320
+Spreadsort,333,252,0.00029290
+Spreadsort,333,253,0.00028620
+Spreadsort,333,254,0.00030000
+Spreadsort,333,255,0.00028430
+Spreadsort,333,256,0.00028770
+Spreadsort,333,257,0.00030140
+Spreadsort,333,258,0.00028430
+Spreadsort,333,259,0.00029760
+Spreadsort,333,260,0.00028130
+Spreadsort,333,261,0.00029590
+Spreadsort,333,262,0.00028330
+Spreadsort,333,263,0.00030800
+Spreadsort,333,264,0.00027840
+Spreadsort,333,265,0.00028320
+Spreadsort,333,266,0.00028290
+Spreadsort,333,267,0.00028450
+Spreadsort,333,268,0.00029690
+Spreadsort,333,269,0.00028980
+Spreadsort,333,270,0.00028250
+Spreadsort,333,271,0.00029490
+Spreadsort,333,272,0.00028130
+Spreadsort,333,273,0.00029410
+Spreadsort,333,274,0.00028190
+Spreadsort,333,275,0.00028630
+Spreadsort,333,276,0.00041230
+Spreadsort,333,277,0.00028320
+Spreadsort,333,278,0.00028600
+Spreadsort,333,279,0.00028510
+Spreadsort,333,280,0.00030010
+Spreadsort,333,281,0.00028730
+Spreadsort,333,282,0.00028440
+Spreadsort,333,283,0.00028940
+Spreadsort,333,284,0.00028820
+Spreadsort,333,285,0.00202220
+Spreadsort,333,286,0.00028270
+Spreadsort,333,287,0.00028280
+Spreadsort,333,288,0.00028430
+Spreadsort,333,289,0.00028340
+Spreadsort,333,290,0.00036660
+Spreadsort,333,291,0.00029340
+Spreadsort,333,292,0.00028980
+Spreadsort,333,293,0.00027810
+Spreadsort,333,294,0.00029100
+Spreadsort,333,295,0.00028890
+Spreadsort,333,296,0.00028480
+Spreadsort,333,297,0.00028300
+Spreadsort,333,298,0.00028910
+Spreadsort,333,299,0.00021100
+Spreadsort,333,300,0.00021020
+Spreadsort,333,301,0.00028400
+Spreadsort,333,302,0.00029020
+Spreadsort,333,303,0.00028690
+Spreadsort,333,304,0.00030940
+Spreadsort,333,305,0.00028800
+Spreadsort,333,306,0.00030360
+Spreadsort,333,307,0.00028220
+Spreadsort,333,308,0.00028370
+Spreadsort,333,309,0.00019510
+Spreadsort,333,310,0.00018790
+Spreadsort,333,311,0.00028110
+Spreadsort,333,312,0.00027120
+Spreadsort,333,313,0.00029090
+Spreadsort,333,314,0.00028580
+Spreadsort,333,315,0.00028830
+Spreadsort,333,316,0.00019040
+Spreadsort,333,317,0.00028340
+Spreadsort,333,318,0.00029190
+Spreadsort,333,319,0.00028660
+Spreadsort,333,320,0.00021220
+Spreadsort,333,321,0.00028440
+Spreadsort,333,322,0.00029330
+Spreadsort,333,323,0.00030390
+Spreadsort,333,324,0.00020280
+Spreadsort,333,325,0.00028230
+Spreadsort,333,326,0.00029170
+Spreadsort,333,327,0.00028550
+Spreadsort,333,328,0.00028380
+Spreadsort,333,329,0.00029530
+Spreadsort,333,330,0.00028110
+Spreadsort,333,331,0.00028500
+Spreadsort,333,332,0.00028400
+Spreadsort,333,333,0.00029590
+Spreadsort,333,334,0.00028100
+Spreadsort,333,335,0.00027980
+Spreadsort,333,336,0.00029350
+Spreadsort,333,337,0.00028110
+Spreadsort,333,338,0.00028250
+Spreadsort,333,339,0.00028260
+Spreadsort,333,340,0.00027930
+Spreadsort,333,341,0.00028730
+Spreadsort,333,342,0.00028090
+Spreadsort,333,343,0.00028920
+Spreadsort,333,344,0.00028190
+Spreadsort,333,345,0.00028340
+Spreadsort,333,346,0.00028920
+Spreadsort,333,347,0.00029160
+Spreadsort,333,348,0.00028090
+Spreadsort,333,349,0.00028580
+Spreadsort,333,350,0.00028280
+Spreadsort,333,351,0.00028080
+Spreadsort,333,352,0.00028170
+Spreadsort,333,353,0.00029490
+Spreadsort,333,354,0.00029360
+Spreadsort,333,355,0.00026060
+Spreadsort,333,356,0.00030260
+Spreadsort,333,357,0.00047770
+Spreadsort,333,358,0.00045890
+Spreadsort,333,359,0.00031150
+Spreadsort,333,360,0.00036480
+Spreadsort,333,361,0.00029670
+Spreadsort,333,362,0.00028250
+Spreadsort,333,363,0.00030610
+Spreadsort,333,364,0.00029950
+Spreadsort,333,365,0.00029690
+Spreadsort,333,366,0.00022590
+Spreadsort,333,367,0.00017670
+Spreadsort,333,368,0.00021860
+Spreadsort,333,369,0.00026460
+Spreadsort,333,370,0.00022470
+Spreadsort,333,371,0.00024460
+Spreadsort,333,372,0.00025090
+Spreadsort,333,373,0.00024510
+Spreadsort,333,374,0.00018550
+Spreadsort,333,375,0.00019370
+Spreadsort,333,376,0.00017530
+Spreadsort,333,377,0.00019480
+Spreadsort,333,378,0.00021110
+Spreadsort,333,379,0.00022860
+Spreadsort,333,380,0.00018870
+Spreadsort,333,381,0.00018600
+Spreadsort,333,382,0.00026560
+Spreadsort,333,383,0.00022120
+Spreadsort,333,384,0.00030200
+Spreadsort,333,385,0.00028790
+Spreadsort,333,386,0.00028670
+Spreadsort,333,387,0.00028010
+Spreadsort,333,388,0.00024760
+Spreadsort,333,389,0.00027980
+Spreadsort,333,390,0.00024100
+Spreadsort,333,391,0.00030120
+Spreadsort,333,392,0.00027530
+Spreadsort,333,393,0.00028350
+Spreadsort,333,394,0.00028390
+Spreadsort,333,395,0.00028990
+Spreadsort,333,396,0.00028450
+Spreadsort,333,397,0.00028120
+Spreadsort,333,398,0.00028190
+Spreadsort,333,399,0.00028220
+Spreadsort,333,400,0.00028580
+Spreadsort,333,401,0.00029770
+Spreadsort,333,402,0.00028530
+Spreadsort,333,403,0.00028220
+Spreadsort,333,404,0.00028460
+Spreadsort,333,405,0.00029530
+Spreadsort,333,406,0.00028250
+Spreadsort,333,407,0.00028460
+Spreadsort,333,408,0.00028470
+Spreadsort,333,409,0.00028240
+Spreadsort,333,410,0.00028570
+Spreadsort,333,411,0.00029870
+Spreadsort,333,412,0.00032470
+Spreadsort,333,413,0.00028230
+Spreadsort,333,414,0.00029790
+Spreadsort,333,415,0.00029220
+Spreadsort,333,416,0.00029340
+Spreadsort,333,417,0.00027900
+Spreadsort,333,418,0.00028460
+Spreadsort,333,419,0.00028030
+Spreadsort,333,420,0.00028490
+Spreadsort,333,421,0.00027950
+Spreadsort,333,422,0.00028340
+Spreadsort,333,423,0.00028540
+Spreadsort,333,424,0.00028440
+Spreadsort,333,425,0.00030070
+Spreadsort,333,426,0.00028680
+Spreadsort,333,427,0.00028830
+Spreadsort,333,428,0.00028250
+Spreadsort,333,429,0.00028370
+Spreadsort,333,430,0.00028070
+Spreadsort,333,431,0.00028720
+Spreadsort,333,432,0.00028290
+Spreadsort,333,433,0.00029280
+Spreadsort,333,434,0.00028290
+Spreadsort,333,435,0.00030780
+Spreadsort,333,436,0.00029580
+Spreadsort,333,437,0.00028270
+Spreadsort,333,438,0.00028290
+Spreadsort,333,439,0.00028720
+Spreadsort,333,440,0.00028250
+Spreadsort,333,441,0.00028340
+Spreadsort,333,442,0.00027970
+Spreadsort,333,443,0.00028260
+Spreadsort,333,444,0.00028180
+Spreadsort,333,445,0.00028730
+Spreadsort,333,446,0.00027080
+Spreadsort,333,447,0.00028480
+Spreadsort,333,448,0.00019090
+Spreadsort,333,449,0.00022180
+Spreadsort,333,450,0.00029630
+Spreadsort,333,451,0.00020260
+Spreadsort,333,452,0.00028620
+Spreadsort,333,453,0.00021680
+Spreadsort,333,454,0.00028400
+Spreadsort,333,455,0.00024480
+Spreadsort,333,456,0.00028500
+Spreadsort,333,457,0.00022030
+Spreadsort,333,458,0.00028180
+Spreadsort,333,459,0.00020340
+Spreadsort,333,460,0.00028310
+Spreadsort,333,461,0.00018100
+Spreadsort,333,462,0.00027830
+Spreadsort,333,463,0.00028210
+Spreadsort,333,464,0.00038990
+Spreadsort,333,465,0.00049610
+Spreadsort,333,466,0.00023590
+Spreadsort,333,467,0.00028970
+Spreadsort,333,468,0.00025130
+Spreadsort,333,469,0.00028440
+Spreadsort,333,470,0.00017520
+Spreadsort,333,471,0.00028760
+Spreadsort,333,472,0.00019360
+Spreadsort,333,473,0.00028680
+Spreadsort,333,474,0.00036040
+Spreadsort,333,475,0.00028450
+Spreadsort,333,476,0.00028430
+Spreadsort,333,477,0.00029570
+Spreadsort,333,478,0.00029400
+Spreadsort,333,479,0.00028400
+Spreadsort,333,480,0.00028560
+Spreadsort,333,481,0.00028660
+Spreadsort,333,482,0.00028330
+Spreadsort,333,483,0.00027930
+Spreadsort,333,484,0.00028850
+Spreadsort,333,485,0.00028720
+Spreadsort,333,486,0.00028040
+Spreadsort,333,487,0.00029240
+Spreadsort,333,488,0.00028790
+Spreadsort,333,489,0.00020270
+Spreadsort,333,490,0.00028350
+Spreadsort,333,491,0.00020700
+Spreadsort,333,492,0.00028650
+Spreadsort,333,493,0.00024430
+Spreadsort,333,494,0.00028440
+Spreadsort,333,495,0.00024760
+Spreadsort,333,496,0.00028060
+Spreadsort,333,497,0.00018630
+Spreadsort,333,498,0.00028260
+Spreadsort,333,499,0.00017990
+Spreadsort,333,500,0.00028700
+Stooge Sort,333,1,1.21316790
+Stooge Sort,333,2,1.23151600
+Stooge Sort,333,3,1.23012560
+Stooge Sort,333,4,1.20234750
+Stooge Sort,333,5,1.21418420
+Stooge Sort,333,6,1.19106290
+Stooge Sort,333,7,1.19436780
+Stooge Sort,333,8,1.20058100
+Stooge Sort,333,9,1.20767390
+Stooge Sort,333,10,1.21905980
+Stooge Sort,333,11,1.19435440
+Stooge Sort,333,12,1.25620420
+Stooge Sort,333,13,1.18430160
+Stooge Sort,333,14,1.19795500
+Stooge Sort,333,15,1.22646570
+Stooge Sort,333,16,1.21473740
+Stooge Sort,333,17,1.21623400
+Stooge Sort,333,18,1.18078530
+Stooge Sort,333,19,1.21723210
+Stooge Sort,333,20,1.19506670
+Stooge Sort,333,21,1.20467300
+Stooge Sort,333,22,1.18317470
+Stooge Sort,333,23,1.19338630
+Stooge Sort,333,24,1.16606100
+Stooge Sort,333,25,1.21055410
+Stooge Sort,333,26,1.19410710
+Stooge Sort,333,27,1.21839220
+Stooge Sort,333,28,1.22169880
+Stooge Sort,333,29,1.20387890
+Stooge Sort,333,30,1.27582650
+Stooge Sort,333,31,1.24823320
+Stooge Sort,333,32,1.23991610
+Stooge Sort,333,33,1.25091200
+Stooge Sort,333,34,1.23764800
+Stooge Sort,333,35,1.20413790
+Stooge Sort,333,36,1.21914140
+Stooge Sort,333,37,1.20321190
+Stooge Sort,333,38,1.22478910
+Stooge Sort,333,39,1.21215530
+Stooge Sort,333,40,1.17387050
+Stooge Sort,333,41,1.20904010
+Stooge Sort,333,42,1.20152180
+Stooge Sort,333,43,1.21710060
+Stooge Sort,333,44,1.22534290
+Stooge Sort,333,45,1.20656570
+Stooge Sort,333,46,1.19437310
+Stooge Sort,333,47,1.19472190
+Stooge Sort,333,48,1.19889890
+Stooge Sort,333,49,1.23497040
+Stooge Sort,333,50,1.21600790
+Stooge Sort,333,51,1.23028150
+Stooge Sort,333,52,1.20276440
+Stooge Sort,333,53,1.20525120
+Stooge Sort,333,54,1.22710600
+Stooge Sort,333,55,1.19262130
+Stooge Sort,333,56,1.23587040
+Stooge Sort,333,57,1.20403720
+Stooge Sort,333,58,1.21858310
+Stooge Sort,333,59,1.17931810
+Stooge Sort,333,60,1.18724000
+Stooge Sort,333,61,1.16449150
+Stooge Sort,333,62,1.18315470
+Stooge Sort,333,63,1.22307730
+Stooge Sort,333,64,1.22044650
+Stooge Sort,333,65,1.21085960
+Stooge Sort,333,66,1.22209710
+Stooge Sort,333,67,1.17086790
+Stooge Sort,333,68,1.22611170
+Stooge Sort,333,69,1.22395880
+Stooge Sort,333,70,1.23155140
+Stooge Sort,333,71,1.24886960
+Stooge Sort,333,72,1.19919690
+Stooge Sort,333,73,1.23589980
+Stooge Sort,333,74,1.18194970
+Stooge Sort,333,75,1.25010910
+Stooge Sort,333,76,1.20358750
+Stooge Sort,333,77,1.17896070
+Stooge Sort,333,78,1.17254960
+Stooge Sort,333,79,1.19401450
+Stooge Sort,333,80,1.20343100
+Stooge Sort,333,81,1.17645230
+Stooge Sort,333,82,1.21131140
+Stooge Sort,333,83,1.20318020
+Stooge Sort,333,84,1.18659020
+Stooge Sort,333,85,1.20795910
+Stooge Sort,333,86,1.19973650
+Stooge Sort,333,87,1.21701650
+Stooge Sort,333,88,1.22115850
+Stooge Sort,333,89,1.15382100
+Stooge Sort,333,90,1.17789100
+Stooge Sort,333,91,1.22281390
+Stooge Sort,333,92,1.19451440
+Stooge Sort,333,93,1.20112900
+Stooge Sort,333,94,1.16663630
+Stooge Sort,333,95,1.22748760
+Stooge Sort,333,96,1.20413790
+Stooge Sort,333,97,1.19668150
+Stooge Sort,333,98,1.22979100
+Stooge Sort,333,99,1.21422750
+Stooge Sort,333,100,1.18826640
+Stooge Sort,333,101,1.20391510
+Stooge Sort,333,102,1.20596850
+Stooge Sort,333,103,1.20244720
+Stooge Sort,333,104,1.21994740
+Stooge Sort,333,105,1.15826450
+Stooge Sort,333,106,1.22204880
+Stooge Sort,333,107,1.18302380
+Stooge Sort,333,108,1.25576680
+Stooge Sort,333,109,1.20872060
+Stooge Sort,333,110,1.22220190
+Stooge Sort,333,111,1.19708810
+Stooge Sort,333,112,1.23601010
+Stooge Sort,333,113,1.22879080
+Stooge Sort,333,114,1.17148430
+Stooge Sort,333,115,1.19600820
+Stooge Sort,333,116,1.24415210
+Stooge Sort,333,117,1.17140690
+Stooge Sort,333,118,1.18795680
+Stooge Sort,333,119,1.18691000
+Stooge Sort,333,120,1.22659970
+Stooge Sort,333,121,1.22353330
+Stooge Sort,333,122,1.16753920
+Stooge Sort,333,123,1.24669830
+Stooge Sort,333,124,1.23422720
+Stooge Sort,333,125,1.21585630
+Stooge Sort,333,126,1.23674280
+Stooge Sort,333,127,1.19413630
+Stooge Sort,333,128,1.17985170
+Stooge Sort,333,129,1.22963280
+Stooge Sort,333,130,1.22640230
+Stooge Sort,333,131,1.17526140
+Stooge Sort,333,132,1.19356760
+Stooge Sort,333,133,1.20320970
+Stooge Sort,333,134,1.17356040
+Stooge Sort,333,135,1.21018170
+Stooge Sort,333,136,1.20358700
+Stooge Sort,333,137,1.21113300
+Stooge Sort,333,138,1.19527480
+Stooge Sort,333,139,1.21356330
+Stooge Sort,333,140,1.23113370
+Stooge Sort,333,141,1.20405740
+Stooge Sort,333,142,1.17542390
+Stooge Sort,333,143,1.14796130
+Stooge Sort,333,144,1.22516350
+Stooge Sort,333,145,1.20772070
+Stooge Sort,333,146,1.16416650
+Stooge Sort,333,147,1.14759380
+Stooge Sort,333,148,1.21671720
+Stooge Sort,333,149,1.19023720
+Stooge Sort,333,150,1.16387270
+Stooge Sort,333,151,1.20841340
+Stooge Sort,333,152,1.19834930
+Stooge Sort,333,153,1.21619140
+Stooge Sort,333,154,1.16505690
+Stooge Sort,333,155,1.21981230
+Stooge Sort,333,156,1.22419880
+Stooge Sort,333,157,1.18375860
+Stooge Sort,333,158,1.20524230
+Stooge Sort,333,159,1.19831710
+Stooge Sort,333,160,1.19093620
+Stooge Sort,333,161,1.18836860
+Stooge Sort,333,162,1.19506040
+Stooge Sort,333,163,1.19148480
+Stooge Sort,333,164,1.21991710
+Stooge Sort,333,165,1.20367800
+Stooge Sort,333,166,1.20314320
+Stooge Sort,333,167,1.12950380
+Stooge Sort,333,168,1.20945280
+Stooge Sort,333,169,1.22577260
+Stooge Sort,333,170,1.20442160
+Stooge Sort,333,171,1.21412970
+Stooge Sort,333,172,1.20900820
+Stooge Sort,333,173,1.18060370
+Stooge Sort,333,174,1.22660060
+Stooge Sort,333,175,1.17646210
+Stooge Sort,333,176,1.22229310
+Stooge Sort,333,177,1.18032920
+Stooge Sort,333,178,1.17847040
+Stooge Sort,333,179,1.20414330
+Stooge Sort,333,180,1.17540980
+Stooge Sort,333,181,1.19575910
+Stooge Sort,333,182,1.19121620
+Stooge Sort,333,183,1.19377240
+Stooge Sort,333,184,1.21745670
+Stooge Sort,333,185,1.20864910
+Stooge Sort,333,186,1.21985320
+Stooge Sort,333,187,1.20246350
+Stooge Sort,333,188,1.18585660
+Stooge Sort,333,189,1.21268750
+Stooge Sort,333,190,1.18348810
+Stooge Sort,333,191,1.21104340
+Stooge Sort,333,192,1.20800250
+Stooge Sort,333,193,1.12995630
+Stooge Sort,333,194,1.20309260
+Stooge Sort,333,195,1.18212020
+Stooge Sort,333,196,1.14424990
+Stooge Sort,333,197,1.19672360
+Stooge Sort,333,198,1.17297790
+Stooge Sort,333,199,1.19139930
+Stooge Sort,333,200,1.18896630
+Stooge Sort,333,201,1.18396800
+Stooge Sort,333,202,1.19490650
+Stooge Sort,333,203,1.18450740
+Stooge Sort,333,204,1.18626470
+Stooge Sort,333,205,1.21350060
+Stooge Sort,333,206,1.21597970
+Stooge Sort,333,207,1.20361990
+Stooge Sort,333,208,1.17385640
+Stooge Sort,333,209,1.20889350
+Stooge Sort,333,210,1.20849510
+Stooge Sort,333,211,1.19738900
+Stooge Sort,333,212,1.24345830
+Stooge Sort,333,213,1.18786600
+Stooge Sort,333,214,1.20487120
+Stooge Sort,333,215,1.18607100
+Stooge Sort,333,216,1.19111470
+Stooge Sort,333,217,1.20987800
+Stooge Sort,333,218,1.18624810
+Stooge Sort,333,219,1.17207840
+Stooge Sort,333,220,1.20604260
+Stooge Sort,333,221,1.16320450
+Stooge Sort,333,222,1.18080270
+Stooge Sort,333,223,1.20563110
+Stooge Sort,333,224,1.19114680
+Stooge Sort,333,225,1.19170150
+Stooge Sort,333,226,1.15876920
+Stooge Sort,333,227,1.18428350
+Stooge Sort,333,228,1.22046520
+Stooge Sort,333,229,1.15884160
+Stooge Sort,333,230,1.19123940
+Stooge Sort,333,231,1.22288710
+Stooge Sort,333,232,1.27670040
+Stooge Sort,333,233,1.20722630
+Stooge Sort,333,234,1.23969580
+Stooge Sort,333,235,1.24909220
+Stooge Sort,333,236,1.26861960
+Stooge Sort,333,237,1.23262030
+Stooge Sort,333,238,1.23683790
+Stooge Sort,333,239,1.22321420
+Stooge Sort,333,240,1.18038520
+Stooge Sort,333,241,1.18864460
+Stooge Sort,333,242,1.19950060
+Stooge Sort,333,243,1.18757740
+Stooge Sort,333,244,1.20240510
+Stooge Sort,333,245,1.23922430
+Stooge Sort,333,246,1.17205350
+Stooge Sort,333,247,1.16048620
+Stooge Sort,333,248,1.19828970
+Stooge Sort,333,249,1.19860770
+Stooge Sort,333,250,1.18973520
+Stooge Sort,333,251,1.21584130
+Stooge Sort,333,252,1.17892740
+Stooge Sort,333,253,1.23019540
+Stooge Sort,333,254,1.16583300
+Stooge Sort,333,255,1.22197770
+Stooge Sort,333,256,1.21773880
+Stooge Sort,333,257,1.17879800
+Stooge Sort,333,258,1.20628050
+Stooge Sort,333,259,1.16020080
+Stooge Sort,333,260,1.20338970
+Stooge Sort,333,261,1.22028100
+Stooge Sort,333,262,1.20032150
+Stooge Sort,333,263,1.22841960
+Stooge Sort,333,264,1.18758810
+Stooge Sort,333,265,1.22538690
+Stooge Sort,333,266,1.19892000
+Stooge Sort,333,267,1.23416470
+Stooge Sort,333,268,1.22124840
+Stooge Sort,333,269,1.19570470
+Stooge Sort,333,270,1.17519410
+Stooge Sort,333,271,1.19986070
+Stooge Sort,333,272,1.20624720
+Stooge Sort,333,273,1.23931500
+Stooge Sort,333,274,1.18764240
+Stooge Sort,333,275,1.17734500
+Stooge Sort,333,276,1.24526890
+Stooge Sort,333,277,1.25700070
+Stooge Sort,333,278,1.20601460
+Stooge Sort,333,279,1.19091630
+Stooge Sort,333,280,1.24203170
+Stooge Sort,333,281,1.19701950
+Stooge Sort,333,282,1.24179770
+Stooge Sort,333,283,1.21135320
+Stooge Sort,333,284,1.18190160
+Stooge Sort,333,285,1.22170430
+Stooge Sort,333,286,1.21519170
+Stooge Sort,333,287,1.18288790
+Stooge Sort,333,288,1.17836180
+Stooge Sort,333,289,1.24500070
+Stooge Sort,333,290,1.20580730
+Stooge Sort,333,291,1.20529970
+Stooge Sort,333,292,1.22719400
+Stooge Sort,333,293,1.23325730
+Stooge Sort,333,294,1.20546230
+Stooge Sort,333,295,1.20773370
+Stooge Sort,333,296,1.19505580
+Stooge Sort,333,297,1.19708740
+Stooge Sort,333,298,1.21533050
+Stooge Sort,333,299,1.20630440
+Stooge Sort,333,300,1.21471850
+Stooge Sort,333,301,1.17555600
+Stooge Sort,333,302,1.20874530
+Stooge Sort,333,303,1.13715630
+Stooge Sort,333,304,1.21896640
+Stooge Sort,333,305,1.22958330
+Stooge Sort,333,306,1.17390450
+Stooge Sort,333,307,1.18182560
+Stooge Sort,333,308,1.22792580
+Stooge Sort,333,309,1.20869240
+Stooge Sort,333,310,1.18731770
+Stooge Sort,333,311,1.23152150
+Stooge Sort,333,312,1.23360650
+Stooge Sort,333,313,1.19525040
+Stooge Sort,333,314,1.20438600
+Stooge Sort,333,315,1.19498200
+Stooge Sort,333,316,1.19225240
+Stooge Sort,333,317,1.20523280
+Stooge Sort,333,318,1.14336230
+Stooge Sort,333,319,1.21512890
+Stooge Sort,333,320,1.20868660
+Stooge Sort,333,321,1.20569100
+Stooge Sort,333,322,1.19140990
+Stooge Sort,333,323,1.19517150
+Stooge Sort,333,324,1.21164350
+Stooge Sort,333,325,1.16426380
+Stooge Sort,333,326,1.19515720
+Stooge Sort,333,327,1.19962580
+Stooge Sort,333,328,1.21519890
+Stooge Sort,333,329,1.17541910
+Stooge Sort,333,330,1.16070390
+Stooge Sort,333,331,1.21405500
+Stooge Sort,333,332,1.22195710
+Stooge Sort,333,333,1.25235210
+Stooge Sort,333,334,1.22189220
+Stooge Sort,333,335,1.22929170
+Stooge Sort,333,336,1.20926130
+Stooge Sort,333,337,1.19157940
+Stooge Sort,333,338,1.20019830
+Stooge Sort,333,339,1.21486740
+Stooge Sort,333,340,1.15918150
+Stooge Sort,333,341,1.20705620
+Stooge Sort,333,342,1.19902590
+Stooge Sort,333,343,1.20173840
+Stooge Sort,333,344,1.21439380
+Stooge Sort,333,345,1.21840980
+Stooge Sort,333,346,1.17963480
+Stooge Sort,333,347,1.19147860
+Stooge Sort,333,348,1.21163740
+Stooge Sort,333,349,1.19977450
+Stooge Sort,333,350,1.15937270
+Stooge Sort,333,351,1.20742060
+Stooge Sort,333,352,1.20968940
+Stooge Sort,333,353,1.20595300
+Stooge Sort,333,354,1.22601010
+Stooge Sort,333,355,1.16499720
+Stooge Sort,333,356,1.21258700
+Stooge Sort,333,357,1.20116790
+Stooge Sort,333,358,1.23382360
+Stooge Sort,333,359,1.21558600
+Stooge Sort,333,360,1.17909270
+Stooge Sort,333,361,1.24110820
+Stooge Sort,333,362,1.20003290
+Stooge Sort,333,363,1.22302550
+Stooge Sort,333,364,1.17663410
+Stooge Sort,333,365,1.23159490
+Stooge Sort,333,366,1.22793310
+Stooge Sort,333,367,1.22749530
+Stooge Sort,333,368,1.23091750
+Stooge Sort,333,369,1.19753560
+Stooge Sort,333,370,1.19756890
+Stooge Sort,333,371,1.19834110
+Stooge Sort,333,372,1.20282420
+Stooge Sort,333,373,1.22432560
+Stooge Sort,333,374,1.24845880
+Stooge Sort,333,375,1.23764840
+Stooge Sort,333,376,1.20486300
+Stooge Sort,333,377,1.22058240
+Stooge Sort,333,378,1.21249670
+Stooge Sort,333,379,1.22802060
+Stooge Sort,333,380,1.16702250
+Stooge Sort,333,381,1.17311300
+Stooge Sort,333,382,1.18542930
+Stooge Sort,333,383,1.19358350
+Stooge Sort,333,384,1.22185840
+Stooge Sort,333,385,1.18051130
+Stooge Sort,333,386,1.18036350
+Stooge Sort,333,387,1.19406340
+Stooge Sort,333,388,1.18184110
+Stooge Sort,333,389,1.16033700
+Stooge Sort,333,390,1.17225530
+Stooge Sort,333,391,1.17952040
+Stooge Sort,333,392,1.17656410
+Stooge Sort,333,393,1.23444840
+Stooge Sort,333,394,1.23117740
+Stooge Sort,333,395,1.16021170
+Stooge Sort,333,396,1.18953620
+Stooge Sort,333,397,1.23551600
+Stooge Sort,333,398,1.21885510
+Stooge Sort,333,399,1.21670150
+Stooge Sort,333,400,1.18709340
+Stooge Sort,333,401,1.20758440
+Stooge Sort,333,402,1.16577990
+Stooge Sort,333,403,1.19146730
+Stooge Sort,333,404,1.19005010
+Stooge Sort,333,405,1.25117700
+Stooge Sort,333,406,1.24028720
+Stooge Sort,333,407,1.24008250
+Stooge Sort,333,408,1.23456250
+Stooge Sort,333,409,1.24984490
+Stooge Sort,333,410,1.20818600
+Stooge Sort,333,411,1.23407910
+Stooge Sort,333,412,1.19603020
+Stooge Sort,333,413,1.23731550
+Stooge Sort,333,414,1.18275220
+Stooge Sort,333,415,1.20989220
+Stooge Sort,333,416,1.18942500
+Stooge Sort,333,417,1.20514830
+Stooge Sort,333,418,1.21925450
+Stooge Sort,333,419,1.19389100
+Stooge Sort,333,420,1.18855000
+Stooge Sort,333,421,1.20357200
+Stooge Sort,333,422,1.19936070
+Stooge Sort,333,423,1.16532980
+Stooge Sort,333,424,1.22456070
+Stooge Sort,333,425,1.24393260
+Stooge Sort,333,426,1.19612420
+Stooge Sort,333,427,1.21844980
+Stooge Sort,333,428,1.22533770
+Stooge Sort,333,429,1.20018490
+Stooge Sort,333,430,1.20940960
+Stooge Sort,333,431,1.21151430
+Stooge Sort,333,432,1.22224050
+Stooge Sort,333,433,1.23058920
+Stooge Sort,333,434,1.22143790
+Stooge Sort,333,435,1.20711410
+Stooge Sort,333,436,1.20254010
+Stooge Sort,333,437,1.21921590
+Stooge Sort,333,438,1.15691570
+Stooge Sort,333,439,1.16943240
+Stooge Sort,333,440,1.20842390
+Stooge Sort,333,441,1.24666160
+Stooge Sort,333,442,1.21714990
+Stooge Sort,333,443,1.20895290
+Stooge Sort,333,444,1.20051770
+Stooge Sort,333,445,1.21580820
+Stooge Sort,333,446,1.19956250
+Stooge Sort,333,447,1.18583510
+Stooge Sort,333,448,1.19550070
+Stooge Sort,333,449,1.19902690
+Stooge Sort,333,450,1.18133490
+Stooge Sort,333,451,1.23003440
+Stooge Sort,333,452,1.18536890
+Stooge Sort,333,453,1.19347410
+Stooge Sort,333,454,1.19625390
+Stooge Sort,333,455,1.19243090
+Stooge Sort,333,456,1.21631740
+Stooge Sort,333,457,1.17950100
+Stooge Sort,333,458,1.21731230
+Stooge Sort,333,459,1.19312020
+Stooge Sort,333,460,1.18471470
+Stooge Sort,333,461,1.19184220
+Stooge Sort,333,462,1.16929280
+Stooge Sort,333,463,1.18035810
+Stooge Sort,333,464,1.17697630
+Stooge Sort,333,465,1.19700960
+Stooge Sort,333,466,1.19465950
+Stooge Sort,333,467,1.21113480
+Stooge Sort,333,468,1.20231410
+Stooge Sort,333,469,1.19315530
+Stooge Sort,333,470,1.21700780
+Stooge Sort,333,471,1.20920640
+Stooge Sort,333,472,1.21165560
+Stooge Sort,333,473,1.18732820
+Stooge Sort,333,474,1.16567650
+Stooge Sort,333,475,1.18973490
+Stooge Sort,333,476,1.17875220
+Stooge Sort,333,477,1.19252590
+Stooge Sort,333,478,1.17254470
+Stooge Sort,333,479,1.21575030
+Stooge Sort,333,480,1.22064450
+Stooge Sort,333,481,1.19654320
+Stooge Sort,333,482,1.24903240
+Stooge Sort,333,483,1.21522340
+Stooge Sort,333,484,1.21154430
+Stooge Sort,333,485,1.21583080
+Stooge Sort,333,486,1.19041920
+Stooge Sort,333,487,1.19722540
+Stooge Sort,333,488,1.21860130
+Stooge Sort,333,489,1.18042550
+Stooge Sort,333,490,1.19048250
+Stooge Sort,333,491,1.20518210
+Stooge Sort,333,492,1.19353480
+Stooge Sort,333,493,1.22322440
+Stooge Sort,333,494,1.19860860
+Stooge Sort,333,495,1.18488290
+Stooge Sort,333,496,1.20360010
+Stooge Sort,333,497,1.21280910
+Stooge Sort,333,498,1.23566080
+Stooge Sort,333,499,1.25246020
+Stooge Sort,333,500,1.21040860
+Strand Sort,333,1,0.00123210
+Strand Sort,333,2,0.00112710
+Strand Sort,333,3,0.00119600
+Strand Sort,333,4,0.00117460
+Strand Sort,333,5,0.00117290
+Strand Sort,333,6,0.00117090
+Strand Sort,333,7,0.00114660
+Strand Sort,333,8,0.00117640
+Strand Sort,333,9,0.00101750
+Strand Sort,333,10,0.00108180
+Strand Sort,333,11,0.00112560
+Strand Sort,333,12,0.00088180
+Strand Sort,333,13,0.00064180
+Strand Sort,333,14,0.00066880
+Strand Sort,333,15,0.00082960
+Strand Sort,333,16,0.00120660
+Strand Sort,333,17,0.00112900
+Strand Sort,333,18,0.00065570
+Strand Sort,333,19,0.00065860
+Strand Sort,333,20,0.00061340
+Strand Sort,333,21,0.00065810
+Strand Sort,333,22,0.00067340
+Strand Sort,333,23,0.00063370
+Strand Sort,333,24,0.00059270
+Strand Sort,333,25,0.00064320
+Strand Sort,333,26,0.00081480
+Strand Sort,333,27,0.00120230
+Strand Sort,333,28,0.00067160
+Strand Sort,333,29,0.00063960
+Strand Sort,333,30,0.00109700
+Strand Sort,333,31,0.00067550
+Strand Sort,333,32,0.00060770
+Strand Sort,333,33,0.00064530
+Strand Sort,333,34,0.00065730
+Strand Sort,333,35,0.00072560
+Strand Sort,333,36,0.00068920
+Strand Sort,333,37,0.00067360
+Strand Sort,333,38,0.00070840
+Strand Sort,333,39,0.00070640
+Strand Sort,333,40,0.00088090
+Strand Sort,333,41,0.00125140
+Strand Sort,333,42,0.00119470
+Strand Sort,333,43,0.00122710
+Strand Sort,333,44,0.00101320
+Strand Sort,333,45,0.00115260
+Strand Sort,333,46,0.00126940
+Strand Sort,333,47,0.00124170
+Strand Sort,333,48,0.00118230
+Strand Sort,333,49,0.00120250
+Strand Sort,333,50,0.00131300
+Strand Sort,333,51,0.00112820
+Strand Sort,333,52,0.00122800
+Strand Sort,333,53,0.00122800
+Strand Sort,333,54,0.00116600
+Strand Sort,333,55,0.00122030
+Strand Sort,333,56,0.00127970
+Strand Sort,333,57,0.00111910
+Strand Sort,333,58,0.00113880
+Strand Sort,333,59,0.00117100
+Strand Sort,333,60,0.00115340
+Strand Sort,333,61,0.00115630
+Strand Sort,333,62,0.00123000
+Strand Sort,333,63,0.00120120
+Strand Sort,333,64,0.00118510
+Strand Sort,333,65,0.00117010
+Strand Sort,333,66,0.00126170
+Strand Sort,333,67,0.00099030
+Strand Sort,333,68,0.00119720
+Strand Sort,333,69,0.00129280
+Strand Sort,333,70,0.00111530
+Strand Sort,333,71,0.00116500
+Strand Sort,333,72,0.00117310
+Strand Sort,333,73,0.00127350
+Strand Sort,333,74,0.00102920
+Strand Sort,333,75,0.00113230
+Strand Sort,333,76,0.00106800
+Strand Sort,333,77,0.00116690
+Strand Sort,333,78,0.00124800
+Strand Sort,333,79,0.00118520
+Strand Sort,333,80,0.00125980
+Strand Sort,333,81,0.00114220
+Strand Sort,333,82,0.00116010
+Strand Sort,333,83,0.00125860
+Strand Sort,333,84,0.00110040
+Strand Sort,333,85,0.00125010
+Strand Sort,333,86,0.00119230
+Strand Sort,333,87,0.00104310
+Strand Sort,333,88,0.00116180
+Strand Sort,333,89,0.00112950
+Strand Sort,333,90,0.00119780
+Strand Sort,333,91,0.00122180
+Strand Sort,333,92,0.00118910
+Strand Sort,333,93,0.00124210
+Strand Sort,333,94,0.00122000
+Strand Sort,333,95,0.00067000
+Strand Sort,333,96,0.00064910
+Strand Sort,333,97,0.00075040
+Strand Sort,333,98,0.00063900
+Strand Sort,333,99,0.00068620
+Strand Sort,333,100,0.00063560
+Strand Sort,333,101,0.00074580
+Strand Sort,333,102,0.00058750
+Strand Sort,333,103,0.00064160
+Strand Sort,333,104,0.00057850
+Strand Sort,333,105,0.00059130
+Strand Sort,333,106,0.00067690
+Strand Sort,333,107,0.00076990
+Strand Sort,333,108,0.00111550
+Strand Sort,333,109,0.00078460
+Strand Sort,333,110,0.00107930
+Strand Sort,333,111,0.00077520
+Strand Sort,333,112,0.00109460
+Strand Sort,333,113,0.00061030
+Strand Sort,333,114,0.00083140
+Strand Sort,333,115,0.00124670
+Strand Sort,333,116,0.00075950
+Strand Sort,333,117,0.00126960
+Strand Sort,333,118,0.00062920
+Strand Sort,333,119,0.00097340
+Strand Sort,333,120,0.00121100
+Strand Sort,333,121,0.00110290
+Strand Sort,333,122,0.00116160
+Strand Sort,333,123,0.00125980
+Strand Sort,333,124,0.00116130
+Strand Sort,333,125,0.00110760
+Strand Sort,333,126,0.00137900
+Strand Sort,333,127,0.00127370
+Strand Sort,333,128,0.00117880
+Strand Sort,333,129,0.00113910
+Strand Sort,333,130,0.00116850
+Strand Sort,333,131,0.00110900
+Strand Sort,333,132,0.00118030
+Strand Sort,333,133,0.00088640
+Strand Sort,333,134,0.00110480
+Strand Sort,333,135,0.00126710
+Strand Sort,333,136,0.00112870
+Strand Sort,333,137,0.00123930
+Strand Sort,333,138,0.00116170
+Strand Sort,333,139,0.00114460
+Strand Sort,333,140,0.00113350
+Strand Sort,333,141,0.00127620
+Strand Sort,333,142,0.00088580
+Strand Sort,333,143,0.00123140
+Strand Sort,333,144,0.00130850
+Strand Sort,333,145,0.00121220
+Strand Sort,333,146,0.00115650
+Strand Sort,333,147,0.00117190
+Strand Sort,333,148,0.00127720
+Strand Sort,333,149,0.00109720
+Strand Sort,333,150,0.00111250
+Strand Sort,333,151,0.00113580
+Strand Sort,333,152,0.00118750
+Strand Sort,333,153,0.00130280
+Strand Sort,333,154,0.00109160
+Strand Sort,333,155,0.00124380
+Strand Sort,333,156,0.00116960
+Strand Sort,333,157,0.00134760
+Strand Sort,333,158,0.00110460
+Strand Sort,333,159,0.00122660
+Strand Sort,333,160,0.00109940
+Strand Sort,333,161,0.00137650
+Strand Sort,333,162,0.00112550
+Strand Sort,333,163,0.00113140
+Strand Sort,333,164,0.00114820
+Strand Sort,333,165,0.00124500
+Strand Sort,333,166,0.00123770
+Strand Sort,333,167,0.00113440
+Strand Sort,333,168,0.00118880
+Strand Sort,333,169,0.00120600
+Strand Sort,333,170,0.00121430
+Strand Sort,333,171,0.00122470
+Strand Sort,333,172,0.00106330
+Strand Sort,333,173,0.00119050
+Strand Sort,333,174,0.00120260
+Strand Sort,333,175,0.00110860
+Strand Sort,333,176,0.00075370
+Strand Sort,333,177,0.00088160
+Strand Sort,333,178,0.00127230
+Strand Sort,333,179,0.00090440
+Strand Sort,333,180,0.00116810
+Strand Sort,333,181,0.00061660
+Strand Sort,333,182,0.00069260
+Strand Sort,333,183,0.00115640
+Strand Sort,333,184,0.00066570
+Strand Sort,333,185,0.00118400
+Strand Sort,333,186,0.00064270
+Strand Sort,333,187,0.00066040
+Strand Sort,333,188,0.00117920
+Strand Sort,333,189,0.00064390
+Strand Sort,333,190,0.00109910
+Strand Sort,333,191,0.00063260
+Strand Sort,333,192,0.00131890
+Strand Sort,333,193,0.00114650
+Strand Sort,333,194,0.00082960
+Strand Sort,333,195,0.00112960
+Strand Sort,333,196,0.00100170
+Strand Sort,333,197,0.00120150
+Strand Sort,333,198,0.00073640
+Strand Sort,333,199,0.00105030
+Strand Sort,333,200,0.00064740
+Strand Sort,333,201,0.00120180
+Strand Sort,333,202,0.00066840
+Strand Sort,333,203,0.00080600
+Strand Sort,333,204,0.00109260
+Strand Sort,333,205,0.00076780
+Strand Sort,333,206,0.00109740
+Strand Sort,333,207,0.00118500
+Strand Sort,333,208,0.00071260
+Strand Sort,333,209,0.00119360
+Strand Sort,333,210,0.00061300
+Strand Sort,333,211,0.00113400
+Strand Sort,333,212,0.00107880
+Strand Sort,333,213,0.00073590
+Strand Sort,333,214,0.00115750
+Strand Sort,333,215,0.00071310
+Strand Sort,333,216,0.00127320
+Strand Sort,333,217,0.00096730
+Strand Sort,333,218,0.00107650
+Strand Sort,333,219,0.00070000
+Strand Sort,333,220,0.00096660
+Strand Sort,333,221,0.00109040
+Strand Sort,333,222,0.00121340
+Strand Sort,333,223,0.00119070
+Strand Sort,333,224,0.00119400
+Strand Sort,333,225,0.00118030
+Strand Sort,333,226,0.00080200
+Strand Sort,333,227,0.00107500
+Strand Sort,333,228,0.00076060
+Strand Sort,333,229,0.00068010
+Strand Sort,333,230,0.00099370
+Strand Sort,333,231,0.00093160
+Strand Sort,333,232,0.00077570
+Strand Sort,333,233,0.00114110
+Strand Sort,333,234,0.00071650
+Strand Sort,333,235,0.00114090
+Strand Sort,333,236,0.00066130
+Strand Sort,333,237,0.00074000
+Strand Sort,333,238,0.00111630
+Strand Sort,333,239,0.00066000
+Strand Sort,333,240,0.00112950
+Strand Sort,333,241,0.00064030
+Strand Sort,333,242,0.00075740
+Strand Sort,333,243,0.00117200
+Strand Sort,333,244,0.00065860
+Strand Sort,333,245,0.00113650
+Strand Sort,333,246,0.00062780
+Strand Sort,333,247,0.00068190
+Strand Sort,333,248,0.00106990
+Strand Sort,333,249,0.00064730
+Strand Sort,333,250,0.00069400
+Strand Sort,333,251,0.00113160
+Strand Sort,333,252,0.00069200
+Strand Sort,333,253,0.00110600
+Strand Sort,333,254,0.00070060
+Strand Sort,333,255,0.00107040
+Strand Sort,333,256,0.00109750
+Strand Sort,333,257,0.00119810
+Strand Sort,333,258,0.00119520
+Strand Sort,333,259,0.00119470
+Strand Sort,333,260,0.00115550
+Strand Sort,333,261,0.00109080
+Strand Sort,333,262,0.00112600
+Strand Sort,333,263,0.00114000
+Strand Sort,333,264,0.00073300
+Strand Sort,333,265,0.00110810
+Strand Sort,333,266,0.00111780
+Strand Sort,333,267,0.00112750
+Strand Sort,333,268,0.00107390
+Strand Sort,333,269,0.00123420
+Strand Sort,333,270,0.00106920
+Strand Sort,333,271,0.00071280
+Strand Sort,333,272,0.00105240
+Strand Sort,333,273,0.00084710
+Strand Sort,333,274,0.00120490
+Strand Sort,333,275,0.00076560
+Strand Sort,333,276,0.00127130
+Strand Sort,333,277,0.00064210
+Strand Sort,333,278,0.00108050
+Strand Sort,333,279,0.00122220
+Strand Sort,333,280,0.00125890
+Strand Sort,333,281,0.00124020
+Strand Sort,333,282,0.00114630
+Strand Sort,333,283,0.00112790
+Strand Sort,333,284,0.00071510
+Strand Sort,333,285,0.00120310
+Strand Sort,333,286,0.00096470
+Strand Sort,333,287,0.00118390
+Strand Sort,333,288,0.00122220
+Strand Sort,333,289,0.00138790
+Strand Sort,333,290,0.00110790
+Strand Sort,333,291,0.00116380
+Strand Sort,333,292,0.00108490
+Strand Sort,333,293,0.00114830
+Strand Sort,333,294,0.00114650
+Strand Sort,333,295,0.00114930
+Strand Sort,333,296,0.00112740
+Strand Sort,333,297,0.00112520
+Strand Sort,333,298,0.00165370
+Strand Sort,333,299,0.00130760
+Strand Sort,333,300,0.00120880
+Strand Sort,333,301,0.00103380
+Strand Sort,333,302,0.00116640
+Strand Sort,333,303,0.00132560
+Strand Sort,333,304,0.00110210
+Strand Sort,333,305,0.00124710
+Strand Sort,333,306,0.00116870
+Strand Sort,333,307,0.00104970
+Strand Sort,333,308,0.00124860
+Strand Sort,333,309,0.00122530
+Strand Sort,333,310,0.00117940
+Strand Sort,333,311,0.00115670
+Strand Sort,333,312,0.00138080
+Strand Sort,333,313,0.00124780
+Strand Sort,333,314,0.00114810
+Strand Sort,333,315,0.00123280
+Strand Sort,333,316,0.00117180
+Strand Sort,333,317,0.00107730
+Strand Sort,333,318,0.00111820
+Strand Sort,333,319,0.00108670
+Strand Sort,333,320,0.00117590
+Strand Sort,333,321,0.00131610
+Strand Sort,333,322,0.00096030
+Strand Sort,333,323,0.00116260
+Strand Sort,333,324,0.00118790
+Strand Sort,333,325,0.00127610
+Strand Sort,333,326,0.00112260
+Strand Sort,333,327,0.00134050
+Strand Sort,333,328,0.00121650
+Strand Sort,333,329,0.00110520
+Strand Sort,333,330,0.00137500
+Strand Sort,333,331,0.00120670
+Strand Sort,333,332,0.00110880
+Strand Sort,333,333,0.00125070
+Strand Sort,333,334,0.00135730
+Strand Sort,333,335,0.00121860
+Strand Sort,333,336,0.00124520
+Strand Sort,333,337,0.00117890
+Strand Sort,333,338,0.00140010
+Strand Sort,333,339,0.00109510
+Strand Sort,333,340,0.00109640
+Strand Sort,333,341,0.00127520
+Strand Sort,333,342,0.00111020
+Strand Sort,333,343,0.00127740
+Strand Sort,333,344,0.00211000
+Strand Sort,333,345,0.00112010
+Strand Sort,333,346,0.00134460
+Strand Sort,333,347,0.00112800
+Strand Sort,333,348,0.00127120
+Strand Sort,333,349,0.00121390
+Strand Sort,333,350,0.00117930
+Strand Sort,333,351,0.00121690
+Strand Sort,333,352,0.00108100
+Strand Sort,333,353,0.00109880
+Strand Sort,333,354,0.00115050
+Strand Sort,333,355,0.00086930
+Strand Sort,333,356,0.00114710
+Strand Sort,333,357,0.00123500
+Strand Sort,333,358,0.00109500
+Strand Sort,333,359,0.00114060
+Strand Sort,333,360,0.00112500
+Strand Sort,333,361,0.00111700
+Strand Sort,333,362,0.00127050
+Strand Sort,333,363,0.00116760
+Strand Sort,333,364,0.00111780
+Strand Sort,333,365,0.00108710
+Strand Sort,333,366,0.00115920
+Strand Sort,333,367,0.00113660
+Strand Sort,333,368,0.00109820
+Strand Sort,333,369,0.00117680
+Strand Sort,333,370,0.00117730
+Strand Sort,333,371,0.00123290
+Strand Sort,333,372,0.00118910
+Strand Sort,333,373,0.00111300
+Strand Sort,333,374,0.00125310
+Strand Sort,333,375,0.00127030
+Strand Sort,333,376,0.00118090
+Strand Sort,333,377,0.00114920
+Strand Sort,333,378,0.00108250
+Strand Sort,333,379,0.00116090
+Strand Sort,333,380,0.00109950
+Strand Sort,333,381,0.00116750
+Strand Sort,333,382,0.00132870
+Strand Sort,333,383,0.00114710
+Strand Sort,333,384,0.00109130
+Strand Sort,333,385,0.00107730
+Strand Sort,333,386,0.00120630
+Strand Sort,333,387,0.00123570
+Strand Sort,333,388,0.00137820
+Strand Sort,333,389,0.00116330
+Strand Sort,333,390,0.00129540
+Strand Sort,333,391,0.00114710
+Strand Sort,333,392,0.00113000
+Strand Sort,333,393,0.00117190
+Strand Sort,333,394,0.00112780
+Strand Sort,333,395,0.00122050
+Strand Sort,333,396,0.00120330
+Strand Sort,333,397,0.00123830
+Strand Sort,333,398,0.00119340
+Strand Sort,333,399,0.00113480
+Strand Sort,333,400,0.00117750
+Strand Sort,333,401,0.00138100
+Strand Sort,333,402,0.00110680
+Strand Sort,333,403,0.00115870
+Strand Sort,333,404,0.00122850
+Strand Sort,333,405,0.00122780
+Strand Sort,333,406,0.00121190
+Strand Sort,333,407,0.00115270
+Strand Sort,333,408,0.00113220
+Strand Sort,333,409,0.00125450
+Strand Sort,333,410,0.00109700
+Strand Sort,333,411,0.00123410
+Strand Sort,333,412,0.00134000
+Strand Sort,333,413,0.00131240
+Strand Sort,333,414,0.00118320
+Strand Sort,333,415,0.00152700
+Strand Sort,333,416,0.00123210
+Strand Sort,333,417,0.00121810
+Strand Sort,333,418,0.00146110
+Strand Sort,333,419,0.00131750
+Strand Sort,333,420,0.00121890
+Strand Sort,333,421,0.00120900
+Strand Sort,333,422,0.00108420
+Strand Sort,333,423,0.00118930
+Strand Sort,333,424,0.00112000
+Strand Sort,333,425,0.00122150
+Strand Sort,333,426,0.00115600
+Strand Sort,333,427,0.00113640
+Strand Sort,333,428,0.00109030
+Strand Sort,333,429,0.00111400
+Strand Sort,333,430,0.00113230
+Strand Sort,333,431,0.00118890
+Strand Sort,333,432,0.00118960
+Strand Sort,333,433,0.00112060
+Strand Sort,333,434,0.00076240
+Strand Sort,333,435,0.00108860
+Strand Sort,333,436,0.00112790
+Strand Sort,333,437,0.00113240
+Strand Sort,333,438,0.00105620
+Strand Sort,333,439,0.00126070
+Strand Sort,333,440,0.00112310
+Strand Sort,333,441,0.00109480
+Strand Sort,333,442,0.00113800
+Strand Sort,333,443,0.00121240
+Strand Sort,333,444,0.00074240
+Strand Sort,333,445,0.00110190
+Strand Sort,333,446,0.00113400
+Strand Sort,333,447,0.00092650
+Strand Sort,333,448,0.00124190
+Strand Sort,333,449,0.00127090
+Strand Sort,333,450,0.00106340
+Strand Sort,333,451,0.00083880
+Strand Sort,333,452,0.00118990
+Strand Sort,333,453,0.00125230
+Strand Sort,333,454,0.00122610
+Strand Sort,333,455,0.00065100
+Strand Sort,333,456,0.00085170
+Strand Sort,333,457,0.00108770
+Strand Sort,333,458,0.00113270
+Strand Sort,333,459,0.00115660
+Strand Sort,333,460,0.00073620
+Strand Sort,333,461,0.00116110
+Strand Sort,333,462,0.00113000
+Strand Sort,333,463,0.00123630
+Strand Sort,333,464,0.00064230
+Strand Sort,333,465,0.00125360
+Strand Sort,333,466,0.00089450
+Strand Sort,333,467,0.00112770
+Strand Sort,333,468,0.00122030
+Strand Sort,333,469,0.00086530
+Strand Sort,333,470,0.00114880
+Strand Sort,333,471,0.00132020
+Strand Sort,333,472,0.00107320
+Strand Sort,333,473,0.00093960
+Strand Sort,333,474,0.00111230
+Strand Sort,333,475,0.00124870
+Strand Sort,333,476,0.00108000
+Strand Sort,333,477,0.00125720
+Strand Sort,333,478,0.00123660
+Strand Sort,333,479,0.00130000
+Strand Sort,333,480,0.00129420
+Strand Sort,333,481,0.00124810
+Strand Sort,333,482,0.00111880
+Strand Sort,333,483,0.00123310
+Strand Sort,333,484,0.00129390
+Strand Sort,333,485,0.00119670
+Strand Sort,333,486,0.00115850
+Strand Sort,333,487,0.00122400
+Strand Sort,333,488,0.00110880
+Strand Sort,333,489,0.00108810
+Strand Sort,333,490,0.00118720
+Strand Sort,333,491,0.00109130
+Strand Sort,333,492,0.00113860
+Strand Sort,333,493,0.00117630
+Strand Sort,333,494,0.00119910
+Strand Sort,333,495,0.00115530
+Strand Sort,333,496,0.00116440
+Strand Sort,333,497,0.00105460
+Strand Sort,333,498,0.00122010
+Strand Sort,333,499,0.00123410
+Strand Sort,333,500,0.00108050
+Tim Sort,333,1,0.00062280
+Tim Sort,333,2,0.00061950
+Tim Sort,333,3,0.00062350
+Tim Sort,333,4,0.00063380
+Tim Sort,333,5,0.00063030
+Tim Sort,333,6,0.00060700
+Tim Sort,333,7,0.00061710
+Tim Sort,333,8,0.00058700
+Tim Sort,333,9,0.00061040
+Tim Sort,333,10,0.00059130
+Tim Sort,333,11,0.00059710
+Tim Sort,333,12,0.00060830
+Tim Sort,333,13,0.00059950
+Tim Sort,333,14,0.00061140
+Tim Sort,333,15,0.00059340
+Tim Sort,333,16,0.00061460
+Tim Sort,333,17,0.00058120
+Tim Sort,333,18,0.00059520
+Tim Sort,333,19,0.00060420
+Tim Sort,333,20,0.00060670
+Tim Sort,333,21,0.00060760
+Tim Sort,333,22,0.00060140
+Tim Sort,333,23,0.00059960
+Tim Sort,333,24,0.00061080
+Tim Sort,333,25,0.00059140
+Tim Sort,333,26,0.00059110
+Tim Sort,333,27,0.00058820
+Tim Sort,333,28,0.00058790
+Tim Sort,333,29,0.00058970
+Tim Sort,333,30,0.00061710
+Tim Sort,333,31,0.00059000
+Tim Sort,333,32,0.00059100
+Tim Sort,333,33,0.00059500
+Tim Sort,333,34,0.00059060
+Tim Sort,333,35,0.00059410
+Tim Sort,333,36,0.00060820
+Tim Sort,333,37,0.00059140
+Tim Sort,333,38,0.00058970
+Tim Sort,333,39,0.00061380
+Tim Sort,333,40,0.00061160
+Tim Sort,333,41,0.00060900
+Tim Sort,333,42,0.00059960
+Tim Sort,333,43,0.00062400
+Tim Sort,333,44,0.00058080
+Tim Sort,333,45,0.00061390
+Tim Sort,333,46,0.00060400
+Tim Sort,333,47,0.00060610
+Tim Sort,333,48,0.00061570
+Tim Sort,333,49,0.00058880
+Tim Sort,333,50,0.00063790
+Tim Sort,333,51,0.00060950
+Tim Sort,333,52,0.00062360
+Tim Sort,333,53,0.00061630
+Tim Sort,333,54,0.00060940
+Tim Sort,333,55,0.00059030
+Tim Sort,333,56,0.00059340
+Tim Sort,333,57,0.00060730
+Tim Sort,333,58,0.00058530
+Tim Sort,333,59,0.00059800
+Tim Sort,333,60,0.00061670
+Tim Sort,333,61,0.00059700
+Tim Sort,333,62,0.00059720
+Tim Sort,333,63,0.00058010
+Tim Sort,333,64,0.00058380
+Tim Sort,333,65,0.00059160
+Tim Sort,333,66,0.00042460
+Tim Sort,333,67,0.00060250
+Tim Sort,333,68,0.00060100
+Tim Sort,333,69,0.00059850
+Tim Sort,333,70,0.00057750
+Tim Sort,333,71,0.00060730
+Tim Sort,333,72,0.00059620
+Tim Sort,333,73,0.00058130
+Tim Sort,333,74,0.00054040
+Tim Sort,333,75,0.00060070
+Tim Sort,333,76,0.00060800
+Tim Sort,333,77,0.00060220
+Tim Sort,333,78,0.00059830
+Tim Sort,333,79,0.00061180
+Tim Sort,333,80,0.00060890
+Tim Sort,333,81,0.00061440
+Tim Sort,333,82,0.00059530
+Tim Sort,333,83,0.00061470
+Tim Sort,333,84,0.00060720
+Tim Sort,333,85,0.00059560
+Tim Sort,333,86,0.00060110
+Tim Sort,333,87,0.00060780
+Tim Sort,333,88,0.00061920
+Tim Sort,333,89,0.00061980
+Tim Sort,333,90,0.00060530
+Tim Sort,333,91,0.00060930
+Tim Sort,333,92,0.00060520
+Tim Sort,333,93,0.00058510
+Tim Sort,333,94,0.00059650
+Tim Sort,333,95,0.00060430
+Tim Sort,333,96,0.00061360
+Tim Sort,333,97,0.00060250
+Tim Sort,333,98,0.00061000
+Tim Sort,333,99,0.00061250
+Tim Sort,333,100,0.00060530
+Tim Sort,333,101,0.00060960
+Tim Sort,333,102,0.00060480
+Tim Sort,333,103,0.00059540
+Tim Sort,333,104,0.00052720
+Tim Sort,333,105,0.00059540
+Tim Sort,333,106,0.00059290
+Tim Sort,333,107,0.00060130
+Tim Sort,333,108,0.00061150
+Tim Sort,333,109,0.00058730
+Tim Sort,333,110,0.00058730
+Tim Sort,333,111,0.00059240
+Tim Sort,333,112,0.00058460
+Tim Sort,333,113,0.00059970
+Tim Sort,333,114,0.00060800
+Tim Sort,333,115,0.00063410
+Tim Sort,333,116,0.00050180
+Tim Sort,333,117,0.00063360
+Tim Sort,333,118,0.00060810
+Tim Sort,333,119,0.00050510
+Tim Sort,333,120,0.00058620
+Tim Sort,333,121,0.00059690
+Tim Sort,333,122,0.00057240
+Tim Sort,333,123,0.00052870
+Tim Sort,333,124,0.00060350
+Tim Sort,333,125,0.00058450
+Tim Sort,333,126,0.00060630
+Tim Sort,333,127,0.00058330
+Tim Sort,333,128,0.00059860
+Tim Sort,333,129,0.00060070
+Tim Sort,333,130,0.00061290
+Tim Sort,333,131,0.00056700
+Tim Sort,333,132,0.00060220
+Tim Sort,333,133,0.00058290
+Tim Sort,333,134,0.00060790
+Tim Sort,333,135,0.00056790
+Tim Sort,333,136,0.00058710
+Tim Sort,333,137,0.00059550
+Tim Sort,333,138,0.00060220
+Tim Sort,333,139,0.00056190
+Tim Sort,333,140,0.00058690
+Tim Sort,333,141,0.00060250
+Tim Sort,333,142,0.00062050
+Tim Sort,333,143,0.00058620
+Tim Sort,333,144,0.00059170
+Tim Sort,333,145,0.00058290
+Tim Sort,333,146,0.00061530
+Tim Sort,333,147,0.00058930
+Tim Sort,333,148,0.00059190
+Tim Sort,333,149,0.00060340
+Tim Sort,333,150,0.00060250
+Tim Sort,333,151,0.00058120
+Tim Sort,333,152,0.00058550
+Tim Sort,333,153,0.00059720
+Tim Sort,333,154,0.00061290
+Tim Sort,333,155,0.00065110
+Tim Sort,333,156,0.00059810
+Tim Sort,333,157,0.00059230
+Tim Sort,333,158,0.00061200
+Tim Sort,333,159,0.00061200
+Tim Sort,333,160,0.00060150
+Tim Sort,333,161,0.00058590
+Tim Sort,333,162,0.00060520
+Tim Sort,333,163,0.00053390
+Tim Sort,333,164,0.00057870
+Tim Sort,333,165,0.00058500
+Tim Sort,333,166,0.00060600
+Tim Sort,333,167,0.00054500
+Tim Sort,333,168,0.00059950
+Tim Sort,333,169,0.00060380
+Tim Sort,333,170,0.00052050
+Tim Sort,333,171,0.00059990
+Tim Sort,333,172,0.00059350
+Tim Sort,333,173,0.00061270
+Tim Sort,333,174,0.00055680
+Tim Sort,333,175,0.00059070
+Tim Sort,333,176,0.00061290
+Tim Sort,333,177,0.00060430
+Tim Sort,333,178,0.00054950
+Tim Sort,333,179,0.00059760
+Tim Sort,333,180,0.00060430
+Tim Sort,333,181,0.00057980
+Tim Sort,333,182,0.00059260
+Tim Sort,333,183,0.00059530
+Tim Sort,333,184,0.00058510
+Tim Sort,333,185,0.00058440
+Tim Sort,333,186,0.00051990
+Tim Sort,333,187,0.00061530
+Tim Sort,333,188,0.00059400
+Tim Sort,333,189,0.00060970
+Tim Sort,333,190,0.00063380
+Tim Sort,333,191,0.00059300
+Tim Sort,333,192,0.00060400
+Tim Sort,333,193,0.00058750
+Tim Sort,333,194,0.00062000
+Tim Sort,333,195,0.00059370
+Tim Sort,333,196,0.00061120
+Tim Sort,333,197,0.00059590
+Tim Sort,333,198,0.00057870
+Tim Sort,333,199,0.00060430
+Tim Sort,333,200,0.00059330
+Tim Sort,333,201,0.00061660
+Tim Sort,333,202,0.00061220
+Tim Sort,333,203,0.00061420
+Tim Sort,333,204,0.00061440
+Tim Sort,333,205,0.00058340
+Tim Sort,333,206,0.00060830
+Tim Sort,333,207,0.00060220
+Tim Sort,333,208,0.00062210
+Tim Sort,333,209,0.00059600
+Tim Sort,333,210,0.00060760
+Tim Sort,333,211,0.00059430
+Tim Sort,333,212,0.00061710
+Tim Sort,333,213,0.00060150
+Tim Sort,333,214,0.00060640
+Tim Sort,333,215,0.00060610
+Tim Sort,333,216,0.00059580
+Tim Sort,333,217,0.00058150
+Tim Sort,333,218,0.00060020
+Tim Sort,333,219,0.00061830
+Tim Sort,333,220,0.00058040
+Tim Sort,333,221,0.00059570
+Tim Sort,333,222,0.00062040
+Tim Sort,333,223,0.00060510
+Tim Sort,333,224,0.00057740
+Tim Sort,333,225,0.00061600
+Tim Sort,333,226,0.00060010
+Tim Sort,333,227,0.00058760
+Tim Sort,333,228,0.00060480
+Tim Sort,333,229,0.00062000
+Tim Sort,333,230,0.00058560
+Tim Sort,333,231,0.00060300
+Tim Sort,333,232,0.00060950
+Tim Sort,333,233,0.00061900
+Tim Sort,333,234,0.00062800
+Tim Sort,333,235,0.00059900
+Tim Sort,333,236,0.00063890
+Tim Sort,333,237,0.00061850
+Tim Sort,333,238,0.00062470
+Tim Sort,333,239,0.00058310
+Tim Sort,333,240,0.00060740
+Tim Sort,333,241,0.00058240
+Tim Sort,333,242,0.00060650
+Tim Sort,333,243,0.00059920
+Tim Sort,333,244,0.00059740
+Tim Sort,333,245,0.00058660
+Tim Sort,333,246,0.00059510
+Tim Sort,333,247,0.00042420
+Tim Sort,333,248,0.00059750
+Tim Sort,333,249,0.00058900
+Tim Sort,333,250,0.00057740
+Tim Sort,333,251,0.00060230
+Tim Sort,333,252,0.00065580
+Tim Sort,333,253,0.00060930
+Tim Sort,333,254,0.00060900
+Tim Sort,333,255,0.00059630
+Tim Sort,333,256,0.00060730
+Tim Sort,333,257,0.00070770
+Tim Sort,333,258,0.00060560
+Tim Sort,333,259,0.00059960
+Tim Sort,333,260,0.00058700
+Tim Sort,333,261,0.00054630
+Tim Sort,333,262,0.00060070
+Tim Sort,333,263,0.00061120
+Tim Sort,333,264,0.00066130
+Tim Sort,333,265,0.00053550
+Tim Sort,333,266,0.00061150
+Tim Sort,333,267,0.00059880
+Tim Sort,333,268,0.00054260
+Tim Sort,333,269,0.00059490
+Tim Sort,333,270,0.00059520
+Tim Sort,333,271,0.00062210
+Tim Sort,333,272,0.00053480
+Tim Sort,333,273,0.00067070
+Tim Sort,333,274,0.00063180
+Tim Sort,333,275,0.00061350
+Tim Sort,333,276,0.00058610
+Tim Sort,333,277,0.00061520
+Tim Sort,333,278,0.00062310
+Tim Sort,333,279,0.00060200
+Tim Sort,333,280,0.00058500
+Tim Sort,333,281,0.00068900
+Tim Sort,333,282,0.00061700
+Tim Sort,333,283,0.00060530
+Tim Sort,333,284,0.00062890
+Tim Sort,333,285,0.00059930
+Tim Sort,333,286,0.00059820
+Tim Sort,333,287,0.00061260
+Tim Sort,333,288,0.00060170
+Tim Sort,333,289,0.00062640
+Tim Sort,333,290,0.00061350
+Tim Sort,333,291,0.00060490
+Tim Sort,333,292,0.00059410
+Tim Sort,333,293,0.00059910
+Tim Sort,333,294,0.00060110
+Tim Sort,333,295,0.00060150
+Tim Sort,333,296,0.00061210
+Tim Sort,333,297,0.00061130
+Tim Sort,333,298,0.00062360
+Tim Sort,333,299,0.00065360
+Tim Sort,333,300,0.00059370
+Tim Sort,333,301,0.00059130
+Tim Sort,333,302,0.00058660
+Tim Sort,333,303,0.00074000
+Tim Sort,333,304,0.00061180
+Tim Sort,333,305,0.00061690
+Tim Sort,333,306,0.00059580
+Tim Sort,333,307,0.00062820
+Tim Sort,333,308,0.00058360
+Tim Sort,333,309,0.00060880
+Tim Sort,333,310,0.00059650
+Tim Sort,333,311,0.00059630
+Tim Sort,333,312,0.00060940
+Tim Sort,333,313,0.00060770
+Tim Sort,333,314,0.00060730
+Tim Sort,333,315,0.00064960
+Tim Sort,333,316,0.00062870
+Tim Sort,333,317,0.00060510
+Tim Sort,333,318,0.00068390
+Tim Sort,333,319,0.00059750
+Tim Sort,333,320,0.00059890
+Tim Sort,333,321,0.00060620
+Tim Sort,333,322,0.00060010
+Tim Sort,333,323,0.00059680
+Tim Sort,333,324,0.00060180
+Tim Sort,333,325,0.00062790
+Tim Sort,333,326,0.00072440
+Tim Sort,333,327,0.00060820
+Tim Sort,333,328,0.00058710
+Tim Sort,333,329,0.00058440
+Tim Sort,333,330,0.00064420
+Tim Sort,333,331,0.00061060
+Tim Sort,333,332,0.00060270
+Tim Sort,333,333,0.00061150
+Tim Sort,333,334,0.00064840
+Tim Sort,333,335,0.00060330
+Tim Sort,333,336,0.00060820
+Tim Sort,333,337,0.00059860
+Tim Sort,333,338,0.00065370
+Tim Sort,333,339,0.00061650
+Tim Sort,333,340,0.00062680
+Tim Sort,333,341,0.00061000
+Tim Sort,333,342,0.00060420
+Tim Sort,333,343,0.00059740
+Tim Sort,333,344,0.00059700
+Tim Sort,333,345,0.00059740
+Tim Sort,333,346,0.00060080
+Tim Sort,333,347,0.00062270
+Tim Sort,333,348,0.00059460
+Tim Sort,333,349,0.00063350
+Tim Sort,333,350,0.00058050
+Tim Sort,333,351,0.00051260
+Tim Sort,333,352,0.00058520
+Tim Sort,333,353,0.00061420
+Tim Sort,333,354,0.00060060
+Tim Sort,333,355,0.00048190
+Tim Sort,333,356,0.00061680
+Tim Sort,333,357,0.00061940
+Tim Sort,333,358,0.00057190
+Tim Sort,333,359,0.00060360
+Tim Sort,333,360,0.00067600
+Tim Sort,333,361,0.00061100
+Tim Sort,333,362,0.00058880
+Tim Sort,333,363,0.00058320
+Tim Sort,333,364,0.00064490
+Tim Sort,333,365,0.00058700
+Tim Sort,333,366,0.00062430
+Tim Sort,333,367,0.00061040
+Tim Sort,333,368,0.00062940
+Tim Sort,333,369,0.00063120
+Tim Sort,333,370,0.00059500
+Tim Sort,333,371,0.00061070
+Tim Sort,333,372,0.00058980
+Tim Sort,333,373,0.00063750
+Tim Sort,333,374,0.00059820
+Tim Sort,333,375,0.00062150
+Tim Sort,333,376,0.00058350
+Tim Sort,333,377,0.00066420
+Tim Sort,333,378,0.00060240
+Tim Sort,333,379,0.00060050
+Tim Sort,333,380,0.00059900
+Tim Sort,333,381,0.00060730
+Tim Sort,333,382,0.00067150
+Tim Sort,333,383,0.00064680
+Tim Sort,333,384,0.00059400
+Tim Sort,333,385,0.00060450
+Tim Sort,333,386,0.00068170
+Tim Sort,333,387,0.00060090
+Tim Sort,333,388,0.00060790
+Tim Sort,333,389,0.00060280
+Tim Sort,333,390,0.00064830
+Tim Sort,333,391,0.00063480
+Tim Sort,333,392,0.00060330
+Tim Sort,333,393,0.00059430
+Tim Sort,333,394,0.00066760
+Tim Sort,333,395,0.00063120
+Tim Sort,333,396,0.00060020
+Tim Sort,333,397,0.00059480
+Tim Sort,333,398,0.00060080
+Tim Sort,333,399,0.00061820
+Tim Sort,333,400,0.00068660
+Tim Sort,333,401,0.00060360
+Tim Sort,333,402,0.00060110
+Tim Sort,333,403,0.00063520
+Tim Sort,333,404,0.00067180
+Tim Sort,333,405,0.00060110
+Tim Sort,333,406,0.00061870
+Tim Sort,333,407,0.00061780
+Tim Sort,333,408,0.00060020
+Tim Sort,333,409,0.00063140
+Tim Sort,333,410,0.00059590
+Tim Sort,333,411,0.00063220
+Tim Sort,333,412,0.00061030
+Tim Sort,333,413,0.00067150
+Tim Sort,333,414,0.00063900
+Tim Sort,333,415,0.00062270
+Tim Sort,333,416,0.00059280
+Tim Sort,333,417,0.00068700
+Tim Sort,333,418,0.00059290
+Tim Sort,333,419,0.00059210
+Tim Sort,333,420,0.00057300
+Tim Sort,333,421,0.00065760
+Tim Sort,333,422,0.00060620
+Tim Sort,333,423,0.00060330
+Tim Sort,333,424,0.00061960
+Tim Sort,333,425,0.00067530
+Tim Sort,333,426,0.00060400
+Tim Sort,333,427,0.00059130
+Tim Sort,333,428,0.00059000
+Tim Sort,333,429,0.00067510
+Tim Sort,333,430,0.00063660
+Tim Sort,333,431,0.00060600
+Tim Sort,333,432,0.00051250
+Tim Sort,333,433,0.00061700
+Tim Sort,333,434,0.00061710
+Tim Sort,333,435,0.00059850
+Tim Sort,333,436,0.00062280
+Tim Sort,333,437,0.00058860
+Tim Sort,333,438,0.00059090
+Tim Sort,333,439,0.00062000
+Tim Sort,333,440,0.00060210
+Tim Sort,333,441,0.00062310
+Tim Sort,333,442,0.00059890
+Tim Sort,333,443,0.00061650
+Tim Sort,333,444,0.00064120
+Tim Sort,333,445,0.00059730
+Tim Sort,333,446,0.00063050
+Tim Sort,333,447,0.00063990
+Tim Sort,333,448,0.00052900
+Tim Sort,333,449,0.00060280
+Tim Sort,333,450,0.00059900
+Tim Sort,333,451,0.00057930
+Tim Sort,333,452,0.00066250
+Tim Sort,333,453,0.00058870
+Tim Sort,333,454,0.00061010
+Tim Sort,333,455,0.00054010
+Tim Sort,333,456,0.00066120
+Tim Sort,333,457,0.00058980
+Tim Sort,333,458,0.00059810
+Tim Sort,333,459,0.00062140
+Tim Sort,333,460,0.00061310
+Tim Sort,333,461,0.00057920
+Tim Sort,333,462,0.00058340
+Tim Sort,333,463,0.00060000
+Tim Sort,333,464,0.00065750
+Tim Sort,333,465,0.00058140
+Tim Sort,333,466,0.00058330
+Tim Sort,333,467,0.00050890
+Tim Sort,333,468,0.00067300
+Tim Sort,333,469,0.00060630
+Tim Sort,333,470,0.00060410
+Tim Sort,333,471,0.00063460
+Tim Sort,333,472,0.00061820
+Tim Sort,333,473,0.00063000
+Tim Sort,333,474,0.00058340
+Tim Sort,333,475,0.00061480
+Tim Sort,333,476,0.00070960
+Tim Sort,333,477,0.00058690
+Tim Sort,333,478,0.00059280
+Tim Sort,333,479,0.00041570
+Tim Sort,333,480,0.00060430
+Tim Sort,333,481,0.00061720
+Tim Sort,333,482,0.00051600
+Tim Sort,333,483,0.00060510
+Tim Sort,333,484,0.00061070
+Tim Sort,333,485,0.00057360
+Tim Sort,333,486,0.00062960
+Tim Sort,333,487,0.00059570
+Tim Sort,333,488,0.00064290
+Tim Sort,333,489,0.00051890
+Tim Sort,333,490,0.00060570
+Tim Sort,333,491,0.00060690
+Tim Sort,333,492,0.00060590
+Tim Sort,333,493,0.00062210
+Tim Sort,333,494,0.00057140
+Tim Sort,333,495,0.00066530
+Tim Sort,333,496,0.00051310
+Tim Sort,333,497,0.00060880
+Tim Sort,333,498,0.00061470
+Tim Sort,333,499,0.00065140
+Tim Sort,333,500,0.00062680
+Tournament Sort,333,1,0.00590340
+Tournament Sort,333,2,0.00592820
+Tournament Sort,333,3,0.00542470
+Tournament Sort,333,4,0.00598850
+Tournament Sort,333,5,0.00581950
+Tournament Sort,333,6,0.00572740
+Tournament Sort,333,7,0.00357610
+Tournament Sort,333,8,0.00596400
+Tournament Sort,333,9,0.00459140
+Tournament Sort,333,10,0.00569640
+Tournament Sort,333,11,0.00579930
+Tournament Sort,333,12,0.00600040
+Tournament Sort,333,13,0.00586840
+Tournament Sort,333,14,0.00576370
+Tournament Sort,333,15,0.00575390
+Tournament Sort,333,16,0.00600040
+Tournament Sort,333,17,0.00512100
+Tournament Sort,333,18,0.00568040
+Tournament Sort,333,19,0.00588920
+Tournament Sort,333,20,0.00594700
+Tournament Sort,333,21,0.00575600
+Tournament Sort,333,22,0.00565400
+Tournament Sort,333,23,0.00591890
+Tournament Sort,333,24,0.00589010
+Tournament Sort,333,25,0.00554930
+Tournament Sort,333,26,0.00583420
+Tournament Sort,333,27,0.00590570
+Tournament Sort,333,28,0.00581090
+Tournament Sort,333,29,0.00325660
+Tournament Sort,333,30,0.00343880
+Tournament Sort,333,31,0.00576260
+Tournament Sort,333,32,0.00587230
+Tournament Sort,333,33,0.00580120
+Tournament Sort,333,34,0.00335280
+Tournament Sort,333,35,0.00583220
+Tournament Sort,333,36,0.00591350
+Tournament Sort,333,37,0.00544170
+Tournament Sort,333,38,0.00579800
+Tournament Sort,333,39,0.00578480
+Tournament Sort,333,40,0.00584870
+Tournament Sort,333,41,0.00593870
+Tournament Sort,333,42,0.00581390
+Tournament Sort,333,43,0.00582560
+Tournament Sort,333,44,0.00580060
+Tournament Sort,333,45,0.00591110
+Tournament Sort,333,46,0.00581670
+Tournament Sort,333,47,0.00582700
+Tournament Sort,333,48,0.00444300
+Tournament Sort,333,49,0.00576630
+Tournament Sort,333,50,0.00585950
+Tournament Sort,333,51,0.00352410
+Tournament Sort,333,52,0.00580950
+Tournament Sort,333,53,0.00578170
+Tournament Sort,333,54,0.00579650
+Tournament Sort,333,55,0.00344880
+Tournament Sort,333,56,0.00585810
+Tournament Sort,333,57,0.00503790
+Tournament Sort,333,58,0.00576750
+Tournament Sort,333,59,0.00584090
+Tournament Sort,333,60,0.00583710
+Tournament Sort,333,61,0.00581640
+Tournament Sort,333,62,0.00576520
+Tournament Sort,333,63,0.00585710
+Tournament Sort,333,64,0.00585930
+Tournament Sort,333,65,0.00580060
+Tournament Sort,333,66,0.00575740
+Tournament Sort,333,67,0.00586180
+Tournament Sort,333,68,0.00615010
+Tournament Sort,333,69,0.00603370
+Tournament Sort,333,70,0.00590710
+Tournament Sort,333,71,0.00582580
+Tournament Sort,333,72,0.00581700
+Tournament Sort,333,73,0.00583210
+Tournament Sort,333,74,0.00572150
+Tournament Sort,333,75,0.00586520
+Tournament Sort,333,76,0.00587780
+Tournament Sort,333,77,0.00578220
+Tournament Sort,333,78,0.00572380
+Tournament Sort,333,79,0.00587880
+Tournament Sort,333,80,0.00585170
+Tournament Sort,333,81,0.00584510
+Tournament Sort,333,82,0.00575450
+Tournament Sort,333,83,0.00581350
+Tournament Sort,333,84,0.00581600
+Tournament Sort,333,85,0.00585290
+Tournament Sort,333,86,0.00578380
+Tournament Sort,333,87,0.00597350
+Tournament Sort,333,88,0.00588330
+Tournament Sort,333,89,0.00581140
+Tournament Sort,333,90,0.00570850
+Tournament Sort,333,91,0.00578830
+Tournament Sort,333,92,0.00515660
+Tournament Sort,333,93,0.00577430
+Tournament Sort,333,94,0.00578700
+Tournament Sort,333,95,0.00579240
+Tournament Sort,333,96,0.00581390
+Tournament Sort,333,97,0.00580940
+Tournament Sort,333,98,0.00585180
+Tournament Sort,333,99,0.00576930
+Tournament Sort,333,100,0.00583550
+Tournament Sort,333,101,0.00577140
+Tournament Sort,333,102,0.00624910
+Tournament Sort,333,103,0.00579720
+Tournament Sort,333,104,0.00622960
+Tournament Sort,333,105,0.00577440
+Tournament Sort,333,106,0.00578620
+Tournament Sort,333,107,0.00617330
+Tournament Sort,333,108,0.00584350
+Tournament Sort,333,109,0.00582470
+Tournament Sort,333,110,0.00575010
+Tournament Sort,333,111,0.00579010
+Tournament Sort,333,112,0.00494590
+Tournament Sort,333,113,0.00578510
+Tournament Sort,333,114,0.00577980
+Tournament Sort,333,115,0.00579950
+Tournament Sort,333,116,0.00460780
+Tournament Sort,333,117,0.00579700
+Tournament Sort,333,118,0.00570750
+Tournament Sort,333,119,0.00578840
+Tournament Sort,333,120,0.00482280
+Tournament Sort,333,121,0.00580780
+Tournament Sort,333,122,0.00509440
+Tournament Sort,333,123,0.00580080
+Tournament Sort,333,124,0.00586780
+Tournament Sort,333,125,0.00590960
+Tournament Sort,333,126,0.00583310
+Tournament Sort,333,127,0.00579910
+Tournament Sort,333,128,0.00581700
+Tournament Sort,333,129,0.00591660
+Tournament Sort,333,130,0.00590120
+Tournament Sort,333,131,0.00604560
+Tournament Sort,333,132,0.00561650
+Tournament Sort,333,133,0.00592810
+Tournament Sort,333,134,0.00587840
+Tournament Sort,333,135,0.00579400
+Tournament Sort,333,136,0.00576020
+Tournament Sort,333,137,0.00582760
+Tournament Sort,333,138,0.00579680
+Tournament Sort,333,139,0.00583920
+Tournament Sort,333,140,0.00583930
+Tournament Sort,333,141,0.00586960
+Tournament Sort,333,142,0.00590610
+Tournament Sort,333,143,0.00581930
+Tournament Sort,333,144,0.00456360
+Tournament Sort,333,145,0.00577570
+Tournament Sort,333,146,0.00583540
+Tournament Sort,333,147,0.00524160
+Tournament Sort,333,148,0.00582390
+Tournament Sort,333,149,0.00495930
+Tournament Sort,333,150,0.00584650
+Tournament Sort,333,151,0.00537780
+Tournament Sort,333,152,0.00568010
+Tournament Sort,333,153,0.00543670
+Tournament Sort,333,154,0.00580700
+Tournament Sort,333,155,0.00581760
+Tournament Sort,333,156,0.00600950
+Tournament Sort,333,157,0.00577950
+Tournament Sort,333,158,0.00582150
+Tournament Sort,333,159,0.00583830
+Tournament Sort,333,160,0.00553500
+Tournament Sort,333,161,0.00447800
+Tournament Sort,333,162,0.00585330
+Tournament Sort,333,163,0.00577690
+Tournament Sort,333,164,0.00576210
+Tournament Sort,333,165,0.00442620
+Tournament Sort,333,166,0.00585620
+Tournament Sort,333,167,0.00584890
+Tournament Sort,333,168,0.00581270
+Tournament Sort,333,169,0.00573680
+Tournament Sort,333,170,0.00587030
+Tournament Sort,333,171,0.00584000
+Tournament Sort,333,172,0.00513180
+Tournament Sort,333,173,0.00577300
+Tournament Sort,333,174,0.00587000
+Tournament Sort,333,175,0.00581620
+Tournament Sort,333,176,0.00505140
+Tournament Sort,333,177,0.00564220
+Tournament Sort,333,178,0.00473150
+Tournament Sort,333,179,0.00606520
+Tournament Sort,333,180,0.00582990
+Tournament Sort,333,181,0.00415290
+Tournament Sort,333,182,0.00574240
+Tournament Sort,333,183,0.00579930
+Tournament Sort,333,184,0.00373730
+Tournament Sort,333,185,0.00586670
+Tournament Sort,333,186,0.00581580
+Tournament Sort,333,187,0.00575190
+Tournament Sort,333,188,0.00426580
+Tournament Sort,333,189,0.00580370
+Tournament Sort,333,190,0.00579810
+Tournament Sort,333,191,0.00580350
+Tournament Sort,333,192,0.00527700
+Tournament Sort,333,193,0.00576450
+Tournament Sort,333,194,0.00583340
+Tournament Sort,333,195,0.00580670
+Tournament Sort,333,196,0.00582290
+Tournament Sort,333,197,0.00397170
+Tournament Sort,333,198,0.00582060
+Tournament Sort,333,199,0.00586440
+Tournament Sort,333,200,0.00575500
+Tournament Sort,333,201,0.00669000
+Tournament Sort,333,202,0.00576280
+Tournament Sort,333,203,0.00579280
+Tournament Sort,333,204,0.00576980
+Tournament Sort,333,205,0.00584840
+Tournament Sort,333,206,0.00588470
+Tournament Sort,333,207,0.00625620
+Tournament Sort,333,208,0.00577140
+Tournament Sort,333,209,0.00580330
+Tournament Sort,333,210,0.00587310
+Tournament Sort,333,211,0.00583380
+Tournament Sort,333,212,0.00608570
+Tournament Sort,333,213,0.00580710
+Tournament Sort,333,214,0.00577940
+Tournament Sort,333,215,0.00549980
+Tournament Sort,333,216,0.00582540
+Tournament Sort,333,217,0.00575890
+Tournament Sort,333,218,0.00583120
+Tournament Sort,333,219,0.00574100
+Tournament Sort,333,220,0.00477340
+Tournament Sort,333,221,0.00583710
+Tournament Sort,333,222,0.00663610
+Tournament Sort,333,223,0.00576540
+Tournament Sort,333,224,0.00580420
+Tournament Sort,333,225,0.00581470
+Tournament Sort,333,226,0.00578120
+Tournament Sort,333,227,0.00589500
+Tournament Sort,333,228,0.00510770
+Tournament Sort,333,229,0.00578830
+Tournament Sort,333,230,0.00584310
+Tournament Sort,333,231,0.00581420
+Tournament Sort,333,232,0.00567560
+Tournament Sort,333,233,0.00597690
+Tournament Sort,333,234,0.00582080
+Tournament Sort,333,235,0.00581370
+Tournament Sort,333,236,0.00583930
+Tournament Sort,333,237,0.00644920
+Tournament Sort,333,238,0.00604150
+Tournament Sort,333,239,0.00583350
+Tournament Sort,333,240,0.00573910
+Tournament Sort,333,241,0.00584350
+Tournament Sort,333,242,0.00575390
+Tournament Sort,333,243,0.00623130
+Tournament Sort,333,244,0.00575920
+Tournament Sort,333,245,0.00582420
+Tournament Sort,333,246,0.00561870
+Tournament Sort,333,247,0.00567630
+Tournament Sort,333,248,0.00604200
+Tournament Sort,333,249,0.00511970
+Tournament Sort,333,250,0.00580550
+Tournament Sort,333,251,0.00582810
+Tournament Sort,333,252,0.00576770
+Tournament Sort,333,253,0.00589320
+Tournament Sort,333,254,0.00497280
+Tournament Sort,333,255,0.00576500
+Tournament Sort,333,256,0.00557950
+Tournament Sort,333,257,0.00579550
+Tournament Sort,333,258,0.00519160
+Tournament Sort,333,259,0.00591930
+Tournament Sort,333,260,0.00585920
+Tournament Sort,333,261,0.00352640
+Tournament Sort,333,262,0.00577970
+Tournament Sort,333,263,0.00579830
+Tournament Sort,333,264,0.00593360
+Tournament Sort,333,265,0.00379960
+Tournament Sort,333,266,0.00587190
+Tournament Sort,333,267,0.00408050
+Tournament Sort,333,268,0.00566530
+Tournament Sort,333,269,0.00575640
+Tournament Sort,333,270,0.00596020
+Tournament Sort,333,271,0.00516480
+Tournament Sort,333,272,0.00360320
+Tournament Sort,333,273,0.00580720
+Tournament Sort,333,274,0.00578960
+Tournament Sort,333,275,0.00590900
+Tournament Sort,333,276,0.00336180
+Tournament Sort,333,277,0.00577730
+Tournament Sort,333,278,0.00537300
+Tournament Sort,333,279,0.00526150
+Tournament Sort,333,280,0.00448690
+Tournament Sort,333,281,0.00462830
+Tournament Sort,333,282,0.00585160
+Tournament Sort,333,283,0.00583590
+Tournament Sort,333,284,0.00578590
+Tournament Sort,333,285,0.00578620
+Tournament Sort,333,286,0.00341110
+Tournament Sort,333,287,0.00585920
+Tournament Sort,333,288,0.00524030
+Tournament Sort,333,289,0.00543670
+Tournament Sort,333,290,0.00574260
+Tournament Sort,333,291,0.00346170
+Tournament Sort,333,292,0.00579450
+Tournament Sort,333,293,0.00576670
+Tournament Sort,333,294,0.00381600
+Tournament Sort,333,295,0.00563930
+Tournament Sort,333,296,0.00569500
+Tournament Sort,333,297,0.00434900
+Tournament Sort,333,298,0.00584360
+Tournament Sort,333,299,0.00575420
+Tournament Sort,333,300,0.00582470
+Tournament Sort,333,301,0.00578160
+Tournament Sort,333,302,0.00568220
+Tournament Sort,333,303,0.00592890
+Tournament Sort,333,304,0.00577450
+Tournament Sort,333,305,0.00582140
+Tournament Sort,333,306,0.00475430
+Tournament Sort,333,307,0.00575840
+Tournament Sort,333,308,0.00598180
+Tournament Sort,333,309,0.00577760
+Tournament Sort,333,310,0.00342450
+Tournament Sort,333,311,0.00577340
+Tournament Sort,333,312,0.00578270
+Tournament Sort,333,313,0.00348590
+Tournament Sort,333,314,0.00596960
+Tournament Sort,333,315,0.00580400
+Tournament Sort,333,316,0.00507490
+Tournament Sort,333,317,0.00455100
+Tournament Sort,333,318,0.00469310
+Tournament Sort,333,319,0.00601000
+Tournament Sort,333,320,0.00461150
+Tournament Sort,333,321,0.00491930
+Tournament Sort,333,322,0.00574850
+Tournament Sort,333,323,0.00410720
+Tournament Sort,333,324,0.00357360
+Tournament Sort,333,325,0.00601070
+Tournament Sort,333,326,0.00585270
+Tournament Sort,333,327,0.00492650
+Tournament Sort,333,328,0.00571300
+Tournament Sort,333,329,0.00357920
+Tournament Sort,333,330,0.00579580
+Tournament Sort,333,331,0.00597610
+Tournament Sort,333,332,0.00574880
+Tournament Sort,333,333,0.00333570
+Tournament Sort,333,334,0.00484530
+Tournament Sort,333,335,0.00516450
+Tournament Sort,333,336,0.00593220
+Tournament Sort,333,337,0.00578440
+Tournament Sort,333,338,0.00599270
+Tournament Sort,333,339,0.00526860
+Tournament Sort,333,340,0.00572100
+Tournament Sort,333,341,0.00589550
+Tournament Sort,333,342,0.00588330
+Tournament Sort,333,343,0.00509050
+Tournament Sort,333,344,0.00602850
+Tournament Sort,333,345,0.00486800
+Tournament Sort,333,346,0.00529440
+Tournament Sort,333,347,0.00580690
+Tournament Sort,333,348,0.00585000
+Tournament Sort,333,349,0.00576950
+Tournament Sort,333,350,0.00575490
+Tournament Sort,333,351,0.00557630
+Tournament Sort,333,352,0.00577880
+Tournament Sort,333,353,0.00581950
+Tournament Sort,333,354,0.00589780
+Tournament Sort,333,355,0.00578040
+Tournament Sort,333,356,0.00577020
+Tournament Sort,333,357,0.00575930
+Tournament Sort,333,358,0.00583770
+Tournament Sort,333,359,0.00593050
+Tournament Sort,333,360,0.00577530
+Tournament Sort,333,361,0.00579160
+Tournament Sort,333,362,0.00577140
+Tournament Sort,333,363,0.00581120
+Tournament Sort,333,364,0.00587250
+Tournament Sort,333,365,0.00578060
+Tournament Sort,333,366,0.00576380
+Tournament Sort,333,367,0.00575370
+Tournament Sort,333,368,0.00579530
+Tournament Sort,333,369,0.00584420
+Tournament Sort,333,370,0.00579300
+Tournament Sort,333,371,0.00551140
+Tournament Sort,333,372,0.00576490
+Tournament Sort,333,373,0.00582100
+Tournament Sort,333,374,0.00588910
+Tournament Sort,333,375,0.00583150
+Tournament Sort,333,376,0.00587820
+Tournament Sort,333,377,0.00580260
+Tournament Sort,333,378,0.00602500
+Tournament Sort,333,379,0.00581950
+Tournament Sort,333,380,0.00576670
+Tournament Sort,333,381,0.00523200
+Tournament Sort,333,382,0.00575140
+Tournament Sort,333,383,0.00599130
+Tournament Sort,333,384,0.00589200
+Tournament Sort,333,385,0.00577270
+Tournament Sort,333,386,0.00612840
+Tournament Sort,333,387,0.00601400
+Tournament Sort,333,388,0.00577740
+Tournament Sort,333,389,0.00584520
+Tournament Sort,333,390,0.00581800
+Tournament Sort,333,391,0.00577040
+Tournament Sort,333,392,0.00589820
+Tournament Sort,333,393,0.00585030
+Tournament Sort,333,394,0.00585650
+Tournament Sort,333,395,0.00462440
+Tournament Sort,333,396,0.00579650
+Tournament Sort,333,397,0.00491790
+Tournament Sort,333,398,0.00596460
+Tournament Sort,333,399,0.00590160
+Tournament Sort,333,400,0.00558310
+Tournament Sort,333,401,0.00554980
+Tournament Sort,333,402,0.00575160
+Tournament Sort,333,403,0.00579000
+Tournament Sort,333,404,0.00583070
+Tournament Sort,333,405,0.00461460
+Tournament Sort,333,406,0.00578390
+Tournament Sort,333,407,0.00569150
+Tournament Sort,333,408,0.00358010
+Tournament Sort,333,409,0.00584540
+Tournament Sort,333,410,0.00582880
+Tournament Sort,333,411,0.00361290
+Tournament Sort,333,412,0.00579750
+Tournament Sort,333,413,0.00593330
+Tournament Sort,333,414,0.00455900
+Tournament Sort,333,415,0.00580470
+Tournament Sort,333,416,0.00574860
+Tournament Sort,333,417,0.00576150
+Tournament Sort,333,418,0.00575670
+Tournament Sort,333,419,0.00339050
+Tournament Sort,333,420,0.00582280
+Tournament Sort,333,421,0.00575890
+Tournament Sort,333,422,0.00343210
+Tournament Sort,333,423,0.00578840
+Tournament Sort,333,424,0.00570450
+Tournament Sort,333,425,0.00349420
+Tournament Sort,333,426,0.00585510
+Tournament Sort,333,427,0.00581650
+Tournament Sort,333,428,0.00580310
+Tournament Sort,333,429,0.00343990
+Tournament Sort,333,430,0.00579470
+Tournament Sort,333,431,0.00583260
+Tournament Sort,333,432,0.00575790
+Tournament Sort,333,433,0.00500910
+Tournament Sort,333,434,0.00578120
+Tournament Sort,333,435,0.00575270
+Tournament Sort,333,436,0.00580380
+Tournament Sort,333,437,0.00579520
+Tournament Sort,333,438,0.00580820
+Tournament Sort,333,439,0.00580860
+Tournament Sort,333,440,0.00591400
+Tournament Sort,333,441,0.00581860
+Tournament Sort,333,442,0.00529710
+Tournament Sort,333,443,0.00587530
+Tournament Sort,333,444,0.00579770
+Tournament Sort,333,445,0.00576830
+Tournament Sort,333,446,0.00581620
+Tournament Sort,333,447,0.00581420
+Tournament Sort,333,448,0.00593530
+Tournament Sort,333,449,0.00579270
+Tournament Sort,333,450,0.00575040
+Tournament Sort,333,451,0.00552140
+Tournament Sort,333,452,0.00602780
+Tournament Sort,333,453,0.00592770
+Tournament Sort,333,454,0.00572080
+Tournament Sort,333,455,0.00521560
+Tournament Sort,333,456,0.00580490
+Tournament Sort,333,457,0.00524040
+Tournament Sort,333,458,0.00579120
+Tournament Sort,333,459,0.00536300
+Tournament Sort,333,460,0.00497240
+Tournament Sort,333,461,0.00573210
+Tournament Sort,333,462,0.00579590
+Tournament Sort,333,463,0.00581840
+Tournament Sort,333,464,0.00579080
+Tournament Sort,333,465,0.00576890
+Tournament Sort,333,466,0.00331450
+Tournament Sort,333,467,0.00584220
+Tournament Sort,333,468,0.00598340
+Tournament Sort,333,469,0.00401450
+Tournament Sort,333,470,0.00598290
+Tournament Sort,333,471,0.00589260
+Tournament Sort,333,472,0.00597460
+Tournament Sort,333,473,0.00546900
+Tournament Sort,333,474,0.00436730
+Tournament Sort,333,475,0.00584940
+Tournament Sort,333,476,0.00510040
+Tournament Sort,333,477,0.00597560
+Tournament Sort,333,478,0.00595630
+Tournament Sort,333,479,0.00565790
+Tournament Sort,333,480,0.00494570
+Tournament Sort,333,481,0.00576110
+Tournament Sort,333,482,0.00376350
+Tournament Sort,333,483,0.00582850
+Tournament Sort,333,484,0.00583050
+Tournament Sort,333,485,0.00335100
+Tournament Sort,333,486,0.00569530
+Tournament Sort,333,487,0.00491060
+Tournament Sort,333,488,0.00416860
+Tournament Sort,333,489,0.00580370
+Tournament Sort,333,490,0.00586270
+Tournament Sort,333,491,0.00516810
+Tournament Sort,333,492,0.00506640
+Tournament Sort,333,493,0.00586030
+Tournament Sort,333,494,0.00547300
+Tournament Sort,333,495,0.00584390
+Tournament Sort,333,496,0.00574290
+Tournament Sort,333,497,0.00579270
+Tournament Sort,333,498,0.00335420
+Tournament Sort,333,499,0.00618840
+Tournament Sort,333,500,0.00570820
+Tree Sort,333,1,0.00038590
+Tree Sort,333,2,0.00061500
+Tree Sort,333,3,0.00029440
+Tree Sort,333,4,0.00039470
+Tree Sort,333,5,0.00061640
+Tree Sort,333,6,0.00047620
+Tree Sort,333,7,0.00057280
+Tree Sort,333,8,0.00039010
+Tree Sort,333,9,0.00046440
+Tree Sort,333,10,0.00045200
+Tree Sort,333,11,0.00038330
+Tree Sort,333,12,0.00045140
+Tree Sort,333,13,0.00083630
+Tree Sort,333,14,0.00054720
+Tree Sort,333,15,0.00077090
+Tree Sort,333,16,0.00048070
+Tree Sort,333,17,0.00047170
+Tree Sort,333,18,0.00048980
+Tree Sort,333,19,0.00051800
+Tree Sort,333,20,0.00059200
+Tree Sort,333,21,0.00066850
+Tree Sort,333,22,0.00050420
+Tree Sort,333,23,0.00049940
+Tree Sort,333,24,0.00044580
+Tree Sort,333,25,0.00049000
+Tree Sort,333,26,0.00049250
+Tree Sort,333,27,0.00052050
+Tree Sort,333,28,0.00051930
+Tree Sort,333,29,0.00051270
+Tree Sort,333,30,0.00044770
+Tree Sort,333,31,0.00049260
+Tree Sort,333,32,0.00045290
+Tree Sort,333,33,0.00048520
+Tree Sort,333,34,0.00046850
+Tree Sort,333,35,0.00049840
+Tree Sort,333,36,0.00047150
+Tree Sort,333,37,0.00053570
+Tree Sort,333,38,0.00045030
+Tree Sort,333,39,0.00050270
+Tree Sort,333,40,0.00047440
+Tree Sort,333,41,0.00047780
+Tree Sort,333,42,0.00044870
+Tree Sort,333,43,0.00049210
+Tree Sort,333,44,0.00048060
+Tree Sort,333,45,0.00050440
+Tree Sort,333,46,0.00050700
+Tree Sort,333,47,0.00047380
+Tree Sort,333,48,0.00050740
+Tree Sort,333,49,0.00048880
+Tree Sort,333,50,0.00049090
+Tree Sort,333,51,0.00050860
+Tree Sort,333,52,0.00049710
+Tree Sort,333,53,0.00047790
+Tree Sort,333,54,0.00050670
+Tree Sort,333,55,0.00049020
+Tree Sort,333,56,0.00046000
+Tree Sort,333,57,0.00048840
+Tree Sort,333,58,0.00044900
+Tree Sort,333,59,0.00052350
+Tree Sort,333,60,0.00053430
+Tree Sort,333,61,0.00052530
+Tree Sort,333,62,0.00048910
+Tree Sort,333,63,0.00049350
+Tree Sort,333,64,0.00047630
+Tree Sort,333,65,0.00050210
+Tree Sort,333,66,0.00049640
+Tree Sort,333,67,0.00046730
+Tree Sort,333,68,0.00049580
+Tree Sort,333,69,0.00050810
+Tree Sort,333,70,0.00050860
+Tree Sort,333,71,0.00051810
+Tree Sort,333,72,0.00049300
+Tree Sort,333,73,0.00045850
+Tree Sort,333,74,0.00049150
+Tree Sort,333,75,0.00047330
+Tree Sort,333,76,0.00050940
+Tree Sort,333,77,0.00050450
+Tree Sort,333,78,0.00049420
+Tree Sort,333,79,0.00049130
+Tree Sort,333,80,0.00049730
+Tree Sort,333,81,0.00046870
+Tree Sort,333,82,0.00048900
+Tree Sort,333,83,0.00052250
+Tree Sort,333,84,0.00057080
+Tree Sort,333,85,0.00050690
+Tree Sort,333,86,0.00051260
+Tree Sort,333,87,0.00049670
+Tree Sort,333,88,0.00048420
+Tree Sort,333,89,0.00048230
+Tree Sort,333,90,0.00050140
+Tree Sort,333,91,0.00047150
+Tree Sort,333,92,0.00050230
+Tree Sort,333,93,0.00045930
+Tree Sort,333,94,0.00048460
+Tree Sort,333,95,0.00048110
+Tree Sort,333,96,0.00050580
+Tree Sort,333,97,0.00048610
+Tree Sort,333,98,0.00048400
+Tree Sort,333,99,0.00049310
+Tree Sort,333,100,0.00055320
+Tree Sort,333,101,0.00049790
+Tree Sort,333,102,0.00048490
+Tree Sort,333,103,0.00050920
+Tree Sort,333,104,0.00049860
+Tree Sort,333,105,0.00047500
+Tree Sort,333,106,0.00052650
+Tree Sort,333,107,0.00048960
+Tree Sort,333,108,0.00052560
+Tree Sort,333,109,0.00050350
+Tree Sort,333,110,0.00049040
+Tree Sort,333,111,0.00046800
+Tree Sort,333,112,0.00047930
+Tree Sort,333,113,0.00054230
+Tree Sort,333,114,0.00049820
+Tree Sort,333,115,0.00047370
+Tree Sort,333,116,0.00049760
+Tree Sort,333,117,0.00050190
+Tree Sort,333,118,0.00047130
+Tree Sort,333,119,0.00052970
+Tree Sort,333,120,0.00053060
+Tree Sort,333,121,0.00051530
+Tree Sort,333,122,0.00055140
+Tree Sort,333,123,0.00054740
+Tree Sort,333,124,0.00045810
+Tree Sort,333,125,0.00048720
+Tree Sort,333,126,0.00048520
+Tree Sort,333,127,0.00055700
+Tree Sort,333,128,0.00053810
+Tree Sort,333,129,0.00050540
+Tree Sort,333,130,0.00048520
+Tree Sort,333,131,0.00053360
+Tree Sort,333,132,0.00050850
+Tree Sort,333,133,0.00048270
+Tree Sort,333,134,0.00049200
+Tree Sort,333,135,0.00049050
+Tree Sort,333,136,0.00048380
+Tree Sort,333,137,0.00056750
+Tree Sort,333,138,0.00052420
+Tree Sort,333,139,0.00048000
+Tree Sort,333,140,0.00052020
+Tree Sort,333,141,0.00045400
+Tree Sort,333,142,0.00047650
+Tree Sort,333,143,0.00049190
+Tree Sort,333,144,0.00048940
+Tree Sort,333,145,0.00068470
+Tree Sort,333,146,0.00050940
+Tree Sort,333,147,0.00049910
+Tree Sort,333,148,0.00048490
+Tree Sort,333,149,0.00049760
+Tree Sort,333,150,0.00048120
+Tree Sort,333,151,0.00045790
+Tree Sort,333,152,0.00055320
+Tree Sort,333,153,0.00048700
+Tree Sort,333,154,0.00071400
+Tree Sort,333,155,0.00050250
+Tree Sort,333,156,0.00051720
+Tree Sort,333,157,0.00045270
+Tree Sort,333,158,0.00052980
+Tree Sort,333,159,0.00050560
+Tree Sort,333,160,0.00056470
+Tree Sort,333,161,0.00046460
+Tree Sort,333,162,0.00047760
+Tree Sort,333,163,0.00044720
+Tree Sort,333,164,0.00054210
+Tree Sort,333,165,0.00049020
+Tree Sort,333,166,0.00046310
+Tree Sort,333,167,0.00048010
+Tree Sort,333,168,0.00051480
+Tree Sort,333,169,0.00052010
+Tree Sort,333,170,0.00047740
+Tree Sort,333,171,0.00044320
+Tree Sort,333,172,0.00048100
+Tree Sort,333,173,0.00051040
+Tree Sort,333,174,0.00048140
+Tree Sort,333,175,0.00051360
+Tree Sort,333,176,0.00046060
+Tree Sort,333,177,0.00046300
+Tree Sort,333,178,0.00051610
+Tree Sort,333,179,0.00050050
+Tree Sort,333,180,0.00049710
+Tree Sort,333,181,0.00053960
+Tree Sort,333,182,0.00045390
+Tree Sort,333,183,0.00046400
+Tree Sort,333,184,0.00046600
+Tree Sort,333,185,0.00052040
+Tree Sort,333,186,0.00052520
+Tree Sort,333,187,0.00053870
+Tree Sort,333,188,0.00051850
+Tree Sort,333,189,0.00049660
+Tree Sort,333,190,0.00047200
+Tree Sort,333,191,0.00053610
+Tree Sort,333,192,0.00051540
+Tree Sort,333,193,0.00054450
+Tree Sort,333,194,0.00054820
+Tree Sort,333,195,0.00051290
+Tree Sort,333,196,0.00047680
+Tree Sort,333,197,0.00048120
+Tree Sort,333,198,0.00056830
+Tree Sort,333,199,0.00048400
+Tree Sort,333,200,0.00050030
+Tree Sort,333,201,0.00052270
+Tree Sort,333,202,0.00047880
+Tree Sort,333,203,0.00049460
+Tree Sort,333,204,0.00046170
+Tree Sort,333,205,0.00050160
+Tree Sort,333,206,0.00052210
+Tree Sort,333,207,0.00047140
+Tree Sort,333,208,0.00049570
+Tree Sort,333,209,0.00048120
+Tree Sort,333,210,0.00048370
+Tree Sort,333,211,0.00050220
+Tree Sort,333,212,0.00050670
+Tree Sort,333,213,0.00054890
+Tree Sort,333,214,0.00046980
+Tree Sort,333,215,0.00046800
+Tree Sort,333,216,0.00048510
+Tree Sort,333,217,0.00048190
+Tree Sort,333,218,0.00048620
+Tree Sort,333,219,0.00051150
+Tree Sort,333,220,0.00048810
+Tree Sort,333,221,0.00047630
+Tree Sort,333,222,0.00049300
+Tree Sort,333,223,0.00051730
+Tree Sort,333,224,0.00049900
+Tree Sort,333,225,0.00050250
+Tree Sort,333,226,0.00046810
+Tree Sort,333,227,0.00048190
+Tree Sort,333,228,0.00049950
+Tree Sort,333,229,0.00049950
+Tree Sort,333,230,0.00048680
+Tree Sort,333,231,0.00051130
+Tree Sort,333,232,0.00048700
+Tree Sort,333,233,0.00052850
+Tree Sort,333,234,0.00050350
+Tree Sort,333,235,0.00050300
+Tree Sort,333,236,0.00049050
+Tree Sort,333,237,0.00056030
+Tree Sort,333,238,0.00052330
+Tree Sort,333,239,0.00071270
+Tree Sort,333,240,0.00062270
+Tree Sort,333,241,0.00058930
+Tree Sort,333,242,0.00049030
+Tree Sort,333,243,0.00048540
+Tree Sort,333,244,0.00060500
+Tree Sort,333,245,0.00048440
+Tree Sort,333,246,0.00050630
+Tree Sort,333,247,0.00055290
+Tree Sort,333,248,0.00049150
+Tree Sort,333,249,0.00054480
+Tree Sort,333,250,0.00055240
+Tree Sort,333,251,0.00047220
+Tree Sort,333,252,0.00047460
+Tree Sort,333,253,0.00049060
+Tree Sort,333,254,0.00052310
+Tree Sort,333,255,0.00053310
+Tree Sort,333,256,0.00059150
+Tree Sort,333,257,0.00056140
+Tree Sort,333,258,0.00051820
+Tree Sort,333,259,0.00054310
+Tree Sort,333,260,0.00053000
+Tree Sort,333,261,0.00054690
+Tree Sort,333,262,0.00052650
+Tree Sort,333,263,0.00047740
+Tree Sort,333,264,0.00061820
+Tree Sort,333,265,0.00049420
+Tree Sort,333,266,0.00048580
+Tree Sort,333,267,0.00049870
+Tree Sort,333,268,0.00046890
+Tree Sort,333,269,0.00051790
+Tree Sort,333,270,0.00046270
+Tree Sort,333,271,0.00048310
+Tree Sort,333,272,0.00050710
+Tree Sort,333,273,0.00052350
+Tree Sort,333,274,0.00049540
+Tree Sort,333,275,0.00050690
+Tree Sort,333,276,0.00048210
+Tree Sort,333,277,0.00043610
+Tree Sort,333,278,0.00049120
+Tree Sort,333,279,0.00050520
+Tree Sort,333,280,0.00047590
+Tree Sort,333,281,0.00048250
+Tree Sort,333,282,0.00050240
+Tree Sort,333,283,0.00047970
+Tree Sort,333,284,0.00049630
+Tree Sort,333,285,0.00052110
+Tree Sort,333,286,0.00046760
+Tree Sort,333,287,0.00049160
+Tree Sort,333,288,0.00049060
+Tree Sort,333,289,0.00047300
+Tree Sort,333,290,0.00047070
+Tree Sort,333,291,0.00053750
+Tree Sort,333,292,0.00047290
+Tree Sort,333,293,0.00047870
+Tree Sort,333,294,0.00050620
+Tree Sort,333,295,0.00055800
+Tree Sort,333,296,0.00047760
+Tree Sort,333,297,0.00055420
+Tree Sort,333,298,0.00046810
+Tree Sort,333,299,0.00047790
+Tree Sort,333,300,0.00049170
+Tree Sort,333,301,0.00047170
+Tree Sort,333,302,0.00048700
+Tree Sort,333,303,0.00047200
+Tree Sort,333,304,0.00051610
+Tree Sort,333,305,0.00048690
+Tree Sort,333,306,0.00046630
+Tree Sort,333,307,0.00048850
+Tree Sort,333,308,0.00053870
+Tree Sort,333,309,0.00046060
+Tree Sort,333,310,0.00051630
+Tree Sort,333,311,0.00050670
+Tree Sort,333,312,0.00047780
+Tree Sort,333,313,0.00048240
+Tree Sort,333,314,0.00050880
+Tree Sort,333,315,0.00048050
+Tree Sort,333,316,0.00051830
+Tree Sort,333,317,0.00048070
+Tree Sort,333,318,0.00046420
+Tree Sort,333,319,0.00048560
+Tree Sort,333,320,0.00048070
+Tree Sort,333,321,0.00047300
+Tree Sort,333,322,0.00054330
+Tree Sort,333,323,0.00048720
+Tree Sort,333,324,0.00055440
+Tree Sort,333,325,0.00052370
+Tree Sort,333,326,0.00050000
+Tree Sort,333,327,0.00035200
+Tree Sort,333,328,0.00048600
+Tree Sort,333,329,0.00045510
+Tree Sort,333,330,0.00045250
+Tree Sort,333,331,0.00052770
+Tree Sort,333,332,0.00033900
+Tree Sort,333,333,0.00046950
+Tree Sort,333,334,0.00049400
+Tree Sort,333,335,0.00030790
+Tree Sort,333,336,0.00040760
+Tree Sort,333,337,0.00047360
+Tree Sort,333,338,0.00051260
+Tree Sort,333,339,0.00045690
+Tree Sort,333,340,0.00047360
+Tree Sort,333,341,0.00049520
+Tree Sort,333,342,0.00032950
+Tree Sort,333,343,0.00053130
+Tree Sort,333,344,0.00047300
+Tree Sort,333,345,0.00053530
+Tree Sort,333,346,0.00048130
+Tree Sort,333,347,0.00049010
+Tree Sort,333,348,0.00052430
+Tree Sort,333,349,0.00051560
+Tree Sort,333,350,0.00034130
+Tree Sort,333,351,0.00043710
+Tree Sort,333,352,0.00045870
+Tree Sort,333,353,0.00050360
+Tree Sort,333,354,0.00048080
+Tree Sort,333,355,0.00047080
+Tree Sort,333,356,0.00048160
+Tree Sort,333,357,0.00045490
+Tree Sort,333,358,0.00040590
+Tree Sort,333,359,0.00055120
+Tree Sort,333,360,0.00030940
+Tree Sort,333,361,0.00049670
+Tree Sort,333,362,0.00048090
+Tree Sort,333,363,0.00048640
+Tree Sort,333,364,0.00049390
+Tree Sort,333,365,0.00047510
+Tree Sort,333,366,0.00038800
+Tree Sort,333,367,0.00035210
+Tree Sort,333,368,0.00045190
+Tree Sort,333,369,0.00049640
+Tree Sort,333,370,0.00043600
+Tree Sort,333,371,0.00038760
+Tree Sort,333,372,0.00055630
+Tree Sort,333,373,0.00045540
+Tree Sort,333,374,0.00037960
+Tree Sort,333,375,0.00049220
+Tree Sort,333,376,0.00050260
+Tree Sort,333,377,0.00051280
+Tree Sort,333,378,0.00060350
+Tree Sort,333,379,0.00039040
+Tree Sort,333,380,0.00051160
+Tree Sort,333,381,0.00053380
+Tree Sort,333,382,0.00038230
+Tree Sort,333,383,0.00040700
+Tree Sort,333,384,0.00042240
+Tree Sort,333,385,0.00049980
+Tree Sort,333,386,0.00044810
+Tree Sort,333,387,0.00047290
+Tree Sort,333,388,0.00045470
+Tree Sort,333,389,0.00052760
+Tree Sort,333,390,0.00047770
+Tree Sort,333,391,0.00049350
+Tree Sort,333,392,0.00048490
+Tree Sort,333,393,0.00047220
+Tree Sort,333,394,0.00050100
+Tree Sort,333,395,0.00050550
+Tree Sort,333,396,0.00048560
+Tree Sort,333,397,0.00052680
+Tree Sort,333,398,0.00052840
+Tree Sort,333,399,0.00046810
+Tree Sort,333,400,0.00049930
+Tree Sort,333,401,0.00047870
+Tree Sort,333,402,0.00048640
+Tree Sort,333,403,0.00047890
+Tree Sort,333,404,0.00050820
+Tree Sort,333,405,0.00046300
+Tree Sort,333,406,0.00031060
+Tree Sort,333,407,0.00037240
+Tree Sort,333,408,0.00049320
+Tree Sort,333,409,0.00054310
+Tree Sort,333,410,0.00046140
+Tree Sort,333,411,0.00044290
+Tree Sort,333,412,0.00033910
+Tree Sort,333,413,0.00049070
+Tree Sort,333,414,0.00047780
+Tree Sort,333,415,0.00051650
+Tree Sort,333,416,0.00028990
+Tree Sort,333,417,0.00044790
+Tree Sort,333,418,0.00046120
+Tree Sort,333,419,0.00048060
+Tree Sort,333,420,0.00050150
+Tree Sort,333,421,0.00050160
+Tree Sort,333,422,0.00030670
+Tree Sort,333,423,0.00048060
+Tree Sort,333,424,0.00048770
+Tree Sort,333,425,0.00043730
+Tree Sort,333,426,0.00047680
+Tree Sort,333,427,0.00051770
+Tree Sort,333,428,0.00043470
+Tree Sort,333,429,0.00048200
+Tree Sort,333,430,0.00030350
+Tree Sort,333,431,0.00049860
+Tree Sort,333,432,0.00048200
+Tree Sort,333,433,0.00050060
+Tree Sort,333,434,0.00047280
+Tree Sort,333,435,0.00046440
+Tree Sort,333,436,0.00031660
+Tree Sort,333,437,0.00045970
+Tree Sort,333,438,0.00045660
+Tree Sort,333,439,0.00050140
+Tree Sort,333,440,0.00045430
+Tree Sort,333,441,0.00048630
+Tree Sort,333,442,0.00046220
+Tree Sort,333,443,0.00047970
+Tree Sort,333,444,0.00038990
+Tree Sort,333,445,0.00050130
+Tree Sort,333,446,0.00046040
+Tree Sort,333,447,0.00029300
+Tree Sort,333,448,0.00037180
+Tree Sort,333,449,0.00049320
+Tree Sort,333,450,0.00029980
+Tree Sort,333,451,0.00049130
+Tree Sort,333,452,0.00044840
+Tree Sort,333,453,0.00045070
+Tree Sort,333,454,0.00046080
+Tree Sort,333,455,0.00030820
+Tree Sort,333,456,0.00047730
+Tree Sort,333,457,0.00048910
+Tree Sort,333,458,0.00049130
+Tree Sort,333,459,0.00030970
+Tree Sort,333,460,0.00049190
+Tree Sort,333,461,0.00044930
+Tree Sort,333,462,0.00048270
+Tree Sort,333,463,0.00051940
+Tree Sort,333,464,0.00050690
+Tree Sort,333,465,0.00031170
+Tree Sort,333,466,0.00048690
+Tree Sort,333,467,0.00049200
+Tree Sort,333,468,0.00055850
+Tree Sort,333,469,0.00052920
+Tree Sort,333,470,0.00047110
+Tree Sort,333,471,0.00047300
+Tree Sort,333,472,0.00047300
+Tree Sort,333,473,0.00039450
+Tree Sort,333,474,0.00047770
+Tree Sort,333,475,0.00047600
+Tree Sort,333,476,0.00042090
+Tree Sort,333,477,0.00045960
+Tree Sort,333,478,0.00040530
+Tree Sort,333,479,0.00047900
+Tree Sort,333,480,0.00030860
+Tree Sort,333,481,0.00047680
+Tree Sort,333,482,0.00032890
+Tree Sort,333,483,0.00034630
+Tree Sort,333,484,0.00044350
+Tree Sort,333,485,0.00043920
+Tree Sort,333,486,0.00043580
+Tree Sort,333,487,0.00050660
+Tree Sort,333,488,0.00054160
+Tree Sort,333,489,0.00046860
+Tree Sort,333,490,0.00048620
+Tree Sort,333,491,0.00049240
+Tree Sort,333,492,0.00050110
+Tree Sort,333,493,0.00048670
+Tree Sort,333,494,0.00055560
+Tree Sort,333,495,0.00052350
+Tree Sort,333,496,0.00050920
+Tree Sort,333,497,0.00047890
+Tree Sort,333,498,0.00050360
+Tree Sort,333,499,0.00034860
+Tree Sort,333,500,0.00041760

--- a/results/results_500.csv
+++ b/results/results_500.csv
@@ -1,0 +1,24501 @@
+Algorithm,Array Size,Iteration,Elapsed Time (seconds)
+Bead Sort,500,1,69.42603060
+Bead Sort,500,2,68.12630140
+Bead Sort,500,3,67.13706820
+Bead Sort,500,4,68.79702390
+Bead Sort,500,5,68.98369670
+Bead Sort,500,6,68.73647040
+Bead Sort,500,7,70.00112720
+Bead Sort,500,8,69.22534880
+Bead Sort,500,9,64.68795270
+Bead Sort,500,10,62.57420170
+Bead Sort,500,11,65.22610270
+Bead Sort,500,12,64.49330520
+Bead Sort,500,13,66.76615580
+Bead Sort,500,14,63.31028730
+Bead Sort,500,15,64.91630530
+Bead Sort,500,16,65.12324030
+Bead Sort,500,17,64.34313900
+Bead Sort,500,18,63.98637380
+Bead Sort,500,19,68.55886650
+Bead Sort,500,20,64.55232060
+Bead Sort,500,21,63.19229080
+Bead Sort,500,22,65.29766070
+Bead Sort,500,23,64.69426060
+Bead Sort,500,24,66.19070710
+Bead Sort,500,25,63.36254540
+Bead Sort,500,26,66.84072800
+Bead Sort,500,27,65.98633450
+Bead Sort,500,28,64.52721430
+Bead Sort,500,29,66.88350190
+Bead Sort,500,30,64.93720190
+Bead Sort,500,31,65.40439750
+Bead Sort,500,32,65.01859470
+Bead Sort,500,33,65.36735390
+Bead Sort,500,34,66.84407630
+Bead Sort,500,35,63.32536520
+Bead Sort,500,36,65.90751280
+Bead Sort,500,37,66.42642140
+Bead Sort,500,38,63.56476510
+Bead Sort,500,39,67.14095830
+Bead Sort,500,40,67.97769070
+Bead Sort,500,41,67.19243140
+Bead Sort,500,42,65.88518330
+Bead Sort,500,43,67.30075670
+Bead Sort,500,44,65.23659410
+Bead Sort,500,45,63.88952020
+Bead Sort,500,46,66.64561510
+Bead Sort,500,47,63.50333760
+Bead Sort,500,48,65.74621420
+Bead Sort,500,49,65.91838870
+Bead Sort,500,50,67.71957090
+Bead Sort,500,51,66.43219880
+Bead Sort,500,52,66.55911020
+Bead Sort,500,53,65.79138420
+Bead Sort,500,54,64.65333130
+Bead Sort,500,55,66.32408270
+Bead Sort,500,56,68.80384080
+Bead Sort,500,57,63.52007930
+Bead Sort,500,58,64.56757610
+Bead Sort,500,59,63.67698780
+Bead Sort,500,60,62.94836840
+Bead Sort,500,61,67.98492990
+Bead Sort,500,62,65.30925120
+Bead Sort,500,63,65.58532500
+Bead Sort,500,64,64.08458870
+Bead Sort,500,65,64.78177170
+Bead Sort,500,66,65.60828350
+Bead Sort,500,67,67.19005780
+Bead Sort,500,68,64.70094300
+Bead Sort,500,69,67.64757060
+Bead Sort,500,70,64.37059800
+Bead Sort,500,71,65.91440520
+Bead Sort,500,72,66.24412730
+Bead Sort,500,73,65.93905390
+Bead Sort,500,74,67.26807080
+Bead Sort,500,75,63.74276520
+Bead Sort,500,76,64.59788580
+Bead Sort,500,77,67.03821340
+Bead Sort,500,78,66.11317100
+Bead Sort,500,79,64.83359540
+Bead Sort,500,80,65.73856320
+Bead Sort,500,81,64.88822620
+Bead Sort,500,82,64.36942290
+Bead Sort,500,83,67.78180060
+Bead Sort,500,84,64.79682360
+Bead Sort,500,85,64.33738620
+Bead Sort,500,86,65.04258280
+Bead Sort,500,87,66.80366590
+Bead Sort,500,88,66.21594070
+Bead Sort,500,89,64.30000130
+Bead Sort,500,90,67.13653440
+Bead Sort,500,91,66.21152050
+Bead Sort,500,92,64.62952830
+Bead Sort,500,93,63.20417280
+Bead Sort,500,94,66.82636430
+Bead Sort,500,95,64.99404880
+Bead Sort,500,96,66.20724100
+Bead Sort,500,97,64.43958010
+Bead Sort,500,98,65.62541400
+Bead Sort,500,99,65.98479130
+Bead Sort,500,100,63.92214130
+Bead Sort,500,101,65.90966700
+Bead Sort,500,102,67.10086890
+Bead Sort,500,103,66.72666190
+Bead Sort,500,104,64.40684610
+Bead Sort,500,105,65.66573140
+Bead Sort,500,106,64.61519210
+Bead Sort,500,107,66.60890730
+Bead Sort,500,108,64.40781600
+Bead Sort,500,109,64.33553170
+Bead Sort,500,110,66.48502790
+Bead Sort,500,111,67.08655850
+Bead Sort,500,112,66.34373230
+Bead Sort,500,113,65.53837510
+Bead Sort,500,114,67.37433430
+Bead Sort,500,115,65.39014580
+Bead Sort,500,116,65.09777760
+Bead Sort,500,117,66.05619200
+Bead Sort,500,118,65.04456340
+Bead Sort,500,119,67.29637740
+Bead Sort,500,120,64.55473930
+Bead Sort,500,121,63.66017670
+Bead Sort,500,122,64.19835650
+Bead Sort,500,123,66.83321480
+Bead Sort,500,124,64.74464540
+Bead Sort,500,125,64.56279250
+Bead Sort,500,126,65.79315000
+Bead Sort,500,127,65.41403220
+Bead Sort,500,128,63.66862590
+Bead Sort,500,129,65.90911760
+Bead Sort,500,130,65.05068710
+Bead Sort,500,131,67.06319080
+Bead Sort,500,132,66.12607060
+Bead Sort,500,133,66.53079700
+Bead Sort,500,134,66.60382170
+Bead Sort,500,135,65.85251600
+Bead Sort,500,136,69.25336990
+Bead Sort,500,137,64.49780490
+Bead Sort,500,138,64.54245440
+Bead Sort,500,139,65.19617730
+Bead Sort,500,140,63.55166910
+Bead Sort,500,141,67.66889790
+Bead Sort,500,142,67.21488960
+Bead Sort,500,143,65.85285460
+Bead Sort,500,144,65.62783300
+Bead Sort,500,145,64.04964990
+Bead Sort,500,146,66.25264300
+Bead Sort,500,147,65.39193780
+Bead Sort,500,148,65.28118680
+Bead Sort,500,149,63.51054580
+Bead Sort,500,150,67.45099470
+Bead Sort,500,151,67.77362570
+Bead Sort,500,152,67.01153590
+Bead Sort,500,153,66.66165580
+Bead Sort,500,154,65.98919190
+Bead Sort,500,155,66.25358420
+Bead Sort,500,156,65.82653020
+Bead Sort,500,157,67.76405770
+Bead Sort,500,158,65.45853450
+Bead Sort,500,159,68.11294670
+Bead Sort,500,160,66.37516410
+Bead Sort,500,161,64.63406940
+Bead Sort,500,162,65.21527650
+Bead Sort,500,163,67.74178110
+Bead Sort,500,164,63.67227780
+Bead Sort,500,165,65.20758300
+Bead Sort,500,166,65.35027450
+Bead Sort,500,167,65.21823180
+Bead Sort,500,168,64.99122370
+Bead Sort,500,169,64.90726970
+Bead Sort,500,170,64.07391740
+Bead Sort,500,171,63.81368850
+Bead Sort,500,172,63.78905980
+Bead Sort,500,173,66.28424220
+Bead Sort,500,174,65.27292830
+Bead Sort,500,175,65.27821490
+Bead Sort,500,176,66.35105330
+Bead Sort,500,177,67.17072690
+Bead Sort,500,178,65.12112710
+Bead Sort,500,179,67.08661900
+Bead Sort,500,180,67.21276410
+Bead Sort,500,181,67.48019030
+Bead Sort,500,182,68.70973010
+Bead Sort,500,183,64.79367140
+Bead Sort,500,184,65.97400350
+Bead Sort,500,185,66.51259130
+Bead Sort,500,186,65.37654460
+Bead Sort,500,187,66.59633200
+Bead Sort,500,188,66.57667280
+Bead Sort,500,189,65.50394200
+Bead Sort,500,190,64.27267100
+Bead Sort,500,191,63.49965770
+Bead Sort,500,192,64.70025600
+Bead Sort,500,193,65.95985500
+Bead Sort,500,194,66.38073020
+Bead Sort,500,195,65.94702980
+Bead Sort,500,196,65.90359350
+Bead Sort,500,197,65.09152390
+Bead Sort,500,198,66.97912100
+Bead Sort,500,199,65.94112940
+Bead Sort,500,200,65.61536800
+Bead Sort,500,201,65.61369700
+Bead Sort,500,202,66.37416170
+Bead Sort,500,203,67.53041160
+Bead Sort,500,204,63.49976190
+Bead Sort,500,205,65.65332140
+Bead Sort,500,206,65.58281300
+Bead Sort,500,207,65.96510790
+Bead Sort,500,208,66.58332040
+Bead Sort,500,209,63.96664280
+Bead Sort,500,210,64.17425890
+Bead Sort,500,211,65.39878750
+Bead Sort,500,212,64.42062610
+Bead Sort,500,213,66.47104330
+Bead Sort,500,214,65.57148860
+Bead Sort,500,215,66.20643120
+Bead Sort,500,216,64.90656640
+Bead Sort,500,217,64.53284670
+Bead Sort,500,218,64.83751830
+Bead Sort,500,219,67.02594960
+Bead Sort,500,220,63.63417180
+Bead Sort,500,221,66.10942170
+Bead Sort,500,222,65.64756870
+Bead Sort,500,223,64.64254740
+Bead Sort,500,224,63.66896890
+Bead Sort,500,225,67.13930830
+Bead Sort,500,226,64.29041690
+Bead Sort,500,227,64.94423390
+Bead Sort,500,228,66.44650980
+Bead Sort,500,229,65.70066890
+Bead Sort,500,230,69.70600680
+Bead Sort,500,231,71.82690810
+Bead Sort,500,232,66.03112570
+Bead Sort,500,233,72.10372350
+Bead Sort,500,234,74.05398060
+Bead Sort,500,235,73.60723630
+Bead Sort,500,236,73.72975200
+Bead Sort,500,237,72.42206330
+Bead Sort,500,238,72.47995560
+Bead Sort,500,239,69.55512410
+Bead Sort,500,240,71.38663880
+Bead Sort,500,241,67.24714010
+Bead Sort,500,242,66.44449610
+Bead Sort,500,243,67.40905430
+Bead Sort,500,244,66.18373400
+Bead Sort,500,245,63.69790750
+Bead Sort,500,246,69.51336360
+Bead Sort,500,247,67.13837200
+Bead Sort,500,248,68.84181980
+Bead Sort,500,249,68.83705150
+Bead Sort,500,250,67.26780590
+Bead Sort,500,251,69.21219650
+Bead Sort,500,252,66.88531890
+Bead Sort,500,253,69.07346440
+Bead Sort,500,254,71.09922820
+Bead Sort,500,255,71.61178560
+Bead Sort,500,256,70.05675730
+Bead Sort,500,257,67.79458740
+Bead Sort,500,258,69.45832940
+Bead Sort,500,259,66.34854930
+Bead Sort,500,260,66.52080380
+Bead Sort,500,261,67.50434760
+Bead Sort,500,262,64.82271500
+Bead Sort,500,263,67.59874090
+Bead Sort,500,264,65.89559410
+Bead Sort,500,265,66.82999520
+Bead Sort,500,266,66.53922540
+Bead Sort,500,267,67.92898190
+Bead Sort,500,268,63.87789550
+Bead Sort,500,269,66.20344640
+Bead Sort,500,270,65.36229680
+Bead Sort,500,271,65.98437070
+Bead Sort,500,272,66.53765330
+Bead Sort,500,273,65.72801640
+Bead Sort,500,274,67.42741990
+Bead Sort,500,275,63.77293330
+Bead Sort,500,276,65.16673290
+Bead Sort,500,277,65.30300270
+Bead Sort,500,278,65.35960890
+Bead Sort,500,279,67.35086580
+Bead Sort,500,280,67.60777690
+Bead Sort,500,281,66.33209830
+Bead Sort,500,282,65.74103230
+Bead Sort,500,283,65.11586700
+Bead Sort,500,284,66.63386650
+Bead Sort,500,285,65.52661640
+Bead Sort,500,286,65.04027660
+Bead Sort,500,287,65.56728340
+Bead Sort,500,288,64.69852380
+Bead Sort,500,289,64.77751480
+Bead Sort,500,290,66.40978290
+Bead Sort,500,291,66.33131530
+Bead Sort,500,292,65.72050430
+Bead Sort,500,293,68.31900530
+Bead Sort,500,294,64.24187340
+Bead Sort,500,295,67.40686130
+Bead Sort,500,296,67.18037180
+Bead Sort,500,297,65.36420570
+Bead Sort,500,298,67.29213340
+Bead Sort,500,299,63.08742020
+Bead Sort,500,300,63.09403500
+Bead Sort,500,301,64.87540450
+Bead Sort,500,302,65.09002860
+Bead Sort,500,303,66.09721500
+Bead Sort,500,304,66.53804480
+Bead Sort,500,305,67.07343090
+Bead Sort,500,306,65.72770370
+Bead Sort,500,307,65.64831270
+Bead Sort,500,308,65.27087860
+Bead Sort,500,309,66.18713330
+Bead Sort,500,310,64.22904950
+Bead Sort,500,311,64.18481030
+Bead Sort,500,312,65.08097550
+Bead Sort,500,313,64.28962690
+Bead Sort,500,314,66.02110690
+Bead Sort,500,315,66.94725340
+Bead Sort,500,316,66.10680710
+Bead Sort,500,317,66.71481560
+Bead Sort,500,318,64.27104550
+Bead Sort,500,319,64.19750870
+Bead Sort,500,320,64.78033220
+Bead Sort,500,321,66.67654930
+Bead Sort,500,322,65.21295710
+Bead Sort,500,323,64.93521890
+Bead Sort,500,324,67.39583180
+Bead Sort,500,325,67.35611600
+Bead Sort,500,326,65.07561760
+Bead Sort,500,327,66.62515030
+Bead Sort,500,328,65.06505400
+Bead Sort,500,329,66.27356490
+Bead Sort,500,330,66.95166370
+Bead Sort,500,331,63.28223870
+Bead Sort,500,332,64.05347550
+Bead Sort,500,333,64.45157990
+Bead Sort,500,334,63.45273840
+Bead Sort,500,335,69.45016650
+Bead Sort,500,336,66.64058890
+Bead Sort,500,337,63.92701120
+Bead Sort,500,338,66.61939680
+Bead Sort,500,339,67.01704650
+Bead Sort,500,340,67.51855000
+Bead Sort,500,341,67.47476490
+Bead Sort,500,342,65.84314180
+Bead Sort,500,343,67.32942900
+Bead Sort,500,344,65.55727070
+Bead Sort,500,345,67.93337550
+Bead Sort,500,346,69.20637340
+Bead Sort,500,347,69.34618210
+Bead Sort,500,348,67.43980700
+Bead Sort,500,349,71.18883700
+Bead Sort,500,350,69.68235580
+Bead Sort,500,351,73.57249930
+Bead Sort,500,352,73.17485620
+Bead Sort,500,353,78.79795430
+Bead Sort,500,354,78.81625920
+Bead Sort,500,355,81.81181400
+Bead Sort,500,356,79.48084270
+Bead Sort,500,357,82.13379240
+Bead Sort,500,358,84.65378430
+Bead Sort,500,359,87.76597640
+Bead Sort,500,360,86.50808120
+Bead Sort,500,361,83.14412980
+Bead Sort,500,362,81.36272260
+Bead Sort,500,363,80.29397150
+Bead Sort,500,364,77.89995190
+Bead Sort,500,365,77.54192520
+Bead Sort,500,366,79.13465530
+Bead Sort,500,367,77.69177680
+Bead Sort,500,368,74.46363010
+Bead Sort,500,369,75.60604100
+Bead Sort,500,370,78.18321230
+Bead Sort,500,371,75.59626740
+Bead Sort,500,372,76.22759250
+Bead Sort,500,373,76.32103310
+Bead Sort,500,374,80.33653780
+Bead Sort,500,375,77.02221550
+Bead Sort,500,376,77.73369300
+Bead Sort,500,377,78.40041190
+Bead Sort,500,378,77.79960590
+Bead Sort,500,379,77.90004210
+Bead Sort,500,380,78.69786280
+Bead Sort,500,381,78.08261960
+Bead Sort,500,382,77.90498460
+Bead Sort,500,383,79.27559620
+Bead Sort,500,384,78.08714810
+Bead Sort,500,385,81.39005370
+Bead Sort,500,386,79.71812530
+Bead Sort,500,387,79.38368100
+Bead Sort,500,388,80.75081180
+Bead Sort,500,389,77.96888930
+Bead Sort,500,390,76.04580610
+Bead Sort,500,391,78.28745920
+Bead Sort,500,392,77.03059860
+Bead Sort,500,393,75.99357530
+Bead Sort,500,394,75.23088870
+Bead Sort,500,395,79.59737550
+Bead Sort,500,396,76.80889670
+Bead Sort,500,397,77.82355950
+Bead Sort,500,398,77.47254560
+Bead Sort,500,399,78.07722480
+Bead Sort,500,400,78.81930940
+Bead Sort,500,401,76.27887650
+Bead Sort,500,402,77.32866570
+Bead Sort,500,403,78.55104210
+Bead Sort,500,404,78.38673210
+Bead Sort,500,405,80.29377220
+Bead Sort,500,406,81.22448330
+Bead Sort,500,407,81.22235570
+Bead Sort,500,408,80.53038620
+Bead Sort,500,409,74.94953450
+Bead Sort,500,410,78.94189930
+Bead Sort,500,411,75.94299540
+Bead Sort,500,412,75.97688500
+Bead Sort,500,413,77.03755760
+Bead Sort,500,414,79.50182960
+Bead Sort,500,415,76.43852670
+Bead Sort,500,416,80.87120100
+Bead Sort,500,417,78.41139220
+Bead Sort,500,418,76.73428920
+Bead Sort,500,419,78.24609460
+Bead Sort,500,420,79.30537250
+Bead Sort,500,421,79.52691700
+Bead Sort,500,422,76.95311200
+Bead Sort,500,423,78.73644260
+Bead Sort,500,424,75.74167640
+Bead Sort,500,425,75.61670800
+Bead Sort,500,426,80.80320550
+Bead Sort,500,427,78.15563890
+Bead Sort,500,428,78.39554230
+Bead Sort,500,429,79.26429480
+Bead Sort,500,430,78.12268880
+Bead Sort,500,431,79.05276190
+Bead Sort,500,432,79.85797610
+Bead Sort,500,433,79.86984910
+Bead Sort,500,434,77.92452980
+Bead Sort,500,435,79.26242660
+Bead Sort,500,436,80.39732200
+Bead Sort,500,437,80.59431440
+Bead Sort,500,438,81.43314710
+Bead Sort,500,439,79.75497170
+Bead Sort,500,440,78.76043770
+Bead Sort,500,441,80.55055100
+Bead Sort,500,442,77.93055290
+Bead Sort,500,443,76.04890090
+Bead Sort,500,444,79.88112160
+Bead Sort,500,445,78.42581910
+Bead Sort,500,446,76.26205810
+Bead Sort,500,447,75.08539850
+Bead Sort,500,448,79.66059480
+Bead Sort,500,449,77.71839270
+Bead Sort,500,450,77.90617650
+Bead Sort,500,451,75.66012270
+Bead Sort,500,452,77.15665000
+Bead Sort,500,453,76.27661690
+Bead Sort,500,454,77.59138320
+Bead Sort,500,455,78.89765460
+Bead Sort,500,456,75.76140910
+Bead Sort,500,457,80.03626620
+Bead Sort,500,458,82.63715350
+Bead Sort,500,459,81.91078350
+Bead Sort,500,460,82.22720110
+Bead Sort,500,461,83.41040760
+Bead Sort,500,462,85.18518200
+Bead Sort,500,463,83.20823250
+Bead Sort,500,464,86.04671290
+Bead Sort,500,465,85.33316360
+Bead Sort,500,466,80.88224540
+Bead Sort,500,467,84.15863230
+Bead Sort,500,468,79.82751580
+Bead Sort,500,469,80.45150450
+Bead Sort,500,470,81.69782240
+Bead Sort,500,471,82.76819470
+Bead Sort,500,472,79.97170240
+Bead Sort,500,473,81.99430920
+Bead Sort,500,474,82.26527510
+Bead Sort,500,475,80.90621260
+Bead Sort,500,476,82.24000280
+Bead Sort,500,477,85.57499960
+Bead Sort,500,478,80.82673920
+Bead Sort,500,479,83.05773820
+Bead Sort,500,480,82.74528840
+Bead Sort,500,481,84.72716620
+Bead Sort,500,482,82.87200150
+Bead Sort,500,483,82.12077370
+Bead Sort,500,484,82.00406680
+Bead Sort,500,485,78.92091750
+Bead Sort,500,486,81.10717900
+Bead Sort,500,487,77.91373540
+Bead Sort,500,488,77.78840910
+Bead Sort,500,489,79.10294510
+Bead Sort,500,490,79.92963860
+Bead Sort,500,491,77.19980500
+Bead Sort,500,492,76.59619120
+Bead Sort,500,493,82.26993650
+Bead Sort,500,494,80.77944610
+Bead Sort,500,495,80.73636870
+Bead Sort,500,496,79.85597910
+Bead Sort,500,497,79.97321420
+Bead Sort,500,498,78.53833900
+Bead Sort,500,499,81.76207240
+Bead Sort,500,500,79.99089360
+Bitonic Sort Parallel,500,1,0.00590470
+Bitonic Sort Parallel,500,2,0.00506660
+Bitonic Sort Parallel,500,3,0.00587550
+Bitonic Sort Parallel,500,4,0.00529560
+Bitonic Sort Parallel,500,5,0.00556390
+Bitonic Sort Parallel,500,6,0.00521180
+Bitonic Sort Parallel,500,7,0.00373670
+Bitonic Sort Parallel,500,8,0.00460180
+Bitonic Sort Parallel,500,9,0.00525590
+Bitonic Sort Parallel,500,10,0.00507650
+Bitonic Sort Parallel,500,11,0.00559350
+Bitonic Sort Parallel,500,12,0.00476640
+Bitonic Sort Parallel,500,13,0.00479920
+Bitonic Sort Parallel,500,14,0.00465310
+Bitonic Sort Parallel,500,15,0.00425230
+Bitonic Sort Parallel,500,16,0.00360990
+Bitonic Sort Parallel,500,17,0.00448150
+Bitonic Sort Parallel,500,18,0.00461640
+Bitonic Sort Parallel,500,19,0.00477140
+Bitonic Sort Parallel,500,20,0.00448660
+Bitonic Sort Parallel,500,21,0.00413450
+Bitonic Sort Parallel,500,22,0.00393750
+Bitonic Sort Parallel,500,23,0.00324840
+Bitonic Sort Parallel,500,24,0.00394670
+Bitonic Sort Parallel,500,25,0.00490800
+Bitonic Sort Parallel,500,26,0.00474520
+Bitonic Sort Parallel,500,27,0.00460320
+Bitonic Sort Parallel,500,28,0.00467280
+Bitonic Sort Parallel,500,29,0.00491690
+Bitonic Sort Parallel,500,30,0.01416140
+Bitonic Sort Parallel,500,31,0.00530490
+Bitonic Sort Parallel,500,32,0.00393540
+Bitonic Sort Parallel,500,33,0.00359680
+Bitonic Sort Parallel,500,34,0.00394350
+Bitonic Sort Parallel,500,35,0.00318380
+Bitonic Sort Parallel,500,36,0.00420490
+Bitonic Sort Parallel,500,37,0.00357180
+Bitonic Sort Parallel,500,38,0.00496560
+Bitonic Sort Parallel,500,39,0.00455530
+Bitonic Sort Parallel,500,40,0.00436260
+Bitonic Sort Parallel,500,41,0.00426500
+Bitonic Sort Parallel,500,42,0.00446220
+Bitonic Sort Parallel,500,43,0.00504960
+Bitonic Sort Parallel,500,44,0.00390860
+Bitonic Sort Parallel,500,45,0.00525680
+Bitonic Sort Parallel,500,46,0.00455930
+Bitonic Sort Parallel,500,47,0.00421050
+Bitonic Sort Parallel,500,48,0.00373340
+Bitonic Sort Parallel,500,49,0.00350370
+Bitonic Sort Parallel,500,50,0.00498260
+Bitonic Sort Parallel,500,51,0.00407100
+Bitonic Sort Parallel,500,52,0.00328030
+Bitonic Sort Parallel,500,53,0.00496580
+Bitonic Sort Parallel,500,54,0.00477840
+Bitonic Sort Parallel,500,55,0.00497860
+Bitonic Sort Parallel,500,56,0.00391220
+Bitonic Sort Parallel,500,57,0.00433470
+Bitonic Sort Parallel,500,58,0.00457130
+Bitonic Sort Parallel,500,59,0.00414990
+Bitonic Sort Parallel,500,60,0.00331780
+Bitonic Sort Parallel,500,61,0.00460630
+Bitonic Sort Parallel,500,62,0.00488700
+Bitonic Sort Parallel,500,63,0.00495990
+Bitonic Sort Parallel,500,64,0.00513340
+Bitonic Sort Parallel,500,65,0.00455920
+Bitonic Sort Parallel,500,66,0.00334170
+Bitonic Sort Parallel,500,67,0.00499390
+Bitonic Sort Parallel,500,68,0.00496350
+Bitonic Sort Parallel,500,69,0.00442980
+Bitonic Sort Parallel,500,70,0.00494350
+Bitonic Sort Parallel,500,71,0.00512350
+Bitonic Sort Parallel,500,72,0.00569720
+Bitonic Sort Parallel,500,73,0.00478310
+Bitonic Sort Parallel,500,74,0.00425490
+Bitonic Sort Parallel,500,75,0.00522200
+Bitonic Sort Parallel,500,76,0.00508430
+Bitonic Sort Parallel,500,77,0.00491330
+Bitonic Sort Parallel,500,78,0.00491000
+Bitonic Sort Parallel,500,79,0.00548060
+Bitonic Sort Parallel,500,80,0.00468530
+Bitonic Sort Parallel,500,81,0.00517660
+Bitonic Sort Parallel,500,82,0.00398220
+Bitonic Sort Parallel,500,83,0.00501680
+Bitonic Sort Parallel,500,84,0.00477630
+Bitonic Sort Parallel,500,85,0.00415670
+Bitonic Sort Parallel,500,86,0.00411390
+Bitonic Sort Parallel,500,87,0.00518590
+Bitonic Sort Parallel,500,88,0.00448950
+Bitonic Sort Parallel,500,89,0.00333500
+Bitonic Sort Parallel,500,90,0.00552170
+Bitonic Sort Parallel,500,91,0.00684780
+Bitonic Sort Parallel,500,92,0.00535740
+Bitonic Sort Parallel,500,93,0.00514120
+Bitonic Sort Parallel,500,94,0.00533550
+Bitonic Sort Parallel,500,95,0.00465280
+Bitonic Sort Parallel,500,96,0.00440960
+Bitonic Sort Parallel,500,97,0.00490850
+Bitonic Sort Parallel,500,98,0.00495320
+Bitonic Sort Parallel,500,99,0.00436270
+Bitonic Sort Parallel,500,100,0.00508050
+Bitonic Sort Parallel,500,101,0.00506730
+Bitonic Sort Parallel,500,102,0.00625950
+Bitonic Sort Parallel,500,103,0.00615760
+Bitonic Sort Parallel,500,104,0.00522700
+Bitonic Sort Parallel,500,105,0.00597550
+Bitonic Sort Parallel,500,106,0.00369080
+Bitonic Sort Parallel,500,107,0.00563960
+Bitonic Sort Parallel,500,108,0.00525250
+Bitonic Sort Parallel,500,109,0.00546930
+Bitonic Sort Parallel,500,110,0.00518930
+Bitonic Sort Parallel,500,111,0.00471850
+Bitonic Sort Parallel,500,112,0.00504350
+Bitonic Sort Parallel,500,113,0.00471140
+Bitonic Sort Parallel,500,114,0.00493530
+Bitonic Sort Parallel,500,115,0.00507020
+Bitonic Sort Parallel,500,116,0.00576590
+Bitonic Sort Parallel,500,117,0.00464490
+Bitonic Sort Parallel,500,118,0.00456810
+Bitonic Sort Parallel,500,119,0.00596400
+Bitonic Sort Parallel,500,120,0.00579340
+Bitonic Sort Parallel,500,121,0.00582930
+Bitonic Sort Parallel,500,122,0.00748610
+Bitonic Sort Parallel,500,123,0.00564380
+Bitonic Sort Parallel,500,124,0.00588640
+Bitonic Sort Parallel,500,125,0.00545790
+Bitonic Sort Parallel,500,126,0.00414010
+Bitonic Sort Parallel,500,127,0.00382580
+Bitonic Sort Parallel,500,128,0.00479280
+Bitonic Sort Parallel,500,129,0.00497640
+Bitonic Sort Parallel,500,130,0.00352570
+Bitonic Sort Parallel,500,131,0.00466610
+Bitonic Sort Parallel,500,132,0.00549420
+Bitonic Sort Parallel,500,133,0.00525120
+Bitonic Sort Parallel,500,134,0.00502720
+Bitonic Sort Parallel,500,135,0.00502000
+Bitonic Sort Parallel,500,136,0.00450280
+Bitonic Sort Parallel,500,137,0.00506420
+Bitonic Sort Parallel,500,138,0.00529770
+Bitonic Sort Parallel,500,139,0.00489880
+Bitonic Sort Parallel,500,140,0.00492250
+Bitonic Sort Parallel,500,141,0.00480990
+Bitonic Sort Parallel,500,142,0.00439230
+Bitonic Sort Parallel,500,143,0.00474320
+Bitonic Sort Parallel,500,144,0.00435540
+Bitonic Sort Parallel,500,145,0.00477130
+Bitonic Sort Parallel,500,146,0.00491300
+Bitonic Sort Parallel,500,147,0.00396870
+Bitonic Sort Parallel,500,148,0.00450440
+Bitonic Sort Parallel,500,149,0.00362330
+Bitonic Sort Parallel,500,150,0.00386130
+Bitonic Sort Parallel,500,151,0.00386240
+Bitonic Sort Parallel,500,152,0.00526200
+Bitonic Sort Parallel,500,153,0.00532300
+Bitonic Sort Parallel,500,154,0.00483080
+Bitonic Sort Parallel,500,155,0.00388030
+Bitonic Sort Parallel,500,156,0.00505080
+Bitonic Sort Parallel,500,157,0.00463170
+Bitonic Sort Parallel,500,158,0.00487950
+Bitonic Sort Parallel,500,159,0.00469630
+Bitonic Sort Parallel,500,160,0.00495020
+Bitonic Sort Parallel,500,161,0.00441060
+Bitonic Sort Parallel,500,162,0.00359960
+Bitonic Sort Parallel,500,163,0.00429650
+Bitonic Sort Parallel,500,164,0.00392830
+Bitonic Sort Parallel,500,165,0.00445580
+Bitonic Sort Parallel,500,166,0.00340590
+Bitonic Sort Parallel,500,167,0.00489660
+Bitonic Sort Parallel,500,168,0.00460820
+Bitonic Sort Parallel,500,169,0.00461580
+Bitonic Sort Parallel,500,170,0.00481800
+Bitonic Sort Parallel,500,171,0.00445290
+Bitonic Sort Parallel,500,172,0.00496340
+Bitonic Sort Parallel,500,173,0.00508400
+Bitonic Sort Parallel,500,174,0.00508340
+Bitonic Sort Parallel,500,175,0.00465050
+Bitonic Sort Parallel,500,176,0.00521670
+Bitonic Sort Parallel,500,177,0.00455810
+Bitonic Sort Parallel,500,178,0.00435030
+Bitonic Sort Parallel,500,179,0.00437380
+Bitonic Sort Parallel,500,180,0.00495480
+Bitonic Sort Parallel,500,181,0.00423770
+Bitonic Sort Parallel,500,182,0.00473740
+Bitonic Sort Parallel,500,183,0.00443400
+Bitonic Sort Parallel,500,184,0.00527740
+Bitonic Sort Parallel,500,185,0.00509170
+Bitonic Sort Parallel,500,186,0.00388430
+Bitonic Sort Parallel,500,187,0.00435960
+Bitonic Sort Parallel,500,188,0.00368600
+Bitonic Sort Parallel,500,189,0.00389240
+Bitonic Sort Parallel,500,190,0.00479860
+Bitonic Sort Parallel,500,191,0.00432630
+Bitonic Sort Parallel,500,192,0.00484950
+Bitonic Sort Parallel,500,193,0.00341650
+Bitonic Sort Parallel,500,194,0.00328710
+Bitonic Sort Parallel,500,195,0.00409710
+Bitonic Sort Parallel,500,196,0.00376610
+Bitonic Sort Parallel,500,197,0.00426140
+Bitonic Sort Parallel,500,198,0.00375800
+Bitonic Sort Parallel,500,199,0.00407920
+Bitonic Sort Parallel,500,200,0.00325370
+Bitonic Sort Parallel,500,201,0.00326580
+Bitonic Sort Parallel,500,202,0.00491900
+Bitonic Sort Parallel,500,203,0.00317820
+Bitonic Sort Parallel,500,204,0.00350910
+Bitonic Sort Parallel,500,205,0.00410850
+Bitonic Sort Parallel,500,206,0.00360270
+Bitonic Sort Parallel,500,207,0.00498640
+Bitonic Sort Parallel,500,208,0.00377910
+Bitonic Sort Parallel,500,209,0.00493310
+Bitonic Sort Parallel,500,210,0.00411680
+Bitonic Sort Parallel,500,211,0.00513740
+Bitonic Sort Parallel,500,212,0.00451970
+Bitonic Sort Parallel,500,213,0.00410070
+Bitonic Sort Parallel,500,214,0.00303700
+Bitonic Sort Parallel,500,215,0.00451530
+Bitonic Sort Parallel,500,216,0.00432910
+Bitonic Sort Parallel,500,217,0.00447380
+Bitonic Sort Parallel,500,218,0.00536710
+Bitonic Sort Parallel,500,219,0.00499100
+Bitonic Sort Parallel,500,220,0.00427920
+Bitonic Sort Parallel,500,221,0.00483300
+Bitonic Sort Parallel,500,222,0.00509970
+Bitonic Sort Parallel,500,223,0.00509010
+Bitonic Sort Parallel,500,224,0.00439730
+Bitonic Sort Parallel,500,225,0.00387680
+Bitonic Sort Parallel,500,226,0.00453020
+Bitonic Sort Parallel,500,227,0.00497580
+Bitonic Sort Parallel,500,228,0.00427990
+Bitonic Sort Parallel,500,229,0.00442170
+Bitonic Sort Parallel,500,230,0.00393130
+Bitonic Sort Parallel,500,231,0.00402860
+Bitonic Sort Parallel,500,232,0.00366040
+Bitonic Sort Parallel,500,233,0.00364740
+Bitonic Sort Parallel,500,234,0.00447100
+Bitonic Sort Parallel,500,235,0.00495030
+Bitonic Sort Parallel,500,236,0.00421820
+Bitonic Sort Parallel,500,237,0.00464480
+Bitonic Sort Parallel,500,238,0.00494420
+Bitonic Sort Parallel,500,239,0.00459170
+Bitonic Sort Parallel,500,240,0.00444530
+Bitonic Sort Parallel,500,241,0.00402520
+Bitonic Sort Parallel,500,242,0.00548250
+Bitonic Sort Parallel,500,243,0.00503920
+Bitonic Sort Parallel,500,244,0.00470410
+Bitonic Sort Parallel,500,245,0.00312450
+Bitonic Sort Parallel,500,246,0.00496260
+Bitonic Sort Parallel,500,247,0.00513740
+Bitonic Sort Parallel,500,248,0.00431010
+Bitonic Sort Parallel,500,249,0.00462440
+Bitonic Sort Parallel,500,250,0.00464300
+Bitonic Sort Parallel,500,251,0.00534520
+Bitonic Sort Parallel,500,252,0.00562370
+Bitonic Sort Parallel,500,253,0.00493450
+Bitonic Sort Parallel,500,254,0.00496670
+Bitonic Sort Parallel,500,255,0.00492590
+Bitonic Sort Parallel,500,256,0.00492390
+Bitonic Sort Parallel,500,257,0.00492010
+Bitonic Sort Parallel,500,258,0.00517020
+Bitonic Sort Parallel,500,259,0.00507050
+Bitonic Sort Parallel,500,260,0.00497540
+Bitonic Sort Parallel,500,261,0.00507290
+Bitonic Sort Parallel,500,262,0.00437800
+Bitonic Sort Parallel,500,263,0.00430910
+Bitonic Sort Parallel,500,264,0.00453230
+Bitonic Sort Parallel,500,265,0.00318090
+Bitonic Sort Parallel,500,266,0.00382110
+Bitonic Sort Parallel,500,267,0.00327470
+Bitonic Sort Parallel,500,268,0.00485410
+Bitonic Sort Parallel,500,269,0.00396760
+Bitonic Sort Parallel,500,270,0.00472210
+Bitonic Sort Parallel,500,271,0.00367110
+Bitonic Sort Parallel,500,272,0.00361870
+Bitonic Sort Parallel,500,273,0.00495630
+Bitonic Sort Parallel,500,274,0.00339410
+Bitonic Sort Parallel,500,275,0.00462110
+Bitonic Sort Parallel,500,276,0.00330600
+Bitonic Sort Parallel,500,277,0.00312870
+Bitonic Sort Parallel,500,278,0.00344490
+Bitonic Sort Parallel,500,279,0.00363640
+Bitonic Sort Parallel,500,280,0.00348490
+Bitonic Sort Parallel,500,281,0.00497430
+Bitonic Sort Parallel,500,282,0.00499750
+Bitonic Sort Parallel,500,283,0.00392010
+Bitonic Sort Parallel,500,284,0.00449120
+Bitonic Sort Parallel,500,285,0.00338190
+Bitonic Sort Parallel,500,286,0.00458170
+Bitonic Sort Parallel,500,287,0.00419510
+Bitonic Sort Parallel,500,288,0.00489740
+Bitonic Sort Parallel,500,289,0.00454830
+Bitonic Sort Parallel,500,290,0.00567550
+Bitonic Sort Parallel,500,291,0.00439510
+Bitonic Sort Parallel,500,292,0.00533710
+Bitonic Sort Parallel,500,293,0.00437940
+Bitonic Sort Parallel,500,294,0.00452690
+Bitonic Sort Parallel,500,295,0.00405820
+Bitonic Sort Parallel,500,296,0.00343310
+Bitonic Sort Parallel,500,297,0.00471340
+Bitonic Sort Parallel,500,298,0.00446020
+Bitonic Sort Parallel,500,299,0.00352740
+Bitonic Sort Parallel,500,300,0.00308690
+Bitonic Sort Parallel,500,301,0.00298570
+Bitonic Sort Parallel,500,302,0.00319150
+Bitonic Sort Parallel,500,303,0.00308930
+Bitonic Sort Parallel,500,304,0.00410810
+Bitonic Sort Parallel,500,305,0.00499590
+Bitonic Sort Parallel,500,306,0.00449500
+Bitonic Sort Parallel,500,307,0.00383920
+Bitonic Sort Parallel,500,308,0.00452740
+Bitonic Sort Parallel,500,309,0.00502150
+Bitonic Sort Parallel,500,310,0.00506670
+Bitonic Sort Parallel,500,311,0.00549660
+Bitonic Sort Parallel,500,312,0.00464710
+Bitonic Sort Parallel,500,313,0.00350750
+Bitonic Sort Parallel,500,314,0.00311010
+Bitonic Sort Parallel,500,315,0.00309380
+Bitonic Sort Parallel,500,316,0.00333110
+Bitonic Sort Parallel,500,317,0.00330260
+Bitonic Sort Parallel,500,318,0.00321980
+Bitonic Sort Parallel,500,319,0.00330200
+Bitonic Sort Parallel,500,320,0.00503750
+Bitonic Sort Parallel,500,321,0.00439790
+Bitonic Sort Parallel,500,322,0.00539680
+Bitonic Sort Parallel,500,323,0.00412270
+Bitonic Sort Parallel,500,324,0.00484390
+Bitonic Sort Parallel,500,325,0.00341440
+Bitonic Sort Parallel,500,326,0.00307690
+Bitonic Sort Parallel,500,327,0.00477660
+Bitonic Sort Parallel,500,328,0.00375180
+Bitonic Sort Parallel,500,329,0.00464650
+Bitonic Sort Parallel,500,330,0.00496740
+Bitonic Sort Parallel,500,331,0.00502120
+Bitonic Sort Parallel,500,332,0.00464760
+Bitonic Sort Parallel,500,333,0.00379660
+Bitonic Sort Parallel,500,334,0.00375620
+Bitonic Sort Parallel,500,335,0.00364870
+Bitonic Sort Parallel,500,336,0.00497120
+Bitonic Sort Parallel,500,337,0.00493590
+Bitonic Sort Parallel,500,338,0.00350940
+Bitonic Sort Parallel,500,339,0.00500120
+Bitonic Sort Parallel,500,340,0.00485360
+Bitonic Sort Parallel,500,341,0.00430310
+Bitonic Sort Parallel,500,342,0.00381270
+Bitonic Sort Parallel,500,343,0.00390620
+Bitonic Sort Parallel,500,344,0.00394770
+Bitonic Sort Parallel,500,345,0.00446110
+Bitonic Sort Parallel,500,346,0.00433120
+Bitonic Sort Parallel,500,347,0.00521970
+Bitonic Sort Parallel,500,348,0.00489780
+Bitonic Sort Parallel,500,349,0.00454880
+Bitonic Sort Parallel,500,350,0.00357470
+Bitonic Sort Parallel,500,351,0.00428090
+Bitonic Sort Parallel,500,352,0.00370150
+Bitonic Sort Parallel,500,353,0.00485560
+Bitonic Sort Parallel,500,354,0.00431320
+Bitonic Sort Parallel,500,355,0.00328670
+Bitonic Sort Parallel,500,356,0.00400430
+Bitonic Sort Parallel,500,357,0.00357000
+Bitonic Sort Parallel,500,358,0.00432170
+Bitonic Sort Parallel,500,359,0.00526070
+Bitonic Sort Parallel,500,360,0.00535120
+Bitonic Sort Parallel,500,361,0.00321780
+Bitonic Sort Parallel,500,362,0.00352220
+Bitonic Sort Parallel,500,363,0.00488210
+Bitonic Sort Parallel,500,364,0.00502310
+Bitonic Sort Parallel,500,365,0.00506460
+Bitonic Sort Parallel,500,366,0.00604580
+Bitonic Sort Parallel,500,367,0.00411490
+Bitonic Sort Parallel,500,368,0.00493170
+Bitonic Sort Parallel,500,369,0.00389490
+Bitonic Sort Parallel,500,370,0.00364290
+Bitonic Sort Parallel,500,371,0.00429140
+Bitonic Sort Parallel,500,372,0.00411860
+Bitonic Sort Parallel,500,373,0.00314260
+Bitonic Sort Parallel,500,374,0.00429740
+Bitonic Sort Parallel,500,375,0.00317240
+Bitonic Sort Parallel,500,376,0.00402740
+Bitonic Sort Parallel,500,377,0.00354450
+Bitonic Sort Parallel,500,378,0.00368920
+Bitonic Sort Parallel,500,379,0.00345100
+Bitonic Sort Parallel,500,380,0.00390840
+Bitonic Sort Parallel,500,381,0.00497900
+Bitonic Sort Parallel,500,382,0.00444510
+Bitonic Sort Parallel,500,383,0.00437610
+Bitonic Sort Parallel,500,384,0.00495580
+Bitonic Sort Parallel,500,385,0.00346220
+Bitonic Sort Parallel,500,386,0.00337480
+Bitonic Sort Parallel,500,387,0.00511250
+Bitonic Sort Parallel,500,388,0.00495830
+Bitonic Sort Parallel,500,389,0.00516680
+Bitonic Sort Parallel,500,390,0.00412880
+Bitonic Sort Parallel,500,391,0.00331660
+Bitonic Sort Parallel,500,392,0.00366360
+Bitonic Sort Parallel,500,393,0.00408060
+Bitonic Sort Parallel,500,394,0.00394130
+Bitonic Sort Parallel,500,395,0.00448470
+Bitonic Sort Parallel,500,396,0.00374820
+Bitonic Sort Parallel,500,397,0.00402490
+Bitonic Sort Parallel,500,398,0.00346930
+Bitonic Sort Parallel,500,399,0.00466910
+Bitonic Sort Parallel,500,400,0.00388330
+Bitonic Sort Parallel,500,401,0.00388350
+Bitonic Sort Parallel,500,402,0.00489200
+Bitonic Sort Parallel,500,403,0.00478210
+Bitonic Sort Parallel,500,404,0.00469760
+Bitonic Sort Parallel,500,405,0.00410230
+Bitonic Sort Parallel,500,406,0.00343310
+Bitonic Sort Parallel,500,407,0.00339830
+Bitonic Sort Parallel,500,408,0.00356590
+Bitonic Sort Parallel,500,409,0.00332310
+Bitonic Sort Parallel,500,410,0.00317540
+Bitonic Sort Parallel,500,411,0.00489800
+Bitonic Sort Parallel,500,412,0.00330330
+Bitonic Sort Parallel,500,413,0.00325900
+Bitonic Sort Parallel,500,414,0.00436470
+Bitonic Sort Parallel,500,415,0.00464350
+Bitonic Sort Parallel,500,416,0.00309460
+Bitonic Sort Parallel,500,417,0.00335840
+Bitonic Sort Parallel,500,418,0.00447990
+Bitonic Sort Parallel,500,419,0.00498800
+Bitonic Sort Parallel,500,420,0.00486470
+Bitonic Sort Parallel,500,421,0.00365630
+Bitonic Sort Parallel,500,422,0.00414980
+Bitonic Sort Parallel,500,423,0.00491970
+Bitonic Sort Parallel,500,424,0.00318010
+Bitonic Sort Parallel,500,425,0.00436130
+Bitonic Sort Parallel,500,426,0.00459350
+Bitonic Sort Parallel,500,427,0.00490250
+Bitonic Sort Parallel,500,428,0.00525080
+Bitonic Sort Parallel,500,429,0.00413530
+Bitonic Sort Parallel,500,430,0.00498850
+Bitonic Sort Parallel,500,431,0.00456040
+Bitonic Sort Parallel,500,432,0.00338070
+Bitonic Sort Parallel,500,433,0.00504460
+Bitonic Sort Parallel,500,434,0.00594380
+Bitonic Sort Parallel,500,435,0.00408880
+Bitonic Sort Parallel,500,436,0.00451940
+Bitonic Sort Parallel,500,437,0.00475450
+Bitonic Sort Parallel,500,438,0.00480420
+Bitonic Sort Parallel,500,439,0.00450510
+Bitonic Sort Parallel,500,440,0.00474940
+Bitonic Sort Parallel,500,441,0.00484380
+Bitonic Sort Parallel,500,442,0.00549330
+Bitonic Sort Parallel,500,443,0.00509210
+Bitonic Sort Parallel,500,444,0.00408330
+Bitonic Sort Parallel,500,445,0.00420170
+Bitonic Sort Parallel,500,446,0.00372520
+Bitonic Sort Parallel,500,447,0.00480490
+Bitonic Sort Parallel,500,448,0.00648610
+Bitonic Sort Parallel,500,449,0.00499710
+Bitonic Sort Parallel,500,450,0.00515640
+Bitonic Sort Parallel,500,451,0.00483940
+Bitonic Sort Parallel,500,452,0.00504800
+Bitonic Sort Parallel,500,453,0.00474370
+Bitonic Sort Parallel,500,454,0.00461920
+Bitonic Sort Parallel,500,455,0.00429850
+Bitonic Sort Parallel,500,456,0.00325660
+Bitonic Sort Parallel,500,457,0.00411150
+Bitonic Sort Parallel,500,458,0.00343330
+Bitonic Sort Parallel,500,459,0.00385190
+Bitonic Sort Parallel,500,460,0.00369430
+Bitonic Sort Parallel,500,461,0.00494560
+Bitonic Sort Parallel,500,462,0.00334690
+Bitonic Sort Parallel,500,463,0.00472250
+Bitonic Sort Parallel,500,464,0.00396840
+Bitonic Sort Parallel,500,465,0.00393210
+Bitonic Sort Parallel,500,466,0.00326920
+Bitonic Sort Parallel,500,467,0.00458760
+Bitonic Sort Parallel,500,468,0.00373980
+Bitonic Sort Parallel,500,469,0.00507160
+Bitonic Sort Parallel,500,470,0.00607970
+Bitonic Sort Parallel,500,471,0.00468480
+Bitonic Sort Parallel,500,472,0.00441890
+Bitonic Sort Parallel,500,473,0.00508700
+Bitonic Sort Parallel,500,474,0.00445230
+Bitonic Sort Parallel,500,475,0.00447150
+Bitonic Sort Parallel,500,476,0.00433160
+Bitonic Sort Parallel,500,477,0.00307020
+Bitonic Sort Parallel,500,478,0.00535310
+Bitonic Sort Parallel,500,479,0.00423780
+Bitonic Sort Parallel,500,480,0.00452480
+Bitonic Sort Parallel,500,481,0.00407360
+Bitonic Sort Parallel,500,482,0.00354820
+Bitonic Sort Parallel,500,483,0.00383640
+Bitonic Sort Parallel,500,484,0.00477220
+Bitonic Sort Parallel,500,485,0.00370010
+Bitonic Sort Parallel,500,486,0.00502790
+Bitonic Sort Parallel,500,487,0.00329560
+Bitonic Sort Parallel,500,488,0.00489790
+Bitonic Sort Parallel,500,489,0.00408230
+Bitonic Sort Parallel,500,490,0.00318090
+Bitonic Sort Parallel,500,491,0.00458970
+Bitonic Sort Parallel,500,492,0.00416290
+Bitonic Sort Parallel,500,493,0.00358300
+Bitonic Sort Parallel,500,494,0.00358920
+Bitonic Sort Parallel,500,495,0.00319490
+Bitonic Sort Parallel,500,496,0.00325800
+Bitonic Sort Parallel,500,497,0.00307810
+Bitonic Sort Parallel,500,498,0.00502700
+Bitonic Sort Parallel,500,499,0.00305890
+Bitonic Sort Parallel,500,500,0.00464050
+Block Sort,500,1,0.00152420
+Block Sort,500,2,0.00122210
+Block Sort,500,3,0.00136690
+Block Sort,500,4,0.00135250
+Block Sort,500,5,0.00149300
+Block Sort,500,6,0.00144160
+Block Sort,500,7,0.00126950
+Block Sort,500,8,0.00148370
+Block Sort,500,9,0.00150230
+Block Sort,500,10,0.00099370
+Block Sort,500,11,0.00088840
+Block Sort,500,12,0.00092260
+Block Sort,500,13,0.00109590
+Block Sort,500,14,0.00081460
+Block Sort,500,15,0.00154870
+Block Sort,500,16,0.00093020
+Block Sort,500,17,0.00152230
+Block Sort,500,18,0.00147290
+Block Sort,500,19,0.00145840
+Block Sort,500,20,0.00127070
+Block Sort,500,21,0.00110270
+Block Sort,500,22,0.00146890
+Block Sort,500,23,0.00106270
+Block Sort,500,24,0.00168010
+Block Sort,500,25,0.00132220
+Block Sort,500,26,0.00105310
+Block Sort,500,27,0.00152370
+Block Sort,500,28,0.00147060
+Block Sort,500,29,0.00118320
+Block Sort,500,30,0.00091480
+Block Sort,500,31,0.00088640
+Block Sort,500,32,0.00138200
+Block Sort,500,33,0.00089370
+Block Sort,500,34,0.00082600
+Block Sort,500,35,0.00112770
+Block Sort,500,36,0.00142110
+Block Sort,500,37,0.00156920
+Block Sort,500,38,0.00086570
+Block Sort,500,39,0.00142670
+Block Sort,500,40,0.00146950
+Block Sort,500,41,0.00146390
+Block Sort,500,42,0.00128430
+Block Sort,500,43,0.00166870
+Block Sort,500,44,0.00150250
+Block Sort,500,45,0.00152560
+Block Sort,500,46,0.00150750
+Block Sort,500,47,0.00149390
+Block Sort,500,48,0.00112150
+Block Sort,500,49,0.00147290
+Block Sort,500,50,0.00151570
+Block Sort,500,51,0.00103900
+Block Sort,500,52,0.00155890
+Block Sort,500,53,0.00167410
+Block Sort,500,54,0.00156910
+Block Sort,500,55,0.00144970
+Block Sort,500,56,0.00148650
+Block Sort,500,57,0.00110360
+Block Sort,500,58,0.00115170
+Block Sort,500,59,0.00149860
+Block Sort,500,60,0.00112960
+Block Sort,500,61,0.00149210
+Block Sort,500,62,0.00154960
+Block Sort,500,63,0.00128050
+Block Sort,500,64,0.00154000
+Block Sort,500,65,0.00148870
+Block Sort,500,66,0.00148630
+Block Sort,500,67,0.00149310
+Block Sort,500,68,0.00119240
+Block Sort,500,69,0.00162470
+Block Sort,500,70,0.00141820
+Block Sort,500,71,0.00150330
+Block Sort,500,72,0.00159720
+Block Sort,500,73,0.00098740
+Block Sort,500,74,0.00165200
+Block Sort,500,75,0.00156800
+Block Sort,500,76,0.00099040
+Block Sort,500,77,0.00168060
+Block Sort,500,78,0.00158520
+Block Sort,500,79,0.00107950
+Block Sort,500,80,0.00084340
+Block Sort,500,81,0.00123990
+Block Sort,500,82,0.00133470
+Block Sort,500,83,0.00087930
+Block Sort,500,84,0.00116840
+Block Sort,500,85,0.00081870
+Block Sort,500,86,0.00084610
+Block Sort,500,87,0.00142620
+Block Sort,500,88,0.00151520
+Block Sort,500,89,0.00087540
+Block Sort,500,90,0.00101780
+Block Sort,500,91,0.00081700
+Block Sort,500,92,0.00126480
+Block Sort,500,93,0.00086690
+Block Sort,500,94,0.00099850
+Block Sort,500,95,0.00131050
+Block Sort,500,96,0.00083330
+Block Sort,500,97,0.00105130
+Block Sort,500,98,0.00109210
+Block Sort,500,99,0.00083130
+Block Sort,500,100,0.00090270
+Block Sort,500,101,0.00108300
+Block Sort,500,102,0.00108040
+Block Sort,500,103,0.00111130
+Block Sort,500,104,0.00083990
+Block Sort,500,105,0.00094930
+Block Sort,500,106,0.00083700
+Block Sort,500,107,0.00087210
+Block Sort,500,108,0.00143040
+Block Sort,500,109,0.00082550
+Block Sort,500,110,0.00093360
+Block Sort,500,111,0.00152060
+Block Sort,500,112,0.00135100
+Block Sort,500,113,0.00129080
+Block Sort,500,114,0.00148400
+Block Sort,500,115,0.00132720
+Block Sort,500,116,0.00085990
+Block Sort,500,117,0.00149390
+Block Sort,500,118,0.00113260
+Block Sort,500,119,0.00103570
+Block Sort,500,120,0.00147050
+Block Sort,500,121,0.00107310
+Block Sort,500,122,0.00116940
+Block Sort,500,123,0.00132770
+Block Sort,500,124,0.00089490
+Block Sort,500,125,0.00156840
+Block Sort,500,126,0.00095530
+Block Sort,500,127,0.00101110
+Block Sort,500,128,0.00091080
+Block Sort,500,129,0.00102140
+Block Sort,500,130,0.00084310
+Block Sort,500,131,0.00134130
+Block Sort,500,132,0.00146680
+Block Sort,500,133,0.00146950
+Block Sort,500,134,0.00145100
+Block Sort,500,135,0.00134300
+Block Sort,500,136,0.00150750
+Block Sort,500,137,0.00103530
+Block Sort,500,138,0.00093370
+Block Sort,500,139,0.00143510
+Block Sort,500,140,0.00100650
+Block Sort,500,141,0.00101260
+Block Sort,500,142,0.00132210
+Block Sort,500,143,0.00084820
+Block Sort,500,144,0.00083840
+Block Sort,500,145,0.00091290
+Block Sort,500,146,0.00094100
+Block Sort,500,147,0.00099690
+Block Sort,500,148,0.00150700
+Block Sort,500,149,0.00114040
+Block Sort,500,150,0.00145750
+Block Sort,500,151,0.00158240
+Block Sort,500,152,0.00149980
+Block Sort,500,153,0.00146730
+Block Sort,500,154,0.00147340
+Block Sort,500,155,0.00112950
+Block Sort,500,156,0.00109970
+Block Sort,500,157,0.00129910
+Block Sort,500,158,0.00107010
+Block Sort,500,159,0.00092580
+Block Sort,500,160,0.00116690
+Block Sort,500,161,0.00156180
+Block Sort,500,162,0.00144220
+Block Sort,500,163,0.00103200
+Block Sort,500,164,0.00139020
+Block Sort,500,165,0.00143820
+Block Sort,500,166,0.00155510
+Block Sort,500,167,0.00135880
+Block Sort,500,168,0.00124660
+Block Sort,500,169,0.00096240
+Block Sort,500,170,0.00166550
+Block Sort,500,171,0.00151800
+Block Sort,500,172,0.00113950
+Block Sort,500,173,0.00135130
+Block Sort,500,174,0.00141120
+Block Sort,500,175,0.00143940
+Block Sort,500,176,0.00143180
+Block Sort,500,177,0.00143170
+Block Sort,500,178,0.00120770
+Block Sort,500,179,0.00104890
+Block Sort,500,180,0.00081620
+Block Sort,500,181,0.00105800
+Block Sort,500,182,0.00096940
+Block Sort,500,183,0.00105990
+Block Sort,500,184,0.00134460
+Block Sort,500,185,0.00143820
+Block Sort,500,186,0.00136470
+Block Sort,500,187,0.00141000
+Block Sort,500,188,0.00148030
+Block Sort,500,189,0.00150110
+Block Sort,500,190,0.00140220
+Block Sort,500,191,0.00082190
+Block Sort,500,192,0.00144560
+Block Sort,500,193,0.00150050
+Block Sort,500,194,0.00091170
+Block Sort,500,195,0.00082290
+Block Sort,500,196,0.00089760
+Block Sort,500,197,0.00132250
+Block Sort,500,198,0.00084070
+Block Sort,500,199,0.00124630
+Block Sort,500,200,0.00114940
+Block Sort,500,201,0.00095770
+Block Sort,500,202,0.00093050
+Block Sort,500,203,0.00135110
+Block Sort,500,204,0.00090290
+Block Sort,500,205,0.00087240
+Block Sort,500,206,0.00084670
+Block Sort,500,207,0.00091740
+Block Sort,500,208,0.00082060
+Block Sort,500,209,0.00152990
+Block Sort,500,210,0.00090460
+Block Sort,500,211,0.00099830
+Block Sort,500,212,0.00140930
+Block Sort,500,213,0.00148320
+Block Sort,500,214,0.00145860
+Block Sort,500,215,0.00146990
+Block Sort,500,216,0.00144350
+Block Sort,500,217,0.00146140
+Block Sort,500,218,0.00125710
+Block Sort,500,219,0.00086260
+Block Sort,500,220,0.00134790
+Block Sort,500,221,0.00100260
+Block Sort,500,222,0.00129040
+Block Sort,500,223,0.00149370
+Block Sort,500,224,0.00163630
+Block Sort,500,225,0.00156670
+Block Sort,500,226,0.00156420
+Block Sort,500,227,0.00153620
+Block Sort,500,228,0.00152130
+Block Sort,500,229,0.00174160
+Block Sort,500,230,0.00154570
+Block Sort,500,231,0.00133740
+Block Sort,500,232,0.00101840
+Block Sort,500,233,0.00130920
+Block Sort,500,234,0.00146030
+Block Sort,500,235,0.00145270
+Block Sort,500,236,0.00147640
+Block Sort,500,237,0.00157780
+Block Sort,500,238,0.00093160
+Block Sort,500,239,0.00089190
+Block Sort,500,240,0.00084630
+Block Sort,500,241,0.00098580
+Block Sort,500,242,0.00145360
+Block Sort,500,243,0.00145520
+Block Sort,500,244,0.00107790
+Block Sort,500,245,0.00147670
+Block Sort,500,246,0.00097510
+Block Sort,500,247,0.00158270
+Block Sort,500,248,0.00157330
+Block Sort,500,249,0.00143990
+Block Sort,500,250,0.00142560
+Block Sort,500,251,0.00144250
+Block Sort,500,252,0.00143900
+Block Sort,500,253,0.00151660
+Block Sort,500,254,0.00154020
+Block Sort,500,255,0.00145450
+Block Sort,500,256,0.00130690
+Block Sort,500,257,0.00111740
+Block Sort,500,258,0.00148120
+Block Sort,500,259,0.00154790
+Block Sort,500,260,0.00166430
+Block Sort,500,261,0.00155530
+Block Sort,500,262,0.00155250
+Block Sort,500,263,0.00154360
+Block Sort,500,264,0.00140040
+Block Sort,500,265,0.00176370
+Block Sort,500,266,0.00147560
+Block Sort,500,267,0.00160900
+Block Sort,500,268,0.00099680
+Block Sort,500,269,0.00120190
+Block Sort,500,270,0.00084050
+Block Sort,500,271,0.00082150
+Block Sort,500,272,0.00150150
+Block Sort,500,273,0.00142200
+Block Sort,500,274,0.00167830
+Block Sort,500,275,0.00166220
+Block Sort,500,276,0.00158510
+Block Sort,500,277,0.00089040
+Block Sort,500,278,0.00101900
+Block Sort,500,279,0.00092350
+Block Sort,500,280,0.00117940
+Block Sort,500,281,0.00098130
+Block Sort,500,282,0.00106230
+Block Sort,500,283,0.00147830
+Block Sort,500,284,0.00086590
+Block Sort,500,285,0.00118900
+Block Sort,500,286,0.00123500
+Block Sort,500,287,0.00127600
+Block Sort,500,288,0.00084360
+Block Sort,500,289,0.00084580
+Block Sort,500,290,0.00086020
+Block Sort,500,291,0.00141910
+Block Sort,500,292,0.00131660
+Block Sort,500,293,0.00142390
+Block Sort,500,294,0.00100820
+Block Sort,500,295,0.00146010
+Block Sort,500,296,0.00146210
+Block Sort,500,297,0.00132790
+Block Sort,500,298,0.00124770
+Block Sort,500,299,0.00159880
+Block Sort,500,300,0.00116620
+Block Sort,500,301,0.00092040
+Block Sort,500,302,0.00145630
+Block Sort,500,303,0.00154420
+Block Sort,500,304,0.00106120
+Block Sort,500,305,0.00100730
+Block Sort,500,306,0.00113660
+Block Sort,500,307,0.00149430
+Block Sort,500,308,0.00147060
+Block Sort,500,309,0.00145150
+Block Sort,500,310,0.00144930
+Block Sort,500,311,0.00148400
+Block Sort,500,312,0.00096790
+Block Sort,500,313,0.00095840
+Block Sort,500,314,0.00083730
+Block Sort,500,315,0.00084530
+Block Sort,500,316,0.00084350
+Block Sort,500,317,0.00150030
+Block Sort,500,318,0.00163280
+Block Sort,500,319,0.00163100
+Block Sort,500,320,0.00095910
+Block Sort,500,321,0.00139910
+Block Sort,500,322,0.00085640
+Block Sort,500,323,0.00112380
+Block Sort,500,324,0.00118350
+Block Sort,500,325,0.00084360
+Block Sort,500,326,0.00099360
+Block Sort,500,327,0.00121010
+Block Sort,500,328,0.00107220
+Block Sort,500,329,0.00084410
+Block Sort,500,330,0.00084460
+Block Sort,500,331,0.00095410
+Block Sort,500,332,0.00138880
+Block Sort,500,333,0.00132580
+Block Sort,500,334,0.00103790
+Block Sort,500,335,0.00094190
+Block Sort,500,336,0.00139800
+Block Sort,500,337,0.00085520
+Block Sort,500,338,0.00114480
+Block Sort,500,339,0.00102640
+Block Sort,500,340,0.00094070
+Block Sort,500,341,0.00131120
+Block Sort,500,342,0.00085790
+Block Sort,500,343,0.00131070
+Block Sort,500,344,0.00146720
+Block Sort,500,345,0.00148040
+Block Sort,500,346,0.00118150
+Block Sort,500,347,0.00153560
+Block Sort,500,348,0.00134450
+Block Sort,500,349,0.00154120
+Block Sort,500,350,0.00156840
+Block Sort,500,351,0.00126360
+Block Sort,500,352,0.00104400
+Block Sort,500,353,0.00097070
+Block Sort,500,354,0.00148790
+Block Sort,500,355,0.00153110
+Block Sort,500,356,0.00152080
+Block Sort,500,357,0.00146090
+Block Sort,500,358,0.00147020
+Block Sort,500,359,0.00107470
+Block Sort,500,360,0.00083890
+Block Sort,500,361,0.00102690
+Block Sort,500,362,0.00095090
+Block Sort,500,363,0.00147660
+Block Sort,500,364,0.00131740
+Block Sort,500,365,0.00098910
+Block Sort,500,366,0.00082330
+Block Sort,500,367,0.00149910
+Block Sort,500,368,0.00149260
+Block Sort,500,369,0.00098800
+Block Sort,500,370,0.00126680
+Block Sort,500,371,0.00168080
+Block Sort,500,372,0.00145360
+Block Sort,500,373,0.00117410
+Block Sort,500,374,0.00152190
+Block Sort,500,375,0.00146140
+Block Sort,500,376,0.00146190
+Block Sort,500,377,0.00129190
+Block Sort,500,378,0.00123990
+Block Sort,500,379,0.00141770
+Block Sort,500,380,0.00103670
+Block Sort,500,381,0.00089780
+Block Sort,500,382,0.00087400
+Block Sort,500,383,0.00083680
+Block Sort,500,384,0.00153040
+Block Sort,500,385,0.00148080
+Block Sort,500,386,0.00147520
+Block Sort,500,387,0.00142630
+Block Sort,500,388,0.00115770
+Block Sort,500,389,0.00129970
+Block Sort,500,390,0.00161730
+Block Sort,500,391,0.00149600
+Block Sort,500,392,0.00147720
+Block Sort,500,393,0.00150450
+Block Sort,500,394,0.00113060
+Block Sort,500,395,0.00084540
+Block Sort,500,396,0.00127800
+Block Sort,500,397,0.00097270
+Block Sort,500,398,0.00129810
+Block Sort,500,399,0.00150190
+Block Sort,500,400,0.00148870
+Block Sort,500,401,0.00080740
+Block Sort,500,402,0.00091050
+Block Sort,500,403,0.00128850
+Block Sort,500,404,0.00127710
+Block Sort,500,405,0.00117510
+Block Sort,500,406,0.00145070
+Block Sort,500,407,0.00150170
+Block Sort,500,408,0.00148350
+Block Sort,500,409,0.00137240
+Block Sort,500,410,0.00099620
+Block Sort,500,411,0.00150890
+Block Sort,500,412,0.00149710
+Block Sort,500,413,0.00145290
+Block Sort,500,414,0.00101710
+Block Sort,500,415,0.00100030
+Block Sort,500,416,0.00163150
+Block Sort,500,417,0.00150860
+Block Sort,500,418,0.00137740
+Block Sort,500,419,0.00085730
+Block Sort,500,420,0.00141210
+Block Sort,500,421,0.00088590
+Block Sort,500,422,0.00110880
+Block Sort,500,423,0.00088650
+Block Sort,500,424,0.00094930
+Block Sort,500,425,0.00092930
+Block Sort,500,426,0.00137230
+Block Sort,500,427,0.00146130
+Block Sort,500,428,0.00148660
+Block Sort,500,429,0.00151650
+Block Sort,500,430,0.00151170
+Block Sort,500,431,0.00157240
+Block Sort,500,432,0.00146470
+Block Sort,500,433,0.00113570
+Block Sort,500,434,0.00084340
+Block Sort,500,435,0.00109830
+Block Sort,500,436,0.00116670
+Block Sort,500,437,0.00158500
+Block Sort,500,438,0.00099470
+Block Sort,500,439,0.00146410
+Block Sort,500,440,0.00144000
+Block Sort,500,441,0.00144360
+Block Sort,500,442,0.00148830
+Block Sort,500,443,0.00134770
+Block Sort,500,444,0.00126100
+Block Sort,500,445,0.00122620
+Block Sort,500,446,0.00089760
+Block Sort,500,447,0.00143050
+Block Sort,500,448,0.00143020
+Block Sort,500,449,0.00143550
+Block Sort,500,450,0.00144340
+Block Sort,500,451,0.00148430
+Block Sort,500,452,0.00105530
+Block Sort,500,453,0.00083490
+Block Sort,500,454,0.00148000
+Block Sort,500,455,0.00146400
+Block Sort,500,456,0.00133360
+Block Sort,500,457,0.00084360
+Block Sort,500,458,0.00083740
+Block Sort,500,459,0.00093760
+Block Sort,500,460,0.00090260
+Block Sort,500,461,0.00092070
+Block Sort,500,462,0.00147580
+Block Sort,500,463,0.00144740
+Block Sort,500,464,0.00149660
+Block Sort,500,465,0.00131690
+Block Sort,500,466,0.00128840
+Block Sort,500,467,0.00096650
+Block Sort,500,468,0.00151790
+Block Sort,500,469,0.00088560
+Block Sort,500,470,0.00109470
+Block Sort,500,471,0.00145580
+Block Sort,500,472,0.00081990
+Block Sort,500,473,0.00158980
+Block Sort,500,474,0.00169170
+Block Sort,500,475,0.00109590
+Block Sort,500,476,0.00151160
+Block Sort,500,477,0.00142780
+Block Sort,500,478,0.00146160
+Block Sort,500,479,0.00135160
+Block Sort,500,480,0.00150940
+Block Sort,500,481,0.00150230
+Block Sort,500,482,0.00145080
+Block Sort,500,483,0.00086270
+Block Sort,500,484,0.00134350
+Block Sort,500,485,0.00148370
+Block Sort,500,486,0.00140870
+Block Sort,500,487,0.00087480
+Block Sort,500,488,0.00096090
+Block Sort,500,489,0.00110400
+Block Sort,500,490,0.00131790
+Block Sort,500,491,0.00122620
+Block Sort,500,492,0.00111890
+Block Sort,500,493,0.00121200
+Block Sort,500,494,0.00088750
+Block Sort,500,495,0.00083270
+Block Sort,500,496,0.00096290
+Block Sort,500,497,0.00082840
+Block Sort,500,498,0.00082000
+Block Sort,500,499,0.00086070
+Block Sort,500,500,0.00085310
+Bubble Sort,500,1,0.01089670
+Bubble Sort,500,2,0.01022080
+Bubble Sort,500,3,0.01361820
+Bubble Sort,500,4,0.00959470
+Bubble Sort,500,5,0.01217670
+Bubble Sort,500,6,0.01169260
+Bubble Sort,500,7,0.01087000
+Bubble Sort,500,8,0.01278270
+Bubble Sort,500,9,0.01198930
+Bubble Sort,500,10,0.01259620
+Bubble Sort,500,11,0.01444170
+Bubble Sort,500,12,0.00915120
+Bubble Sort,500,13,0.01299780
+Bubble Sort,500,14,0.01015810
+Bubble Sort,500,15,0.01423650
+Bubble Sort,500,16,0.01118300
+Bubble Sort,500,17,0.01137390
+Bubble Sort,500,18,0.01395560
+Bubble Sort,500,19,0.01351050
+Bubble Sort,500,20,0.01221130
+Bubble Sort,500,21,0.01113740
+Bubble Sort,500,22,0.01291190
+Bubble Sort,500,23,0.01316110
+Bubble Sort,500,24,0.01544710
+Bubble Sort,500,25,0.01477050
+Bubble Sort,500,26,0.01237040
+Bubble Sort,500,27,0.01134940
+Bubble Sort,500,28,0.01311560
+Bubble Sort,500,29,0.01232180
+Bubble Sort,500,30,0.01009300
+Bubble Sort,500,31,0.00914020
+Bubble Sort,500,32,0.01313010
+Bubble Sort,500,33,0.01298330
+Bubble Sort,500,34,0.01233090
+Bubble Sort,500,35,0.01203790
+Bubble Sort,500,36,0.01289540
+Bubble Sort,500,37,0.01357800
+Bubble Sort,500,38,0.01061970
+Bubble Sort,500,39,0.01434860
+Bubble Sort,500,40,0.01353120
+Bubble Sort,500,41,0.01061050
+Bubble Sort,500,42,0.00985940
+Bubble Sort,500,43,0.00906190
+Bubble Sort,500,44,0.01461590
+Bubble Sort,500,45,0.00954420
+Bubble Sort,500,46,0.01222060
+Bubble Sort,500,47,0.01170580
+Bubble Sort,500,48,0.01215730
+Bubble Sort,500,49,0.01079890
+Bubble Sort,500,50,0.01073980
+Bubble Sort,500,51,0.01466810
+Bubble Sort,500,52,0.01378630
+Bubble Sort,500,53,0.01235760
+Bubble Sort,500,54,0.01263490
+Bubble Sort,500,55,0.01365740
+Bubble Sort,500,56,0.01065250
+Bubble Sort,500,57,0.01320930
+Bubble Sort,500,58,0.01484770
+Bubble Sort,500,59,0.01359060
+Bubble Sort,500,60,0.01225160
+Bubble Sort,500,61,0.01058390
+Bubble Sort,500,62,0.00911400
+Bubble Sort,500,63,0.01272900
+Bubble Sort,500,64,0.01080310
+Bubble Sort,500,65,0.01257610
+Bubble Sort,500,66,0.01395020
+Bubble Sort,500,67,0.01025580
+Bubble Sort,500,68,0.01409980
+Bubble Sort,500,69,0.01285170
+Bubble Sort,500,70,0.01197300
+Bubble Sort,500,71,0.01344050
+Bubble Sort,500,72,0.01000420
+Bubble Sort,500,73,0.00970060
+Bubble Sort,500,74,0.01007230
+Bubble Sort,500,75,0.01345700
+Bubble Sort,500,76,0.01316110
+Bubble Sort,500,77,0.01135240
+Bubble Sort,500,78,0.01236110
+Bubble Sort,500,79,0.01131640
+Bubble Sort,500,80,0.01089270
+Bubble Sort,500,81,0.01192920
+Bubble Sort,500,82,0.01232260
+Bubble Sort,500,83,0.01353390
+Bubble Sort,500,84,0.01326430
+Bubble Sort,500,85,0.01311830
+Bubble Sort,500,86,0.01476090
+Bubble Sort,500,87,0.01430740
+Bubble Sort,500,88,0.01310680
+Bubble Sort,500,89,0.01523590
+Bubble Sort,500,90,0.01244700
+Bubble Sort,500,91,0.01322420
+Bubble Sort,500,92,0.01147300
+Bubble Sort,500,93,0.01261080
+Bubble Sort,500,94,0.01502650
+Bubble Sort,500,95,0.01579730
+Bubble Sort,500,96,0.01484370
+Bubble Sort,500,97,0.01469520
+Bubble Sort,500,98,0.01436040
+Bubble Sort,500,99,0.01702930
+Bubble Sort,500,100,0.01567870
+Bubble Sort,500,101,0.01267670
+Bubble Sort,500,102,0.01524180
+Bubble Sort,500,103,0.01134380
+Bubble Sort,500,104,0.01459150
+Bubble Sort,500,105,0.01399930
+Bubble Sort,500,106,0.01336720
+Bubble Sort,500,107,0.01066290
+Bubble Sort,500,108,0.01361430
+Bubble Sort,500,109,0.01158990
+Bubble Sort,500,110,0.01181330
+Bubble Sort,500,111,0.01072070
+Bubble Sort,500,112,0.01034470
+Bubble Sort,500,113,0.01097910
+Bubble Sort,500,114,0.01378010
+Bubble Sort,500,115,0.01041090
+Bubble Sort,500,116,0.01280400
+Bubble Sort,500,117,0.01351890
+Bubble Sort,500,118,0.01431740
+Bubble Sort,500,119,0.01212480
+Bubble Sort,500,120,0.01226920
+Bubble Sort,500,121,0.01046050
+Bubble Sort,500,122,0.01282940
+Bubble Sort,500,123,0.01191650
+Bubble Sort,500,124,0.01040880
+Bubble Sort,500,125,0.00972270
+Bubble Sort,500,126,0.01033050
+Bubble Sort,500,127,0.01203300
+Bubble Sort,500,128,0.00916870
+Bubble Sort,500,129,0.01378230
+Bubble Sort,500,130,0.01480230
+Bubble Sort,500,131,0.01056250
+Bubble Sort,500,132,0.01119490
+Bubble Sort,500,133,0.01163320
+Bubble Sort,500,134,0.01345530
+Bubble Sort,500,135,0.01327830
+Bubble Sort,500,136,0.01443460
+Bubble Sort,500,137,0.01323480
+Bubble Sort,500,138,0.01478000
+Bubble Sort,500,139,0.01132820
+Bubble Sort,500,140,0.01186560
+Bubble Sort,500,141,0.01358490
+Bubble Sort,500,142,0.01244420
+Bubble Sort,500,143,0.01147490
+Bubble Sort,500,144,0.01141380
+Bubble Sort,500,145,0.01279540
+Bubble Sort,500,146,0.01141580
+Bubble Sort,500,147,0.01126930
+Bubble Sort,500,148,0.01144760
+Bubble Sort,500,149,0.01315500
+Bubble Sort,500,150,0.01277990
+Bubble Sort,500,151,0.01250320
+Bubble Sort,500,152,0.01314620
+Bubble Sort,500,153,0.01226670
+Bubble Sort,500,154,0.01295610
+Bubble Sort,500,155,0.01297630
+Bubble Sort,500,156,0.01463760
+Bubble Sort,500,157,0.01380720
+Bubble Sort,500,158,0.01345700
+Bubble Sort,500,159,0.01228770
+Bubble Sort,500,160,0.01106390
+Bubble Sort,500,161,0.01062980
+Bubble Sort,500,162,0.01014640
+Bubble Sort,500,163,0.01305800
+Bubble Sort,500,164,0.01123740
+Bubble Sort,500,165,0.01367350
+Bubble Sort,500,166,0.01304970
+Bubble Sort,500,167,0.01042360
+Bubble Sort,500,168,0.00979870
+Bubble Sort,500,169,0.00974370
+Bubble Sort,500,170,0.00951190
+Bubble Sort,500,171,0.01139120
+Bubble Sort,500,172,0.01261960
+Bubble Sort,500,173,0.01122860
+Bubble Sort,500,174,0.01279770
+Bubble Sort,500,175,0.00991630
+Bubble Sort,500,176,0.01156550
+Bubble Sort,500,177,0.01325480
+Bubble Sort,500,178,0.02127390
+Bubble Sort,500,179,0.05160170
+Bubble Sort,500,180,0.02073820
+Bubble Sort,500,181,0.02289320
+Bubble Sort,500,182,0.01377920
+Bubble Sort,500,183,0.01388700
+Bubble Sort,500,184,0.01383470
+Bubble Sort,500,185,0.01362510
+Bubble Sort,500,186,0.01115600
+Bubble Sort,500,187,0.01256210
+Bubble Sort,500,188,0.01309570
+Bubble Sort,500,189,0.01216790
+Bubble Sort,500,190,0.01102410
+Bubble Sort,500,191,0.01112950
+Bubble Sort,500,192,0.01293200
+Bubble Sort,500,193,0.01162780
+Bubble Sort,500,194,0.01059610
+Bubble Sort,500,195,0.01292090
+Bubble Sort,500,196,0.01026570
+Bubble Sort,500,197,0.01303060
+Bubble Sort,500,198,0.00982340
+Bubble Sort,500,199,0.01457280
+Bubble Sort,500,200,0.01130560
+Bubble Sort,500,201,0.01354080
+Bubble Sort,500,202,0.01230910
+Bubble Sort,500,203,0.01340190
+Bubble Sort,500,204,0.01272540
+Bubble Sort,500,205,0.01168680
+Bubble Sort,500,206,0.01277120
+Bubble Sort,500,207,0.01147600
+Bubble Sort,500,208,0.01243030
+Bubble Sort,500,209,0.01536210
+Bubble Sort,500,210,0.01385740
+Bubble Sort,500,211,0.01521260
+Bubble Sort,500,212,0.01385450
+Bubble Sort,500,213,0.01192410
+Bubble Sort,500,214,0.01112890
+Bubble Sort,500,215,0.01360760
+Bubble Sort,500,216,0.01124050
+Bubble Sort,500,217,0.01260040
+Bubble Sort,500,218,0.01415250
+Bubble Sort,500,219,0.01293050
+Bubble Sort,500,220,0.01410510
+Bubble Sort,500,221,0.01078550
+Bubble Sort,500,222,0.01244130
+Bubble Sort,500,223,0.01062350
+Bubble Sort,500,224,0.01042430
+Bubble Sort,500,225,0.01089880
+Bubble Sort,500,226,0.01031720
+Bubble Sort,500,227,0.01252910
+Bubble Sort,500,228,0.01080420
+Bubble Sort,500,229,0.01347880
+Bubble Sort,500,230,0.01312950
+Bubble Sort,500,231,0.01403640
+Bubble Sort,500,232,0.01338500
+Bubble Sort,500,233,0.01291280
+Bubble Sort,500,234,0.01189200
+Bubble Sort,500,235,0.01214360
+Bubble Sort,500,236,0.01226280
+Bubble Sort,500,237,0.01426360
+Bubble Sort,500,238,0.01240380
+Bubble Sort,500,239,0.01241910
+Bubble Sort,500,240,0.01078140
+Bubble Sort,500,241,0.01014660
+Bubble Sort,500,242,0.01304670
+Bubble Sort,500,243,0.01006390
+Bubble Sort,500,244,0.01378490
+Bubble Sort,500,245,0.01079430
+Bubble Sort,500,246,0.01274670
+Bubble Sort,500,247,0.01436800
+Bubble Sort,500,248,0.01398450
+Bubble Sort,500,249,0.01256370
+Bubble Sort,500,250,0.01351700
+Bubble Sort,500,251,0.01116380
+Bubble Sort,500,252,0.01278300
+Bubble Sort,500,253,0.01023970
+Bubble Sort,500,254,0.01420550
+Bubble Sort,500,255,0.01001030
+Bubble Sort,500,256,0.01144460
+Bubble Sort,500,257,0.01512570
+Bubble Sort,500,258,0.01437440
+Bubble Sort,500,259,0.01177330
+Bubble Sort,500,260,0.01388440
+Bubble Sort,500,261,0.01170820
+Bubble Sort,500,262,0.01352260
+Bubble Sort,500,263,0.01129750
+Bubble Sort,500,264,0.01267970
+Bubble Sort,500,265,0.01293630
+Bubble Sort,500,266,0.00919440
+Bubble Sort,500,267,0.01395040
+Bubble Sort,500,268,0.01142860
+Bubble Sort,500,269,0.01350770
+Bubble Sort,500,270,0.01235890
+Bubble Sort,500,271,0.01213230
+Bubble Sort,500,272,0.01419920
+Bubble Sort,500,273,0.00905600
+Bubble Sort,500,274,0.01060970
+Bubble Sort,500,275,0.01442130
+Bubble Sort,500,276,0.01297970
+Bubble Sort,500,277,0.01085330
+Bubble Sort,500,278,0.01177010
+Bubble Sort,500,279,0.01355870
+Bubble Sort,500,280,0.01214040
+Bubble Sort,500,281,0.01193070
+Bubble Sort,500,282,0.01402370
+Bubble Sort,500,283,0.01281690
+Bubble Sort,500,284,0.01137960
+Bubble Sort,500,285,0.01402860
+Bubble Sort,500,286,0.01277820
+Bubble Sort,500,287,0.01343800
+Bubble Sort,500,288,0.01138970
+Bubble Sort,500,289,0.01385010
+Bubble Sort,500,290,0.01337450
+Bubble Sort,500,291,0.01391610
+Bubble Sort,500,292,0.01282150
+Bubble Sort,500,293,0.01021390
+Bubble Sort,500,294,0.01142610
+Bubble Sort,500,295,0.01161160
+Bubble Sort,500,296,0.01196100
+Bubble Sort,500,297,0.01094460
+Bubble Sort,500,298,0.01215090
+Bubble Sort,500,299,0.01121990
+Bubble Sort,500,300,0.01226000
+Bubble Sort,500,301,0.01108930
+Bubble Sort,500,302,0.01258260
+Bubble Sort,500,303,0.00945320
+Bubble Sort,500,304,0.01182710
+Bubble Sort,500,305,0.01404690
+Bubble Sort,500,306,0.01181640
+Bubble Sort,500,307,0.01318130
+Bubble Sort,500,308,0.01031090
+Bubble Sort,500,309,0.01256240
+Bubble Sort,500,310,0.01066060
+Bubble Sort,500,311,0.01265030
+Bubble Sort,500,312,0.01218040
+Bubble Sort,500,313,0.01255870
+Bubble Sort,500,314,0.01150150
+Bubble Sort,500,315,0.01161230
+Bubble Sort,500,316,0.01304290
+Bubble Sort,500,317,0.01407440
+Bubble Sort,500,318,0.01295190
+Bubble Sort,500,319,0.01304570
+Bubble Sort,500,320,0.01218910
+Bubble Sort,500,321,0.01202030
+Bubble Sort,500,322,0.01328840
+Bubble Sort,500,323,0.01211630
+Bubble Sort,500,324,0.01240850
+Bubble Sort,500,325,0.01184660
+Bubble Sort,500,326,0.01151470
+Bubble Sort,500,327,0.01508190
+Bubble Sort,500,328,0.00989960
+Bubble Sort,500,329,0.01277320
+Bubble Sort,500,330,0.01465000
+Bubble Sort,500,331,0.01262720
+Bubble Sort,500,332,0.01331660
+Bubble Sort,500,333,0.01118100
+Bubble Sort,500,334,0.01360610
+Bubble Sort,500,335,0.01055560
+Bubble Sort,500,336,0.01254380
+Bubble Sort,500,337,0.01276180
+Bubble Sort,500,338,0.00941990
+Bubble Sort,500,339,0.01259280
+Bubble Sort,500,340,0.01169980
+Bubble Sort,500,341,0.01024220
+Bubble Sort,500,342,0.01415850
+Bubble Sort,500,343,0.01321050
+Bubble Sort,500,344,0.01216490
+Bubble Sort,500,345,0.01000030
+Bubble Sort,500,346,0.01471260
+Bubble Sort,500,347,0.00969570
+Bubble Sort,500,348,0.01069530
+Bubble Sort,500,349,0.01304390
+Bubble Sort,500,350,0.01103880
+Bubble Sort,500,351,0.01233950
+Bubble Sort,500,352,0.01258030
+Bubble Sort,500,353,0.01010600
+Bubble Sort,500,354,0.01262350
+Bubble Sort,500,355,0.01351960
+Bubble Sort,500,356,0.01386360
+Bubble Sort,500,357,0.01245520
+Bubble Sort,500,358,0.01083890
+Bubble Sort,500,359,0.01479590
+Bubble Sort,500,360,0.01290000
+Bubble Sort,500,361,0.01462030
+Bubble Sort,500,362,0.01050150
+Bubble Sort,500,363,0.01196650
+Bubble Sort,500,364,0.01082650
+Bubble Sort,500,365,0.01310840
+Bubble Sort,500,366,0.01081420
+Bubble Sort,500,367,0.01173940
+Bubble Sort,500,368,0.01388990
+Bubble Sort,500,369,0.01459340
+Bubble Sort,500,370,0.01145870
+Bubble Sort,500,371,0.01486380
+Bubble Sort,500,372,0.01431710
+Bubble Sort,500,373,0.01273790
+Bubble Sort,500,374,0.01431300
+Bubble Sort,500,375,0.01247570
+Bubble Sort,500,376,0.01326140
+Bubble Sort,500,377,0.01467480
+Bubble Sort,500,378,0.01433820
+Bubble Sort,500,379,0.01335110
+Bubble Sort,500,380,0.01150050
+Bubble Sort,500,381,0.01510410
+Bubble Sort,500,382,0.01134890
+Bubble Sort,500,383,0.00939060
+Bubble Sort,500,384,0.01529360
+Bubble Sort,500,385,0.01000780
+Bubble Sort,500,386,0.01403430
+Bubble Sort,500,387,0.00977860
+Bubble Sort,500,388,0.01067650
+Bubble Sort,500,389,0.01351130
+Bubble Sort,500,390,0.01065130
+Bubble Sort,500,391,0.01296360
+Bubble Sort,500,392,0.01431130
+Bubble Sort,500,393,0.01284430
+Bubble Sort,500,394,0.01506010
+Bubble Sort,500,395,0.00995070
+Bubble Sort,500,396,0.00961990
+Bubble Sort,500,397,0.01356690
+Bubble Sort,500,398,0.01112510
+Bubble Sort,500,399,0.01099120
+Bubble Sort,500,400,0.01084010
+Bubble Sort,500,401,0.00919560
+Bubble Sort,500,402,0.01158850
+Bubble Sort,500,403,0.01318830
+Bubble Sort,500,404,0.01180580
+Bubble Sort,500,405,0.01152460
+Bubble Sort,500,406,0.01346000
+Bubble Sort,500,407,0.01486900
+Bubble Sort,500,408,0.01292770
+Bubble Sort,500,409,0.01054260
+Bubble Sort,500,410,0.01253460
+Bubble Sort,500,411,0.01465450
+Bubble Sort,500,412,0.01024000
+Bubble Sort,500,413,0.01060460
+Bubble Sort,500,414,0.01071990
+Bubble Sort,500,415,0.01167980
+Bubble Sort,500,416,0.01082960
+Bubble Sort,500,417,0.01475160
+Bubble Sort,500,418,0.01137610
+Bubble Sort,500,419,0.01114840
+Bubble Sort,500,420,0.01180700
+Bubble Sort,500,421,0.00913760
+Bubble Sort,500,422,0.00943120
+Bubble Sort,500,423,0.01359280
+Bubble Sort,500,424,0.01284380
+Bubble Sort,500,425,0.01189260
+Bubble Sort,500,426,0.00952500
+Bubble Sort,500,427,0.01339760
+Bubble Sort,500,428,0.01082780
+Bubble Sort,500,429,0.01297110
+Bubble Sort,500,430,0.01356530
+Bubble Sort,500,431,0.01075230
+Bubble Sort,500,432,0.01397690
+Bubble Sort,500,433,0.01265740
+Bubble Sort,500,434,0.01294750
+Bubble Sort,500,435,0.01186180
+Bubble Sort,500,436,0.01043900
+Bubble Sort,500,437,0.01253140
+Bubble Sort,500,438,0.01070320
+Bubble Sort,500,439,0.01503940
+Bubble Sort,500,440,0.01087560
+Bubble Sort,500,441,0.01000590
+Bubble Sort,500,442,0.01494530
+Bubble Sort,500,443,0.01179590
+Bubble Sort,500,444,0.00961530
+Bubble Sort,500,445,0.01255140
+Bubble Sort,500,446,0.01138460
+Bubble Sort,500,447,0.01071060
+Bubble Sort,500,448,0.01144900
+Bubble Sort,500,449,0.01336740
+Bubble Sort,500,450,0.01365610
+Bubble Sort,500,451,0.01177040
+Bubble Sort,500,452,0.01457030
+Bubble Sort,500,453,0.01057940
+Bubble Sort,500,454,0.01344200
+Bubble Sort,500,455,0.01171080
+Bubble Sort,500,456,0.01350630
+Bubble Sort,500,457,0.01200900
+Bubble Sort,500,458,0.01336470
+Bubble Sort,500,459,0.01165830
+Bubble Sort,500,460,0.01338770
+Bubble Sort,500,461,0.01555050
+Bubble Sort,500,462,0.01468070
+Bubble Sort,500,463,0.01206350
+Bubble Sort,500,464,0.01021860
+Bubble Sort,500,465,0.01196470
+Bubble Sort,500,466,0.01459900
+Bubble Sort,500,467,0.01141850
+Bubble Sort,500,468,0.01299280
+Bubble Sort,500,469,0.01232910
+Bubble Sort,500,470,0.00999140
+Bubble Sort,500,471,0.01301560
+Bubble Sort,500,472,0.01326190
+Bubble Sort,500,473,0.01225390
+Bubble Sort,500,474,0.01550020
+Bubble Sort,500,475,0.01514530
+Bubble Sort,500,476,0.01490050
+Bubble Sort,500,477,0.00927240
+Bubble Sort,500,478,0.01152670
+Bubble Sort,500,479,0.01352540
+Bubble Sort,500,480,0.01293440
+Bubble Sort,500,481,0.01379510
+Bubble Sort,500,482,0.01312180
+Bubble Sort,500,483,0.01509980
+Bubble Sort,500,484,0.01341500
+Bubble Sort,500,485,0.01585780
+Bubble Sort,500,486,0.01434850
+Bubble Sort,500,487,0.01430740
+Bubble Sort,500,488,0.01531700
+Bubble Sort,500,489,0.01521050
+Bubble Sort,500,490,0.01507850
+Bubble Sort,500,491,0.01230740
+Bubble Sort,500,492,0.01318040
+Bubble Sort,500,493,0.01378040
+Bubble Sort,500,494,0.01458060
+Bubble Sort,500,495,0.01561520
+Bubble Sort,500,496,0.01363750
+Bubble Sort,500,497,0.01576270
+Bubble Sort,500,498,0.01403830
+Bubble Sort,500,499,0.01205940
+Bubble Sort,500,500,0.00990960
+Bucket Sort,500,1,0.00048820
+Bucket Sort,500,2,0.00054460
+Bucket Sort,500,3,0.00023220
+Bucket Sort,500,4,0.00040070
+Bucket Sort,500,5,0.00024380
+Bucket Sort,500,6,0.00032020
+Bucket Sort,500,7,0.00026060
+Bucket Sort,500,8,0.00038850
+Bucket Sort,500,9,0.00030820
+Bucket Sort,500,10,0.00038440
+Bucket Sort,500,11,0.00038540
+Bucket Sort,500,12,0.00038560
+Bucket Sort,500,13,0.00024220
+Bucket Sort,500,14,0.00024580
+Bucket Sort,500,15,0.00039730
+Bucket Sort,500,16,0.00024770
+Bucket Sort,500,17,0.00039220
+Bucket Sort,500,18,0.00022420
+Bucket Sort,500,19,0.00026210
+Bucket Sort,500,20,0.00040010
+Bucket Sort,500,21,0.00022670
+Bucket Sort,500,22,0.00039040
+Bucket Sort,500,23,0.00038290
+Bucket Sort,500,24,0.00038930
+Bucket Sort,500,25,0.00038790
+Bucket Sort,500,26,0.00039350
+Bucket Sort,500,27,0.00039950
+Bucket Sort,500,28,0.00038350
+Bucket Sort,500,29,0.00045630
+Bucket Sort,500,30,0.00038220
+Bucket Sort,500,31,0.00039130
+Bucket Sort,500,32,0.00037930
+Bucket Sort,500,33,0.00038670
+Bucket Sort,500,34,0.00039770
+Bucket Sort,500,35,0.00038890
+Bucket Sort,500,36,0.00032550
+Bucket Sort,500,37,0.00035330
+Bucket Sort,500,38,0.00023630
+Bucket Sort,500,39,0.00043350
+Bucket Sort,500,40,0.00023370
+Bucket Sort,500,41,0.00029800
+Bucket Sort,500,42,0.00023600
+Bucket Sort,500,43,0.00037950
+Bucket Sort,500,44,0.00040350
+Bucket Sort,500,45,0.00030940
+Bucket Sort,500,46,0.00039840
+Bucket Sort,500,47,0.00043560
+Bucket Sort,500,48,0.00037860
+Bucket Sort,500,49,0.00042710
+Bucket Sort,500,50,0.00039910
+Bucket Sort,500,51,0.00023920
+Bucket Sort,500,52,0.00026520
+Bucket Sort,500,53,0.00029870
+Bucket Sort,500,54,0.00039730
+Bucket Sort,500,55,0.00025980
+Bucket Sort,500,56,0.00042820
+Bucket Sort,500,57,0.00038520
+Bucket Sort,500,58,0.00031980
+Bucket Sort,500,59,0.00038180
+Bucket Sort,500,60,0.00038760
+Bucket Sort,500,61,0.00037610
+Bucket Sort,500,62,0.00042480
+Bucket Sort,500,63,0.00037800
+Bucket Sort,500,64,0.00045870
+Bucket Sort,500,65,0.00034840
+Bucket Sort,500,66,0.00039040
+Bucket Sort,500,67,0.00039020
+Bucket Sort,500,68,0.00038830
+Bucket Sort,500,69,0.00038190
+Bucket Sort,500,70,0.00026670
+Bucket Sort,500,71,0.00038340
+Bucket Sort,500,72,0.00022660
+Bucket Sort,500,73,0.00038100
+Bucket Sort,500,74,0.00047460
+Bucket Sort,500,75,0.00038510
+Bucket Sort,500,76,0.00039120
+Bucket Sort,500,77,0.00027440
+Bucket Sort,500,78,0.00041050
+Bucket Sort,500,79,0.00038470
+Bucket Sort,500,80,0.00025330
+Bucket Sort,500,81,0.00037920
+Bucket Sort,500,82,0.00025060
+Bucket Sort,500,83,0.00023510
+Bucket Sort,500,84,0.00037940
+Bucket Sort,500,85,0.00034940
+Bucket Sort,500,86,0.00030760
+Bucket Sort,500,87,0.00038490
+Bucket Sort,500,88,0.00032220
+Bucket Sort,500,89,0.00025870
+Bucket Sort,500,90,0.00023300
+Bucket Sort,500,91,0.00033790
+Bucket Sort,500,92,0.00024650
+Bucket Sort,500,93,0.00041450
+Bucket Sort,500,94,0.00031250
+Bucket Sort,500,95,0.00038740
+Bucket Sort,500,96,0.00035290
+Bucket Sort,500,97,0.00039820
+Bucket Sort,500,98,0.00041950
+Bucket Sort,500,99,0.00023300
+Bucket Sort,500,100,0.00038100
+Bucket Sort,500,101,0.00022640
+Bucket Sort,500,102,0.00038660
+Bucket Sort,500,103,0.00023020
+Bucket Sort,500,104,0.00032030
+Bucket Sort,500,105,0.00040450
+Bucket Sort,500,106,0.00038060
+Bucket Sort,500,107,0.00038420
+Bucket Sort,500,108,0.00027330
+Bucket Sort,500,109,0.00026290
+Bucket Sort,500,110,0.00038900
+Bucket Sort,500,111,0.00029140
+Bucket Sort,500,112,0.00038390
+Bucket Sort,500,113,0.00030830
+Bucket Sort,500,114,0.00030680
+Bucket Sort,500,115,0.00039140
+Bucket Sort,500,116,0.00032150
+Bucket Sort,500,117,0.00038470
+Bucket Sort,500,118,0.00044470
+Bucket Sort,500,119,0.00039950
+Bucket Sort,500,120,0.00038990
+Bucket Sort,500,121,0.00038510
+Bucket Sort,500,122,0.00040730
+Bucket Sort,500,123,0.00040100
+Bucket Sort,500,124,0.00098080
+Bucket Sort,500,125,0.00042440
+Bucket Sort,500,126,0.00040890
+Bucket Sort,500,127,0.00037630
+Bucket Sort,500,128,0.00027200
+Bucket Sort,500,129,0.00040630
+Bucket Sort,500,130,0.00038490
+Bucket Sort,500,131,0.00049510
+Bucket Sort,500,132,0.00033260
+Bucket Sort,500,133,0.00029080
+Bucket Sort,500,134,0.00041200
+Bucket Sort,500,135,0.00035170
+Bucket Sort,500,136,0.00031160
+Bucket Sort,500,137,0.00040000
+Bucket Sort,500,138,0.00024200
+Bucket Sort,500,139,0.00023040
+Bucket Sort,500,140,0.00039480
+Bucket Sort,500,141,0.00042460
+Bucket Sort,500,142,0.00036330
+Bucket Sort,500,143,0.00038020
+Bucket Sort,500,144,0.00023810
+Bucket Sort,500,145,0.00036290
+Bucket Sort,500,146,0.00035980
+Bucket Sort,500,147,0.00037880
+Bucket Sort,500,148,0.00038090
+Bucket Sort,500,149,0.00025730
+Bucket Sort,500,150,0.00046080
+Bucket Sort,500,151,0.00039950
+Bucket Sort,500,152,0.00038770
+Bucket Sort,500,153,0.00038680
+Bucket Sort,500,154,0.00038650
+Bucket Sort,500,155,0.00031030
+Bucket Sort,500,156,0.00038420
+Bucket Sort,500,157,0.00022730
+Bucket Sort,500,158,0.00036280
+Bucket Sort,500,159,0.00039360
+Bucket Sort,500,160,0.00032230
+Bucket Sort,500,161,0.00043680
+Bucket Sort,500,162,0.00025160
+Bucket Sort,500,163,0.00047100
+Bucket Sort,500,164,0.00037640
+Bucket Sort,500,165,0.00036370
+Bucket Sort,500,166,0.00023980
+Bucket Sort,500,167,0.00022920
+Bucket Sort,500,168,0.00023230
+Bucket Sort,500,169,0.00046050
+Bucket Sort,500,170,0.00033280
+Bucket Sort,500,171,0.00038760
+Bucket Sort,500,172,0.00039750
+Bucket Sort,500,173,0.00039120
+Bucket Sort,500,174,0.00038460
+Bucket Sort,500,175,0.00024070
+Bucket Sort,500,176,0.00038780
+Bucket Sort,500,177,0.00024750
+Bucket Sort,500,178,0.00038040
+Bucket Sort,500,179,0.00023450
+Bucket Sort,500,180,0.00039610
+Bucket Sort,500,181,0.00027250
+Bucket Sort,500,182,0.00023060
+Bucket Sort,500,183,0.00038320
+Bucket Sort,500,184,0.00028390
+Bucket Sort,500,185,0.00038080
+Bucket Sort,500,186,0.00023280
+Bucket Sort,500,187,0.00037010
+Bucket Sort,500,188,0.00038730
+Bucket Sort,500,189,0.00028940
+Bucket Sort,500,190,0.00035030
+Bucket Sort,500,191,0.00037850
+Bucket Sort,500,192,0.00039230
+Bucket Sort,500,193,0.00037680
+Bucket Sort,500,194,0.00037030
+Bucket Sort,500,195,0.00023040
+Bucket Sort,500,196,0.00038260
+Bucket Sort,500,197,0.00022480
+Bucket Sort,500,198,0.00024530
+Bucket Sort,500,199,0.00037920
+Bucket Sort,500,200,0.00030620
+Bucket Sort,500,201,0.00037660
+Bucket Sort,500,202,0.00022780
+Bucket Sort,500,203,0.00031140
+Bucket Sort,500,204,0.00040610
+Bucket Sort,500,205,0.00037630
+Bucket Sort,500,206,0.00043320
+Bucket Sort,500,207,0.00023020
+Bucket Sort,500,208,0.00041320
+Bucket Sort,500,209,0.00022480
+Bucket Sort,500,210,0.00039380
+Bucket Sort,500,211,0.00039830
+Bucket Sort,500,212,0.00022610
+Bucket Sort,500,213,0.00023880
+Bucket Sort,500,214,0.00022740
+Bucket Sort,500,215,0.00026150
+Bucket Sort,500,216,0.00031230
+Bucket Sort,500,217,0.00023180
+Bucket Sort,500,218,0.00028910
+Bucket Sort,500,219,0.00023780
+Bucket Sort,500,220,0.00025960
+Bucket Sort,500,221,0.00043600
+Bucket Sort,500,222,0.00035190
+Bucket Sort,500,223,0.00042750
+Bucket Sort,500,224,0.00035430
+Bucket Sort,500,225,0.00023240
+Bucket Sort,500,226,0.00040550
+Bucket Sort,500,227,0.00028970
+Bucket Sort,500,228,0.00023460
+Bucket Sort,500,229,0.00024800
+Bucket Sort,500,230,0.00023040
+Bucket Sort,500,231,0.00032010
+Bucket Sort,500,232,0.00038830
+Bucket Sort,500,233,0.00024670
+Bucket Sort,500,234,0.00038780
+Bucket Sort,500,235,0.00025820
+Bucket Sort,500,236,0.00039780
+Bucket Sort,500,237,0.00024760
+Bucket Sort,500,238,0.00036130
+Bucket Sort,500,239,0.00039210
+Bucket Sort,500,240,0.00023230
+Bucket Sort,500,241,0.00038040
+Bucket Sort,500,242,0.00036970
+Bucket Sort,500,243,0.00037770
+Bucket Sort,500,244,0.00038810
+Bucket Sort,500,245,0.00038080
+Bucket Sort,500,246,0.00037780
+Bucket Sort,500,247,0.00034420
+Bucket Sort,500,248,0.00038340
+Bucket Sort,500,249,0.00039500
+Bucket Sort,500,250,0.00025000
+Bucket Sort,500,251,0.00042940
+Bucket Sort,500,252,0.00024050
+Bucket Sort,500,253,0.00024330
+Bucket Sort,500,254,0.00042320
+Bucket Sort,500,255,0.00034450
+Bucket Sort,500,256,0.00038840
+Bucket Sort,500,257,0.00023010
+Bucket Sort,500,258,0.00023290
+Bucket Sort,500,259,0.00023440
+Bucket Sort,500,260,0.00022530
+Bucket Sort,500,261,0.00022970
+Bucket Sort,500,262,0.00033100
+Bucket Sort,500,263,0.00038690
+Bucket Sort,500,264,0.00023350
+Bucket Sort,500,265,0.00028280
+Bucket Sort,500,266,0.00023280
+Bucket Sort,500,267,0.00042670
+Bucket Sort,500,268,0.00028510
+Bucket Sort,500,269,0.00022960
+Bucket Sort,500,270,0.00036350
+Bucket Sort,500,271,0.00032460
+Bucket Sort,500,272,0.00041110
+Bucket Sort,500,273,0.00038840
+Bucket Sort,500,274,0.00023550
+Bucket Sort,500,275,0.00025070
+Bucket Sort,500,276,0.00039600
+Bucket Sort,500,277,0.00039150
+Bucket Sort,500,278,0.00040850
+Bucket Sort,500,279,0.00038120
+Bucket Sort,500,280,0.00030560
+Bucket Sort,500,281,0.00039700
+Bucket Sort,500,282,0.00038310
+Bucket Sort,500,283,0.00039000
+Bucket Sort,500,284,0.00038290
+Bucket Sort,500,285,0.00038240
+Bucket Sort,500,286,0.00032360
+Bucket Sort,500,287,0.00022890
+Bucket Sort,500,288,0.00041440
+Bucket Sort,500,289,0.00029320
+Bucket Sort,500,290,0.00034340
+Bucket Sort,500,291,0.00039900
+Bucket Sort,500,292,0.00024360
+Bucket Sort,500,293,0.00038540
+Bucket Sort,500,294,0.00026830
+Bucket Sort,500,295,0.00037550
+Bucket Sort,500,296,0.00023660
+Bucket Sort,500,297,0.00040620
+Bucket Sort,500,298,0.00037470
+Bucket Sort,500,299,0.00035520
+Bucket Sort,500,300,0.00034780
+Bucket Sort,500,301,0.00040700
+Bucket Sort,500,302,0.00062350
+Bucket Sort,500,303,0.00025860
+Bucket Sort,500,304,0.00038360
+Bucket Sort,500,305,0.00024260
+Bucket Sort,500,306,0.00022890
+Bucket Sort,500,307,0.00036500
+Bucket Sort,500,308,0.00028110
+Bucket Sort,500,309,0.00039140
+Bucket Sort,500,310,0.00040260
+Bucket Sort,500,311,0.00040250
+Bucket Sort,500,312,0.00039640
+Bucket Sort,500,313,0.00033390
+Bucket Sort,500,314,0.00038800
+Bucket Sort,500,315,0.00043540
+Bucket Sort,500,316,0.00023240
+Bucket Sort,500,317,0.00024660
+Bucket Sort,500,318,0.00036910
+Bucket Sort,500,319,0.00024510
+Bucket Sort,500,320,0.00043200
+Bucket Sort,500,321,0.00031670
+Bucket Sort,500,322,0.00024510
+Bucket Sort,500,323,0.00023130
+Bucket Sort,500,324,0.00038330
+Bucket Sort,500,325,0.00039330
+Bucket Sort,500,326,0.00038360
+Bucket Sort,500,327,0.00039100
+Bucket Sort,500,328,0.00038800
+Bucket Sort,500,329,0.00038740
+Bucket Sort,500,330,0.00037470
+Bucket Sort,500,331,0.00037510
+Bucket Sort,500,332,0.00039280
+Bucket Sort,500,333,0.00038690
+Bucket Sort,500,334,0.00043810
+Bucket Sort,500,335,0.00023490
+Bucket Sort,500,336,0.00027420
+Bucket Sort,500,337,0.00043630
+Bucket Sort,500,338,0.00048910
+Bucket Sort,500,339,0.00045250
+Bucket Sort,500,340,0.00038620
+Bucket Sort,500,341,0.00039900
+Bucket Sort,500,342,0.00042340
+Bucket Sort,500,343,0.00041130
+Bucket Sort,500,344,0.00039700
+Bucket Sort,500,345,0.00041040
+Bucket Sort,500,346,0.00039430
+Bucket Sort,500,347,0.00040310
+Bucket Sort,500,348,0.00039490
+Bucket Sort,500,349,0.00040200
+Bucket Sort,500,350,0.00039610
+Bucket Sort,500,351,0.00040190
+Bucket Sort,500,352,0.00039460
+Bucket Sort,500,353,0.00040540
+Bucket Sort,500,354,0.00039260
+Bucket Sort,500,355,0.00041330
+Bucket Sort,500,356,0.00023180
+Bucket Sort,500,357,0.00038780
+Bucket Sort,500,358,0.00023560
+Bucket Sort,500,359,0.00038290
+Bucket Sort,500,360,0.00023010
+Bucket Sort,500,361,0.00027740
+Bucket Sort,500,362,0.00038320
+Bucket Sort,500,363,0.00027300
+Bucket Sort,500,364,0.00023190
+Bucket Sort,500,365,0.00024540
+Bucket Sort,500,366,0.00026440
+Bucket Sort,500,367,0.00039050
+Bucket Sort,500,368,0.00023170
+Bucket Sort,500,369,0.00039280
+Bucket Sort,500,370,0.00022680
+Bucket Sort,500,371,0.00023350
+Bucket Sort,500,372,0.00038090
+Bucket Sort,500,373,0.00022570
+Bucket Sort,500,374,0.00038370
+Bucket Sort,500,375,0.00027940
+Bucket Sort,500,376,0.00037240
+Bucket Sort,500,377,0.00042360
+Bucket Sort,500,378,0.00039490
+Bucket Sort,500,379,0.00038780
+Bucket Sort,500,380,0.00041890
+Bucket Sort,500,381,0.00033420
+Bucket Sort,500,382,0.00040840
+Bucket Sort,500,383,0.00025550
+Bucket Sort,500,384,0.00026270
+Bucket Sort,500,385,0.00024890
+Bucket Sort,500,386,0.00044360
+Bucket Sort,500,387,0.00026450
+Bucket Sort,500,388,0.00037940
+Bucket Sort,500,389,0.00022780
+Bucket Sort,500,390,0.00050980
+Bucket Sort,500,391,0.00027950
+Bucket Sort,500,392,0.00035480
+Bucket Sort,500,393,0.00038420
+Bucket Sort,500,394,0.00038990
+Bucket Sort,500,395,0.00037770
+Bucket Sort,500,396,0.00044240
+Bucket Sort,500,397,0.00038380
+Bucket Sort,500,398,0.00040200
+Bucket Sort,500,399,0.00037590
+Bucket Sort,500,400,0.00038910
+Bucket Sort,500,401,0.00037980
+Bucket Sort,500,402,0.00038390
+Bucket Sort,500,403,0.00022770
+Bucket Sort,500,404,0.00053420
+Bucket Sort,500,405,0.00032980
+Bucket Sort,500,406,0.00023980
+Bucket Sort,500,407,0.00025090
+Bucket Sort,500,408,0.00023130
+Bucket Sort,500,409,0.00026850
+Bucket Sort,500,410,0.00023160
+Bucket Sort,500,411,0.00041530
+Bucket Sort,500,412,0.00024150
+Bucket Sort,500,413,0.00022760
+Bucket Sort,500,414,0.00024610
+Bucket Sort,500,415,0.00033450
+Bucket Sort,500,416,0.00040700
+Bucket Sort,500,417,0.00045430
+Bucket Sort,500,418,0.00037520
+Bucket Sort,500,419,0.00038480
+Bucket Sort,500,420,0.00038050
+Bucket Sort,500,421,0.00037620
+Bucket Sort,500,422,0.00037540
+Bucket Sort,500,423,0.00023650
+Bucket Sort,500,424,0.00038310
+Bucket Sort,500,425,0.00041960
+Bucket Sort,500,426,0.00037880
+Bucket Sort,500,427,0.00043960
+Bucket Sort,500,428,0.00037930
+Bucket Sort,500,429,0.00039390
+Bucket Sort,500,430,0.00035450
+Bucket Sort,500,431,0.00039380
+Bucket Sort,500,432,0.00031780
+Bucket Sort,500,433,0.00040030
+Bucket Sort,500,434,0.00036120
+Bucket Sort,500,435,0.00037260
+Bucket Sort,500,436,0.00040110
+Bucket Sort,500,437,0.00037680
+Bucket Sort,500,438,0.00038660
+Bucket Sort,500,439,0.00038230
+Bucket Sort,500,440,0.00038870
+Bucket Sort,500,441,0.00037340
+Bucket Sort,500,442,0.00039840
+Bucket Sort,500,443,0.00038680
+Bucket Sort,500,444,0.00036100
+Bucket Sort,500,445,0.00033960
+Bucket Sort,500,446,0.00024260
+Bucket Sort,500,447,0.00023240
+Bucket Sort,500,448,0.00042120
+Bucket Sort,500,449,0.00025450
+Bucket Sort,500,450,0.00033090
+Bucket Sort,500,451,0.00031790
+Bucket Sort,500,452,0.00039330
+Bucket Sort,500,453,0.00043000
+Bucket Sort,500,454,0.00023310
+Bucket Sort,500,455,0.00023340
+Bucket Sort,500,456,0.00027530
+Bucket Sort,500,457,0.00036650
+Bucket Sort,500,458,0.00028670
+Bucket Sort,500,459,0.00023300
+Bucket Sort,500,460,0.00026230
+Bucket Sort,500,461,0.00043720
+Bucket Sort,500,462,0.00049700
+Bucket Sort,500,463,0.00029530
+Bucket Sort,500,464,0.00024250
+Bucket Sort,500,465,0.00038820
+Bucket Sort,500,466,0.00023180
+Bucket Sort,500,467,0.00037800
+Bucket Sort,500,468,0.00024860
+Bucket Sort,500,469,0.00028150
+Bucket Sort,500,470,0.00038110
+Bucket Sort,500,471,0.00038300
+Bucket Sort,500,472,0.00040950
+Bucket Sort,500,473,0.00038040
+Bucket Sort,500,474,0.00023100
+Bucket Sort,500,475,0.00038200
+Bucket Sort,500,476,0.00038790
+Bucket Sort,500,477,0.00031360
+Bucket Sort,500,478,0.00038280
+Bucket Sort,500,479,0.00022940
+Bucket Sort,500,480,0.00039260
+Bucket Sort,500,481,0.00037000
+Bucket Sort,500,482,0.00038450
+Bucket Sort,500,483,0.00042140
+Bucket Sort,500,484,0.00037880
+Bucket Sort,500,485,0.00039130
+Bucket Sort,500,486,0.00026220
+Bucket Sort,500,487,0.00038210
+Bucket Sort,500,488,0.00027610
+Bucket Sort,500,489,0.00038220
+Bucket Sort,500,490,0.00024870
+Bucket Sort,500,491,0.00036840
+Bucket Sort,500,492,0.00038630
+Bucket Sort,500,493,0.00040110
+Bucket Sort,500,494,0.00039060
+Bucket Sort,500,495,0.00038290
+Bucket Sort,500,496,0.00039270
+Bucket Sort,500,497,0.00037990
+Bucket Sort,500,498,0.00038370
+Bucket Sort,500,499,0.00037790
+Bucket Sort,500,500,0.00023240
+Burst Sort,500,1,0.00036300
+Burst Sort,500,2,0.00041820
+Burst Sort,500,3,0.00040170
+Burst Sort,500,4,0.00040330
+Burst Sort,500,5,0.00039810
+Burst Sort,500,6,0.00041770
+Burst Sort,500,7,0.00037310
+Burst Sort,500,8,0.00037110
+Burst Sort,500,9,0.00024050
+Burst Sort,500,10,0.00038250
+Burst Sort,500,11,0.00042210
+Burst Sort,500,12,0.00041910
+Burst Sort,500,13,0.00038000
+Burst Sort,500,14,0.00028530
+Burst Sort,500,15,0.00036600
+Burst Sort,500,16,0.00036980
+Burst Sort,500,17,0.00055280
+Burst Sort,500,18,0.00037820
+Burst Sort,500,19,0.00023400
+Burst Sort,500,20,0.00037310
+Burst Sort,500,21,0.00022850
+Burst Sort,500,22,0.00036570
+Burst Sort,500,23,0.00022680
+Burst Sort,500,24,0.00022480
+Burst Sort,500,25,0.00037100
+Burst Sort,500,26,0.00022700
+Burst Sort,500,27,0.00025500
+Burst Sort,500,28,0.00022790
+Burst Sort,500,29,0.00023420
+Burst Sort,500,30,0.00023390
+Burst Sort,500,31,0.00026660
+Burst Sort,500,32,0.00044010
+Burst Sort,500,33,0.00034320
+Burst Sort,500,34,0.00027560
+Burst Sort,500,35,0.00022730
+Burst Sort,500,36,0.00024240
+Burst Sort,500,37,0.00023130
+Burst Sort,500,38,0.00024010
+Burst Sort,500,39,0.00037540
+Burst Sort,500,40,0.00024410
+Burst Sort,500,41,0.00031970
+Burst Sort,500,42,0.00025360
+Burst Sort,500,43,0.00038500
+Burst Sort,500,44,0.00038580
+Burst Sort,500,45,0.00022980
+Burst Sort,500,46,0.00035720
+Burst Sort,500,47,0.00030600
+Burst Sort,500,48,0.00035370
+Burst Sort,500,49,0.00033760
+Burst Sort,500,50,0.00035030
+Burst Sort,500,51,0.00037860
+Burst Sort,500,52,0.00047780
+Burst Sort,500,53,0.00037280
+Burst Sort,500,54,0.00037780
+Burst Sort,500,55,0.00037610
+Burst Sort,500,56,0.00036730
+Burst Sort,500,57,0.00037450
+Burst Sort,500,58,0.00023420
+Burst Sort,500,59,0.00037090
+Burst Sort,500,60,0.00026510
+Burst Sort,500,61,0.00029360
+Burst Sort,500,62,0.00023580
+Burst Sort,500,63,0.00024890
+Burst Sort,500,64,0.00031370
+Burst Sort,500,65,0.00022530
+Burst Sort,500,66,0.00034660
+Burst Sort,500,67,0.00025970
+Burst Sort,500,68,0.00037400
+Burst Sort,500,69,0.00032010
+Burst Sort,500,70,0.00024180
+Burst Sort,500,71,0.00036560
+Burst Sort,500,72,0.00038210
+Burst Sort,500,73,0.00036120
+Burst Sort,500,74,0.00039270
+Burst Sort,500,75,0.00037770
+Burst Sort,500,76,0.00037640
+Burst Sort,500,77,0.00040520
+Burst Sort,500,78,0.00037290
+Burst Sort,500,79,0.00037450
+Burst Sort,500,80,0.00037310
+Burst Sort,500,81,0.00033890
+Burst Sort,500,82,0.00037570
+Burst Sort,500,83,0.00028050
+Burst Sort,500,84,0.00037320
+Burst Sort,500,85,0.00028520
+Burst Sort,500,86,0.00038730
+Burst Sort,500,87,0.00036760
+Burst Sort,500,88,0.00040160
+Burst Sort,500,89,0.00024360
+Burst Sort,500,90,0.00032660
+Burst Sort,500,91,0.00037160
+Burst Sort,500,92,0.00038010
+Burst Sort,500,93,0.00027910
+Burst Sort,500,94,0.00032530
+Burst Sort,500,95,0.00038060
+Burst Sort,500,96,0.00037510
+Burst Sort,500,97,0.00037090
+Burst Sort,500,98,0.00028860
+Burst Sort,500,99,0.00036840
+Burst Sort,500,100,0.00032110
+Burst Sort,500,101,0.00039040
+Burst Sort,500,102,0.00033080
+Burst Sort,500,103,0.00036860
+Burst Sort,500,104,0.00035430
+Burst Sort,500,105,0.00024730
+Burst Sort,500,106,0.00022760
+Burst Sort,500,107,0.00025190
+Burst Sort,500,108,0.00027900
+Burst Sort,500,109,0.00030260
+Burst Sort,500,110,0.00035800
+Burst Sort,500,111,0.00039350
+Burst Sort,500,112,0.00036620
+Burst Sort,500,113,0.00037060
+Burst Sort,500,114,0.00022750
+Burst Sort,500,115,0.00037980
+Burst Sort,500,116,0.00038580
+Burst Sort,500,117,0.00040540
+Burst Sort,500,118,0.00028880
+Burst Sort,500,119,0.00023890
+Burst Sort,500,120,0.00036630
+Burst Sort,500,121,0.00036640
+Burst Sort,500,122,0.00036530
+Burst Sort,500,123,0.00031470
+Burst Sort,500,124,0.00036370
+Burst Sort,500,125,0.00022460
+Burst Sort,500,126,0.00038190
+Burst Sort,500,127,0.00024610
+Burst Sort,500,128,0.00037980
+Burst Sort,500,129,0.00037850
+Burst Sort,500,130,0.00037340
+Burst Sort,500,131,0.00036740
+Burst Sort,500,132,0.00037790
+Burst Sort,500,133,0.00027240
+Burst Sort,500,134,0.00030350
+Burst Sort,500,135,0.00038590
+Burst Sort,500,136,0.00023660
+Burst Sort,500,137,0.00039470
+Burst Sort,500,138,0.00023760
+Burst Sort,500,139,0.00041370
+Burst Sort,500,140,0.00030380
+Burst Sort,500,141,0.00023640
+Burst Sort,500,142,0.00037310
+Burst Sort,500,143,0.00025550
+Burst Sort,500,144,0.00033400
+Burst Sort,500,145,0.00025940
+Burst Sort,500,146,0.00024150
+Burst Sort,500,147,0.00027240
+Burst Sort,500,148,0.00025150
+Burst Sort,500,149,0.00024320
+Burst Sort,500,150,0.00030900
+Burst Sort,500,151,0.00032830
+Burst Sort,500,152,0.00030840
+Burst Sort,500,153,0.00037480
+Burst Sort,500,154,0.00026040
+Burst Sort,500,155,0.00039610
+Burst Sort,500,156,0.00024740
+Burst Sort,500,157,0.00022850
+Burst Sort,500,158,0.00034530
+Burst Sort,500,159,0.00031790
+Burst Sort,500,160,0.00037660
+Burst Sort,500,161,0.00022420
+Burst Sort,500,162,0.00042540
+Burst Sort,500,163,0.00038580
+Burst Sort,500,164,0.00038700
+Burst Sort,500,165,0.00037760
+Burst Sort,500,166,0.00038150
+Burst Sort,500,167,0.00023060
+Burst Sort,500,168,0.00029000
+Burst Sort,500,169,0.00029220
+Burst Sort,500,170,0.00026110
+Burst Sort,500,171,0.00036040
+Burst Sort,500,172,0.00035470
+Burst Sort,500,173,0.00032500
+Burst Sort,500,174,0.00035390
+Burst Sort,500,175,0.00030490
+Burst Sort,500,176,0.00037450
+Burst Sort,500,177,0.00036390
+Burst Sort,500,178,0.00038880
+Burst Sort,500,179,0.00035830
+Burst Sort,500,180,0.00037930
+Burst Sort,500,181,0.00036670
+Burst Sort,500,182,0.00037320
+Burst Sort,500,183,0.00035610
+Burst Sort,500,184,0.00037380
+Burst Sort,500,185,0.00024260
+Burst Sort,500,186,0.00035750
+Burst Sort,500,187,0.00024110
+Burst Sort,500,188,0.00025390
+Burst Sort,500,189,0.00035590
+Burst Sort,500,190,0.00022680
+Burst Sort,500,191,0.00036730
+Burst Sort,500,192,0.00028080
+Burst Sort,500,193,0.00037890
+Burst Sort,500,194,0.00028980
+Burst Sort,500,195,0.00023340
+Burst Sort,500,196,0.00037340
+Burst Sort,500,197,0.00024020
+Burst Sort,500,198,0.00029150
+Burst Sort,500,199,0.00023010
+Burst Sort,500,200,0.00024390
+Burst Sort,500,201,0.00022710
+Burst Sort,500,202,0.00024630
+Burst Sort,500,203,0.00037870
+Burst Sort,500,204,0.00044480
+Burst Sort,500,205,0.00038980
+Burst Sort,500,206,0.00036620
+Burst Sort,500,207,0.00037810
+Burst Sort,500,208,0.00027880
+Burst Sort,500,209,0.00036470
+Burst Sort,500,210,0.00032600
+Burst Sort,500,211,0.00036580
+Burst Sort,500,212,0.00024370
+Burst Sort,500,213,0.00039470
+Burst Sort,500,214,0.00039150
+Burst Sort,500,215,0.00039640
+Burst Sort,500,216,0.00038450
+Burst Sort,500,217,0.00043050
+Burst Sort,500,218,0.00039520
+Burst Sort,500,219,0.00039830
+Burst Sort,500,220,0.00023900
+Burst Sort,500,221,0.00027900
+Burst Sort,500,222,0.00027070
+Burst Sort,500,223,0.00039710
+Burst Sort,500,224,0.00041750
+Burst Sort,500,225,0.00039880
+Burst Sort,500,226,0.00036900
+Burst Sort,500,227,0.00037680
+Burst Sort,500,228,0.00025610
+Burst Sort,500,229,0.00028950
+Burst Sort,500,230,0.00022590
+Burst Sort,500,231,0.00037980
+Burst Sort,500,232,0.00044370
+Burst Sort,500,233,0.00033980
+Burst Sort,500,234,0.00027040
+Burst Sort,500,235,0.00039380
+Burst Sort,500,236,0.00040090
+Burst Sort,500,237,0.00038090
+Burst Sort,500,238,0.00040720
+Burst Sort,500,239,0.00023080
+Burst Sort,500,240,0.00023400
+Burst Sort,500,241,0.00038480
+Burst Sort,500,242,0.00038200
+Burst Sort,500,243,0.00038790
+Burst Sort,500,244,0.00038790
+Burst Sort,500,245,0.00023540
+Burst Sort,500,246,0.00037390
+Burst Sort,500,247,0.00022830
+Burst Sort,500,248,0.00036890
+Burst Sort,500,249,0.00022230
+Burst Sort,500,250,0.00023700
+Burst Sort,500,251,0.00039610
+Burst Sort,500,252,0.00036780
+Burst Sort,500,253,0.00036980
+Burst Sort,500,254,0.00036280
+Burst Sort,500,255,0.00037270
+Burst Sort,500,256,0.00036100
+Burst Sort,500,257,0.00037180
+Burst Sort,500,258,0.00036720
+Burst Sort,500,259,0.00039480
+Burst Sort,500,260,0.00035770
+Burst Sort,500,261,0.00040600
+Burst Sort,500,262,0.00032580
+Burst Sort,500,263,0.00026730
+Burst Sort,500,264,0.00036340
+Burst Sort,500,265,0.00031550
+Burst Sort,500,266,0.00035990
+Burst Sort,500,267,0.00038350
+Burst Sort,500,268,0.00029320
+Burst Sort,500,269,0.00037030
+Burst Sort,500,270,0.00023800
+Burst Sort,500,271,0.00034500
+Burst Sort,500,272,0.00023770
+Burst Sort,500,273,0.00039780
+Burst Sort,500,274,0.00039170
+Burst Sort,500,275,0.00039270
+Burst Sort,500,276,0.00039870
+Burst Sort,500,277,0.00040900
+Burst Sort,500,278,0.00031480
+Burst Sort,500,279,0.00037670
+Burst Sort,500,280,0.00037650
+Burst Sort,500,281,0.00038000
+Burst Sort,500,282,0.00037200
+Burst Sort,500,283,0.00037420
+Burst Sort,500,284,0.00036890
+Burst Sort,500,285,0.00037650
+Burst Sort,500,286,0.00036740
+Burst Sort,500,287,0.00031830
+Burst Sort,500,288,0.00037410
+Burst Sort,500,289,0.00025240
+Burst Sort,500,290,0.00037250
+Burst Sort,500,291,0.00034440
+Burst Sort,500,292,0.00036700
+Burst Sort,500,293,0.00026570
+Burst Sort,500,294,0.00037510
+Burst Sort,500,295,0.00036990
+Burst Sort,500,296,0.00039000
+Burst Sort,500,297,0.00036990
+Burst Sort,500,298,0.00033830
+Burst Sort,500,299,0.00044790
+Burst Sort,500,300,0.00024160
+Burst Sort,500,301,0.00028430
+Burst Sort,500,302,0.00037430
+Burst Sort,500,303,0.00040150
+Burst Sort,500,304,0.00039660
+Burst Sort,500,305,0.00037670
+Burst Sort,500,306,0.00038080
+Burst Sort,500,307,0.00038700
+Burst Sort,500,308,0.00037380
+Burst Sort,500,309,0.00037840
+Burst Sort,500,310,0.00037090
+Burst Sort,500,311,0.00037650
+Burst Sort,500,312,0.00037140
+Burst Sort,500,313,0.00027450
+Burst Sort,500,314,0.00037360
+Burst Sort,500,315,0.00037080
+Burst Sort,500,316,0.00039160
+Burst Sort,500,317,0.00026340
+Burst Sort,500,318,0.00034920
+Burst Sort,500,319,0.00034200
+Burst Sort,500,320,0.00034570
+Burst Sort,500,321,0.00022770
+Burst Sort,500,322,0.00040770
+Burst Sort,500,323,0.00035980
+Burst Sort,500,324,0.00045120
+Burst Sort,500,325,0.00046570
+Burst Sort,500,326,0.00032450
+Burst Sort,500,327,0.00037100
+Burst Sort,500,328,0.00022520
+Burst Sort,500,329,0.00041860
+Burst Sort,500,330,0.00033900
+Burst Sort,500,331,0.00025340
+Burst Sort,500,332,0.00040910
+Burst Sort,500,333,0.00048660
+Burst Sort,500,334,0.00041480
+Burst Sort,500,335,0.00023550
+Burst Sort,500,336,0.00038010
+Burst Sort,500,337,0.00022540
+Burst Sort,500,338,0.00037200
+Burst Sort,500,339,0.00023300
+Burst Sort,500,340,0.00026470
+Burst Sort,500,341,0.00036970
+Burst Sort,500,342,0.00022900
+Burst Sort,500,343,0.00036290
+Burst Sort,500,344,0.00030810
+Burst Sort,500,345,0.00037520
+Burst Sort,500,346,0.00035790
+Burst Sort,500,347,0.00023370
+Burst Sort,500,348,0.00033070
+Burst Sort,500,349,0.00031490
+Burst Sort,500,350,0.00037770
+Burst Sort,500,351,0.00023480
+Burst Sort,500,352,0.00037110
+Burst Sort,500,353,0.00025240
+Burst Sort,500,354,0.00023130
+Burst Sort,500,355,0.00042750
+Burst Sort,500,356,0.00037560
+Burst Sort,500,357,0.00037900
+Burst Sort,500,358,0.00039610
+Burst Sort,500,359,0.00037280
+Burst Sort,500,360,0.00039930
+Burst Sort,500,361,0.00037030
+Burst Sort,500,362,0.00024620
+Burst Sort,500,363,0.00039760
+Burst Sort,500,364,0.00047710
+Burst Sort,500,365,0.00038380
+Burst Sort,500,366,0.00037200
+Burst Sort,500,367,0.00036600
+Burst Sort,500,368,0.00037250
+Burst Sort,500,369,0.00036690
+Burst Sort,500,370,0.00037300
+Burst Sort,500,371,0.00036810
+Burst Sort,500,372,0.00036580
+Burst Sort,500,373,0.00038430
+Burst Sort,500,374,0.00023720
+Burst Sort,500,375,0.00037680
+Burst Sort,500,376,0.00022700
+Burst Sort,500,377,0.00022490
+Burst Sort,500,378,0.00036720
+Burst Sort,500,379,0.00022100
+Burst Sort,500,380,0.00036580
+Burst Sort,500,381,0.00022980
+Burst Sort,500,382,0.00022350
+Burst Sort,500,383,0.00036550
+Burst Sort,500,384,0.00023200
+Burst Sort,500,385,0.00033120
+Burst Sort,500,386,0.00041550
+Burst Sort,500,387,0.00039400
+Burst Sort,500,388,0.00040890
+Burst Sort,500,389,0.00039590
+Burst Sort,500,390,0.00039750
+Burst Sort,500,391,0.00039900
+Burst Sort,500,392,0.00039740
+Burst Sort,500,393,0.00037950
+Burst Sort,500,394,0.00036500
+Burst Sort,500,395,0.00031860
+Burst Sort,500,396,0.00033650
+Burst Sort,500,397,0.00022500
+Burst Sort,500,398,0.00035010
+Burst Sort,500,399,0.00022950
+Burst Sort,500,400,0.00022590
+Burst Sort,500,401,0.00026750
+Burst Sort,500,402,0.00024440
+Burst Sort,500,403,0.00023220
+Burst Sort,500,404,0.00022340
+Burst Sort,500,405,0.00039060
+Burst Sort,500,406,0.00038590
+Burst Sort,500,407,0.00037300
+Burst Sort,500,408,0.00039700
+Burst Sort,500,409,0.00036700
+Burst Sort,500,410,0.00027860
+Burst Sort,500,411,0.00024940
+Burst Sort,500,412,0.00043750
+Burst Sort,500,413,0.00024140
+Burst Sort,500,414,0.00052800
+Burst Sort,500,415,0.00024360
+Burst Sort,500,416,0.00023290
+Burst Sort,500,417,0.00027590
+Burst Sort,500,418,0.00023150
+Burst Sort,500,419,0.00022880
+Burst Sort,500,420,0.00022930
+Burst Sort,500,421,0.00034750
+Burst Sort,500,422,0.00023520
+Burst Sort,500,423,0.00037860
+Burst Sort,500,424,0.00022700
+Burst Sort,500,425,0.00022820
+Burst Sort,500,426,0.00036910
+Burst Sort,500,427,0.00022520
+Burst Sort,500,428,0.00036950
+Burst Sort,500,429,0.00037940
+Burst Sort,500,430,0.00039180
+Burst Sort,500,431,0.00040880
+Burst Sort,500,432,0.00030700
+Burst Sort,500,433,0.00027780
+Burst Sort,500,434,0.00032570
+Burst Sort,500,435,0.00024280
+Burst Sort,500,436,0.00039460
+Burst Sort,500,437,0.00037060
+Burst Sort,500,438,0.00034960
+Burst Sort,500,439,0.00037780
+Burst Sort,500,440,0.00033350
+Burst Sort,500,441,0.00036170
+Burst Sort,500,442,0.00037580
+Burst Sort,500,443,0.00023420
+Burst Sort,500,444,0.00037520
+Burst Sort,500,445,0.00037310
+Burst Sort,500,446,0.00040430
+Burst Sort,500,447,0.00038010
+Burst Sort,500,448,0.00040980
+Burst Sort,500,449,0.00042480
+Burst Sort,500,450,0.00039690
+Burst Sort,500,451,0.00035690
+Burst Sort,500,452,0.00037210
+Burst Sort,500,453,0.00022930
+Burst Sort,500,454,0.00025130
+Burst Sort,500,455,0.00036810
+Burst Sort,500,456,0.00022910
+Burst Sort,500,457,0.00038790
+Burst Sort,500,458,0.00028890
+Burst Sort,500,459,0.00022810
+Burst Sort,500,460,0.00024260
+Burst Sort,500,461,0.00025960
+Burst Sort,500,462,0.00023310
+Burst Sort,500,463,0.00023320
+Burst Sort,500,464,0.00022780
+Burst Sort,500,465,0.00023440
+Burst Sort,500,466,0.00032830
+Burst Sort,500,467,0.00023300
+Burst Sort,500,468,0.00040220
+Burst Sort,500,469,0.00037790
+Burst Sort,500,470,0.00044620
+Burst Sort,500,471,0.00037390
+Burst Sort,500,472,0.00038940
+Burst Sort,500,473,0.00045960
+Burst Sort,500,474,0.00040260
+Burst Sort,500,475,0.00039290
+Burst Sort,500,476,0.00044680
+Burst Sort,500,477,0.00038970
+Burst Sort,500,478,0.00033660
+Burst Sort,500,479,0.00031560
+Burst Sort,500,480,0.00039250
+Burst Sort,500,481,0.00034250
+Burst Sort,500,482,0.00057270
+Burst Sort,500,483,0.00032230
+Burst Sort,500,484,0.00040880
+Burst Sort,500,485,0.00033060
+Burst Sort,500,486,0.00039720
+Burst Sort,500,487,0.00039700
+Burst Sort,500,488,0.00041330
+Burst Sort,500,489,0.00040880
+Burst Sort,500,490,0.00031860
+Burst Sort,500,491,0.00037710
+Burst Sort,500,492,0.00037830
+Burst Sort,500,493,0.00023660
+Burst Sort,500,494,0.00045470
+Burst Sort,500,495,0.00038160
+Burst Sort,500,496,0.00040710
+Burst Sort,500,497,0.00037570
+Burst Sort,500,498,0.00041730
+Burst Sort,500,499,0.00039160
+Burst Sort,500,500,0.00022870
+Cocktail Sort,500,1,0.01622530
+Cocktail Sort,500,2,0.01389940
+Cocktail Sort,500,3,0.01397630
+Cocktail Sort,500,4,0.01230410
+Cocktail Sort,500,5,0.01289310
+Cocktail Sort,500,6,0.01182820
+Cocktail Sort,500,7,0.01199490
+Cocktail Sort,500,8,0.01191770
+Cocktail Sort,500,9,0.01360420
+Cocktail Sort,500,10,0.01314030
+Cocktail Sort,500,11,0.01289300
+Cocktail Sort,500,12,0.01369260
+Cocktail Sort,500,13,0.01193960
+Cocktail Sort,500,14,0.01468060
+Cocktail Sort,500,15,0.01387000
+Cocktail Sort,500,16,0.01536190
+Cocktail Sort,500,17,0.01399850
+Cocktail Sort,500,18,0.01124910
+Cocktail Sort,500,19,0.01291240
+Cocktail Sort,500,20,0.01346620
+Cocktail Sort,500,21,0.01296470
+Cocktail Sort,500,22,0.01060930
+Cocktail Sort,500,23,0.01159470
+Cocktail Sort,500,24,0.01206650
+Cocktail Sort,500,25,0.01304430
+Cocktail Sort,500,26,0.01090030
+Cocktail Sort,500,27,0.01328910
+Cocktail Sort,500,28,0.01403260
+Cocktail Sort,500,29,0.01258580
+Cocktail Sort,500,30,0.01206320
+Cocktail Sort,500,31,0.01458780
+Cocktail Sort,500,32,0.01462870
+Cocktail Sort,500,33,0.01132730
+Cocktail Sort,500,34,0.01224240
+Cocktail Sort,500,35,0.01450370
+Cocktail Sort,500,36,0.01446150
+Cocktail Sort,500,37,0.01486180
+Cocktail Sort,500,38,0.01284380
+Cocktail Sort,500,39,0.01411530
+Cocktail Sort,500,40,0.01388680
+Cocktail Sort,500,41,0.01499000
+Cocktail Sort,500,42,0.01307530
+Cocktail Sort,500,43,0.01465950
+Cocktail Sort,500,44,0.01563220
+Cocktail Sort,500,45,0.01471410
+Cocktail Sort,500,46,0.01364430
+Cocktail Sort,500,47,0.01362590
+Cocktail Sort,500,48,0.01374850
+Cocktail Sort,500,49,0.01303350
+Cocktail Sort,500,50,0.01308500
+Cocktail Sort,500,51,0.01077400
+Cocktail Sort,500,52,0.01333160
+Cocktail Sort,500,53,0.01322730
+Cocktail Sort,500,54,0.01297980
+Cocktail Sort,500,55,0.01382450
+Cocktail Sort,500,56,0.01114170
+Cocktail Sort,500,57,0.01432590
+Cocktail Sort,500,58,0.01244860
+Cocktail Sort,500,59,0.01130350
+Cocktail Sort,500,60,0.01282900
+Cocktail Sort,500,61,0.01318360
+Cocktail Sort,500,62,0.01112990
+Cocktail Sort,500,63,0.01367610
+Cocktail Sort,500,64,0.01259720
+Cocktail Sort,500,65,0.01292110
+Cocktail Sort,500,66,0.01377440
+Cocktail Sort,500,67,0.01064680
+Cocktail Sort,500,68,0.01407580
+Cocktail Sort,500,69,0.01012390
+Cocktail Sort,500,70,0.01274000
+Cocktail Sort,500,71,0.01449330
+Cocktail Sort,500,72,0.01161050
+Cocktail Sort,500,73,0.01332550
+Cocktail Sort,500,74,0.01152570
+Cocktail Sort,500,75,0.01269520
+Cocktail Sort,500,76,0.01082450
+Cocktail Sort,500,77,0.01121720
+Cocktail Sort,500,78,0.01305890
+Cocktail Sort,500,79,0.01328670
+Cocktail Sort,500,80,0.01333220
+Cocktail Sort,500,81,0.01122810
+Cocktail Sort,500,82,0.01289470
+Cocktail Sort,500,83,0.01217280
+Cocktail Sort,500,84,0.01161070
+Cocktail Sort,500,85,0.01312240
+Cocktail Sort,500,86,0.00972940
+Cocktail Sort,500,87,0.00927700
+Cocktail Sort,500,88,0.01065500
+Cocktail Sort,500,89,0.01113990
+Cocktail Sort,500,90,0.01050440
+Cocktail Sort,500,91,0.01282600
+Cocktail Sort,500,92,0.01276890
+Cocktail Sort,500,93,0.00981070
+Cocktail Sort,500,94,0.01247200
+Cocktail Sort,500,95,0.01296030
+Cocktail Sort,500,96,0.00938420
+Cocktail Sort,500,97,0.01317980
+Cocktail Sort,500,98,0.01142780
+Cocktail Sort,500,99,0.01123560
+Cocktail Sort,500,100,0.01273000
+Cocktail Sort,500,101,0.01332240
+Cocktail Sort,500,102,0.01220560
+Cocktail Sort,500,103,0.01334660
+Cocktail Sort,500,104,0.01433880
+Cocktail Sort,500,105,0.01238210
+Cocktail Sort,500,106,0.01372080
+Cocktail Sort,500,107,0.01398360
+Cocktail Sort,500,108,0.01003070
+Cocktail Sort,500,109,0.01396320
+Cocktail Sort,500,110,0.01248340
+Cocktail Sort,500,111,0.01294040
+Cocktail Sort,500,112,0.01282140
+Cocktail Sort,500,113,0.01228030
+Cocktail Sort,500,114,0.01468640
+Cocktail Sort,500,115,0.01441090
+Cocktail Sort,500,116,0.01528250
+Cocktail Sort,500,117,0.01430290
+Cocktail Sort,500,118,0.01095250
+Cocktail Sort,500,119,0.01037740
+Cocktail Sort,500,120,0.01332240
+Cocktail Sort,500,121,0.01475880
+Cocktail Sort,500,122,0.01379450
+Cocktail Sort,500,123,0.01659990
+Cocktail Sort,500,124,0.01875520
+Cocktail Sort,500,125,0.01567590
+Cocktail Sort,500,126,0.02590350
+Cocktail Sort,500,127,0.01485250
+Cocktail Sort,500,128,0.02153750
+Cocktail Sort,500,129,0.01530810
+Cocktail Sort,500,130,0.01466930
+Cocktail Sort,500,131,0.01412350
+Cocktail Sort,500,132,0.01254950
+Cocktail Sort,500,133,0.01298510
+Cocktail Sort,500,134,0.01345480
+Cocktail Sort,500,135,0.01130390
+Cocktail Sort,500,136,0.01233680
+Cocktail Sort,500,137,0.01302830
+Cocktail Sort,500,138,0.01141360
+Cocktail Sort,500,139,0.01133510
+Cocktail Sort,500,140,0.01466350
+Cocktail Sort,500,141,0.01324870
+Cocktail Sort,500,142,0.01369570
+Cocktail Sort,500,143,0.01189860
+Cocktail Sort,500,144,0.01356330
+Cocktail Sort,500,145,0.01253000
+Cocktail Sort,500,146,0.01342930
+Cocktail Sort,500,147,0.01468000
+Cocktail Sort,500,148,0.01439340
+Cocktail Sort,500,149,0.01436810
+Cocktail Sort,500,150,0.01398210
+Cocktail Sort,500,151,0.01462980
+Cocktail Sort,500,152,0.01451040
+Cocktail Sort,500,153,0.01469900
+Cocktail Sort,500,154,0.01319430
+Cocktail Sort,500,155,0.01258030
+Cocktail Sort,500,156,0.01126040
+Cocktail Sort,500,157,0.01199030
+Cocktail Sort,500,158,0.01154500
+Cocktail Sort,500,159,0.01293960
+Cocktail Sort,500,160,0.01126040
+Cocktail Sort,500,161,0.01190050
+Cocktail Sort,500,162,0.01312280
+Cocktail Sort,500,163,0.01359980
+Cocktail Sort,500,164,0.01044470
+Cocktail Sort,500,165,0.01019840
+Cocktail Sort,500,166,0.01011550
+Cocktail Sort,500,167,0.01145160
+Cocktail Sort,500,168,0.00915950
+Cocktail Sort,500,169,0.01008140
+Cocktail Sort,500,170,0.01301100
+Cocktail Sort,500,171,0.01125060
+Cocktail Sort,500,172,0.00973660
+Cocktail Sort,500,173,0.01212550
+Cocktail Sort,500,174,0.01139150
+Cocktail Sort,500,175,0.00966320
+Cocktail Sort,500,176,0.01323190
+Cocktail Sort,500,177,0.01043230
+Cocktail Sort,500,178,0.01190030
+Cocktail Sort,500,179,0.01408740
+Cocktail Sort,500,180,0.01218760
+Cocktail Sort,500,181,0.01349600
+Cocktail Sort,500,182,0.01119560
+Cocktail Sort,500,183,0.01233460
+Cocktail Sort,500,184,0.01196370
+Cocktail Sort,500,185,0.01189010
+Cocktail Sort,500,186,0.01239500
+Cocktail Sort,500,187,0.01270050
+Cocktail Sort,500,188,0.01358230
+Cocktail Sort,500,189,0.00940960
+Cocktail Sort,500,190,0.01398490
+Cocktail Sort,500,191,0.01134850
+Cocktail Sort,500,192,0.01302190
+Cocktail Sort,500,193,0.01232970
+Cocktail Sort,500,194,0.01274540
+Cocktail Sort,500,195,0.01296960
+Cocktail Sort,500,196,0.01117330
+Cocktail Sort,500,197,0.01293180
+Cocktail Sort,500,198,0.01243800
+Cocktail Sort,500,199,0.01217750
+Cocktail Sort,500,200,0.01150600
+Cocktail Sort,500,201,0.01304570
+Cocktail Sort,500,202,0.00988370
+Cocktail Sort,500,203,0.01205420
+Cocktail Sort,500,204,0.01019060
+Cocktail Sort,500,205,0.01035370
+Cocktail Sort,500,206,0.01247030
+Cocktail Sort,500,207,0.01194510
+Cocktail Sort,500,208,0.01199970
+Cocktail Sort,500,209,0.01385540
+Cocktail Sort,500,210,0.01256230
+Cocktail Sort,500,211,0.01318570
+Cocktail Sort,500,212,0.01196600
+Cocktail Sort,500,213,0.01260940
+Cocktail Sort,500,214,0.01226060
+Cocktail Sort,500,215,0.01000480
+Cocktail Sort,500,216,0.01071180
+Cocktail Sort,500,217,0.00912100
+Cocktail Sort,500,218,0.01374700
+Cocktail Sort,500,219,0.01153560
+Cocktail Sort,500,220,0.01237980
+Cocktail Sort,500,221,0.01104130
+Cocktail Sort,500,222,0.01024940
+Cocktail Sort,500,223,0.01167520
+Cocktail Sort,500,224,0.00980350
+Cocktail Sort,500,225,0.01173280
+Cocktail Sort,500,226,0.01082780
+Cocktail Sort,500,227,0.01010170
+Cocktail Sort,500,228,0.01326060
+Cocktail Sort,500,229,0.01213980
+Cocktail Sort,500,230,0.01353670
+Cocktail Sort,500,231,0.01138290
+Cocktail Sort,500,232,0.01154860
+Cocktail Sort,500,233,0.01417820
+Cocktail Sort,500,234,0.01219790
+Cocktail Sort,500,235,0.01414120
+Cocktail Sort,500,236,0.01347490
+Cocktail Sort,500,237,0.01338030
+Cocktail Sort,500,238,0.01071090
+Cocktail Sort,500,239,0.01070480
+Cocktail Sort,500,240,0.01369270
+Cocktail Sort,500,241,0.01305530
+Cocktail Sort,500,242,0.01255520
+Cocktail Sort,500,243,0.01086110
+Cocktail Sort,500,244,0.01361540
+Cocktail Sort,500,245,0.01177100
+Cocktail Sort,500,246,0.01095860
+Cocktail Sort,500,247,0.01243690
+Cocktail Sort,500,248,0.01000300
+Cocktail Sort,500,249,0.01142340
+Cocktail Sort,500,250,0.01184520
+Cocktail Sort,500,251,0.01363080
+Cocktail Sort,500,252,0.01406320
+Cocktail Sort,500,253,0.01116330
+Cocktail Sort,500,254,0.01127980
+Cocktail Sort,500,255,0.01164740
+Cocktail Sort,500,256,0.01357870
+Cocktail Sort,500,257,0.00902450
+Cocktail Sort,500,258,0.01380750
+Cocktail Sort,500,259,0.01403530
+Cocktail Sort,500,260,0.01362270
+Cocktail Sort,500,261,0.01189910
+Cocktail Sort,500,262,0.01235410
+Cocktail Sort,500,263,0.01098030
+Cocktail Sort,500,264,0.01191520
+Cocktail Sort,500,265,0.01085810
+Cocktail Sort,500,266,0.01225800
+Cocktail Sort,500,267,0.01067320
+Cocktail Sort,500,268,0.01247400
+Cocktail Sort,500,269,0.01166170
+Cocktail Sort,500,270,0.01127320
+Cocktail Sort,500,271,0.01087080
+Cocktail Sort,500,272,0.01134950
+Cocktail Sort,500,273,0.01081940
+Cocktail Sort,500,274,0.01021200
+Cocktail Sort,500,275,0.01009690
+Cocktail Sort,500,276,0.01413280
+Cocktail Sort,500,277,0.01416850
+Cocktail Sort,500,278,0.01244210
+Cocktail Sort,500,279,0.01247020
+Cocktail Sort,500,280,0.01149520
+Cocktail Sort,500,281,0.01172660
+Cocktail Sort,500,282,0.01298760
+Cocktail Sort,500,283,0.01227980
+Cocktail Sort,500,284,0.01317130
+Cocktail Sort,500,285,0.01270260
+Cocktail Sort,500,286,0.01383910
+Cocktail Sort,500,287,0.01089120
+Cocktail Sort,500,288,0.01145290
+Cocktail Sort,500,289,0.01194730
+Cocktail Sort,500,290,0.00914100
+Cocktail Sort,500,291,0.01096720
+Cocktail Sort,500,292,0.01359130
+Cocktail Sort,500,293,0.01141020
+Cocktail Sort,500,294,0.01128620
+Cocktail Sort,500,295,0.01131830
+Cocktail Sort,500,296,0.01165160
+Cocktail Sort,500,297,0.01366990
+Cocktail Sort,500,298,0.01190010
+Cocktail Sort,500,299,0.01181520
+Cocktail Sort,500,300,0.01340100
+Cocktail Sort,500,301,0.00927200
+Cocktail Sort,500,302,0.01056530
+Cocktail Sort,500,303,0.01051320
+Cocktail Sort,500,304,0.00835620
+Cocktail Sort,500,305,0.01369630
+Cocktail Sort,500,306,0.00976610
+Cocktail Sort,500,307,0.01133990
+Cocktail Sort,500,308,0.01044500
+Cocktail Sort,500,309,0.01114880
+Cocktail Sort,500,310,0.01248190
+Cocktail Sort,500,311,0.01197120
+Cocktail Sort,500,312,0.01133870
+Cocktail Sort,500,313,0.01210590
+Cocktail Sort,500,314,0.01060580
+Cocktail Sort,500,315,0.01333330
+Cocktail Sort,500,316,0.01220730
+Cocktail Sort,500,317,0.01267950
+Cocktail Sort,500,318,0.01282680
+Cocktail Sort,500,319,0.01438380
+Cocktail Sort,500,320,0.01405260
+Cocktail Sort,500,321,0.01031990
+Cocktail Sort,500,322,0.01480030
+Cocktail Sort,500,323,0.01217110
+Cocktail Sort,500,324,0.00969910
+Cocktail Sort,500,325,0.01281640
+Cocktail Sort,500,326,0.01122250
+Cocktail Sort,500,327,0.01138620
+Cocktail Sort,500,328,0.00974720
+Cocktail Sort,500,329,0.01223030
+Cocktail Sort,500,330,0.01263570
+Cocktail Sort,500,331,0.01187420
+Cocktail Sort,500,332,0.01252350
+Cocktail Sort,500,333,0.01262710
+Cocktail Sort,500,334,0.01392870
+Cocktail Sort,500,335,0.01079670
+Cocktail Sort,500,336,0.01067020
+Cocktail Sort,500,337,0.01116990
+Cocktail Sort,500,338,0.01046410
+Cocktail Sort,500,339,0.01091500
+Cocktail Sort,500,340,0.01337170
+Cocktail Sort,500,341,0.01232840
+Cocktail Sort,500,342,0.00936140
+Cocktail Sort,500,343,0.01203320
+Cocktail Sort,500,344,0.00935200
+Cocktail Sort,500,345,0.01050380
+Cocktail Sort,500,346,0.01207750
+Cocktail Sort,500,347,0.01162640
+Cocktail Sort,500,348,0.01116590
+Cocktail Sort,500,349,0.01272530
+Cocktail Sort,500,350,0.01214510
+Cocktail Sort,500,351,0.01272580
+Cocktail Sort,500,352,0.01365290
+Cocktail Sort,500,353,0.01369910
+Cocktail Sort,500,354,0.01221770
+Cocktail Sort,500,355,0.01153300
+Cocktail Sort,500,356,0.01249040
+Cocktail Sort,500,357,0.01105030
+Cocktail Sort,500,358,0.01135030
+Cocktail Sort,500,359,0.00929430
+Cocktail Sort,500,360,0.01338970
+Cocktail Sort,500,361,0.01129840
+Cocktail Sort,500,362,0.01150340
+Cocktail Sort,500,363,0.01143770
+Cocktail Sort,500,364,0.01185290
+Cocktail Sort,500,365,0.01140990
+Cocktail Sort,500,366,0.01067650
+Cocktail Sort,500,367,0.01157350
+Cocktail Sort,500,368,0.01149420
+Cocktail Sort,500,369,0.01309760
+Cocktail Sort,500,370,0.01240370
+Cocktail Sort,500,371,0.01265400
+Cocktail Sort,500,372,0.00878710
+Cocktail Sort,500,373,0.01127950
+Cocktail Sort,500,374,0.01265690
+Cocktail Sort,500,375,0.01163300
+Cocktail Sort,500,376,0.01077070
+Cocktail Sort,500,377,0.01354320
+Cocktail Sort,500,378,0.01160040
+Cocktail Sort,500,379,0.00981450
+Cocktail Sort,500,380,0.01161240
+Cocktail Sort,500,381,0.01152930
+Cocktail Sort,500,382,0.01180300
+Cocktail Sort,500,383,0.01156760
+Cocktail Sort,500,384,0.01028010
+Cocktail Sort,500,385,0.01175590
+Cocktail Sort,500,386,0.01039150
+Cocktail Sort,500,387,0.00901820
+Cocktail Sort,500,388,0.00965640
+Cocktail Sort,500,389,0.00987180
+Cocktail Sort,500,390,0.01098410
+Cocktail Sort,500,391,0.01319840
+Cocktail Sort,500,392,0.00954950
+Cocktail Sort,500,393,0.01324880
+Cocktail Sort,500,394,0.01022920
+Cocktail Sort,500,395,0.01045540
+Cocktail Sort,500,396,0.01178720
+Cocktail Sort,500,397,0.01108190
+Cocktail Sort,500,398,0.01310680
+Cocktail Sort,500,399,0.00954170
+Cocktail Sort,500,400,0.01011380
+Cocktail Sort,500,401,0.01015030
+Cocktail Sort,500,402,0.00832010
+Cocktail Sort,500,403,0.01176640
+Cocktail Sort,500,404,0.01058740
+Cocktail Sort,500,405,0.01128560
+Cocktail Sort,500,406,0.01062140
+Cocktail Sort,500,407,0.01117050
+Cocktail Sort,500,408,0.01270730
+Cocktail Sort,500,409,0.01250300
+Cocktail Sort,500,410,0.01189530
+Cocktail Sort,500,411,0.01102530
+Cocktail Sort,500,412,0.01152220
+Cocktail Sort,500,413,0.01306550
+Cocktail Sort,500,414,0.01135680
+Cocktail Sort,500,415,0.01247180
+Cocktail Sort,500,416,0.01080180
+Cocktail Sort,500,417,0.01281260
+Cocktail Sort,500,418,0.01138240
+Cocktail Sort,500,419,0.00969840
+Cocktail Sort,500,420,0.01472050
+Cocktail Sort,500,421,0.01117910
+Cocktail Sort,500,422,0.00966520
+Cocktail Sort,500,423,0.01031330
+Cocktail Sort,500,424,0.01359030
+Cocktail Sort,500,425,0.01261450
+Cocktail Sort,500,426,0.01400650
+Cocktail Sort,500,427,0.01285310
+Cocktail Sort,500,428,0.00886670
+Cocktail Sort,500,429,0.01200210
+Cocktail Sort,500,430,0.00863460
+Cocktail Sort,500,431,0.01105460
+Cocktail Sort,500,432,0.01055470
+Cocktail Sort,500,433,0.01175470
+Cocktail Sort,500,434,0.01422140
+Cocktail Sort,500,435,0.01163490
+Cocktail Sort,500,436,0.01364820
+Cocktail Sort,500,437,0.00925210
+Cocktail Sort,500,438,0.01105930
+Cocktail Sort,500,439,0.00972680
+Cocktail Sort,500,440,0.01452070
+Cocktail Sort,500,441,0.01380740
+Cocktail Sort,500,442,0.00994070
+Cocktail Sort,500,443,0.01113350
+Cocktail Sort,500,444,0.01095410
+Cocktail Sort,500,445,0.01168560
+Cocktail Sort,500,446,0.01242670
+Cocktail Sort,500,447,0.01250660
+Cocktail Sort,500,448,0.01347930
+Cocktail Sort,500,449,0.01349150
+Cocktail Sort,500,450,0.00932820
+Cocktail Sort,500,451,0.01176770
+Cocktail Sort,500,452,0.00934600
+Cocktail Sort,500,453,0.01057750
+Cocktail Sort,500,454,0.01314950
+Cocktail Sort,500,455,0.00851380
+Cocktail Sort,500,456,0.01140580
+Cocktail Sort,500,457,0.01136610
+Cocktail Sort,500,458,0.01013470
+Cocktail Sort,500,459,0.01186720
+Cocktail Sort,500,460,0.01266090
+Cocktail Sort,500,461,0.01012980
+Cocktail Sort,500,462,0.01296680
+Cocktail Sort,500,463,0.00861970
+Cocktail Sort,500,464,0.00924450
+Cocktail Sort,500,465,0.01197430
+Cocktail Sort,500,466,0.01006430
+Cocktail Sort,500,467,0.01093130
+Cocktail Sort,500,468,0.01162580
+Cocktail Sort,500,469,0.01178410
+Cocktail Sort,500,470,0.01136060
+Cocktail Sort,500,471,0.00914870
+Cocktail Sort,500,472,0.01330850
+Cocktail Sort,500,473,0.01435540
+Cocktail Sort,500,474,0.01496840
+Cocktail Sort,500,475,0.01420110
+Cocktail Sort,500,476,0.01576100
+Cocktail Sort,500,477,0.01394870
+Cocktail Sort,500,478,0.01077290
+Cocktail Sort,500,479,0.00910110
+Cocktail Sort,500,480,0.01123340
+Cocktail Sort,500,481,0.01025390
+Cocktail Sort,500,482,0.01413690
+Cocktail Sort,500,483,0.00935950
+Cocktail Sort,500,484,0.01327370
+Cocktail Sort,500,485,0.01172380
+Cocktail Sort,500,486,0.01509960
+Cocktail Sort,500,487,0.01430210
+Cocktail Sort,500,488,0.01180690
+Cocktail Sort,500,489,0.01226150
+Cocktail Sort,500,490,0.01099730
+Cocktail Sort,500,491,0.01337770
+Cocktail Sort,500,492,0.01156410
+Cocktail Sort,500,493,0.01181300
+Cocktail Sort,500,494,0.01055330
+Cocktail Sort,500,495,0.01141780
+Cocktail Sort,500,496,0.01080470
+Cocktail Sort,500,497,0.01054160
+Cocktail Sort,500,498,0.01212080
+Cocktail Sort,500,499,0.01271720
+Cocktail Sort,500,500,0.01294860
+Comb Sort,500,1,0.00071720
+Comb Sort,500,2,0.00096890
+Comb Sort,500,3,0.00075120
+Comb Sort,500,4,0.00099150
+Comb Sort,500,5,0.00099810
+Comb Sort,500,6,0.00098860
+Comb Sort,500,7,0.00056570
+Comb Sort,500,8,0.00063200
+Comb Sort,500,9,0.00145220
+Comb Sort,500,10,0.00112240
+Comb Sort,500,11,0.00095730
+Comb Sort,500,12,0.00098700
+Comb Sort,500,13,0.00127190
+Comb Sort,500,14,0.00108130
+Comb Sort,500,15,0.00104100
+Comb Sort,500,16,0.00147710
+Comb Sort,500,17,0.00105570
+Comb Sort,500,18,0.00122890
+Comb Sort,500,19,0.00098390
+Comb Sort,500,20,0.00100420
+Comb Sort,500,21,0.00094010
+Comb Sort,500,22,0.00104230
+Comb Sort,500,23,0.00104270
+Comb Sort,500,24,0.00099920
+Comb Sort,500,25,0.00099220
+Comb Sort,500,26,0.00132430
+Comb Sort,500,27,0.00094090
+Comb Sort,500,28,0.00099170
+Comb Sort,500,29,0.00164960
+Comb Sort,500,30,0.00103360
+Comb Sort,500,31,0.00196340
+Comb Sort,500,32,0.00092950
+Comb Sort,500,33,0.00087840
+Comb Sort,500,34,0.00098490
+Comb Sort,500,35,0.00221630
+Comb Sort,500,36,0.00099060
+Comb Sort,500,37,0.00102400
+Comb Sort,500,38,0.00104120
+Comb Sort,500,39,0.00098690
+Comb Sort,500,40,0.00112310
+Comb Sort,500,41,0.00098070
+Comb Sort,500,42,0.00098690
+Comb Sort,500,43,0.00136770
+Comb Sort,500,44,0.00092140
+Comb Sort,500,45,0.00098670
+Comb Sort,500,46,0.00095340
+Comb Sort,500,47,0.00104840
+Comb Sort,500,48,0.00104070
+Comb Sort,500,49,0.00120130
+Comb Sort,500,50,0.00102720
+Comb Sort,500,51,0.00098410
+Comb Sort,500,52,0.00084900
+Comb Sort,500,53,0.00104230
+Comb Sort,500,54,0.00102100
+Comb Sort,500,55,0.00102460
+Comb Sort,500,56,0.00087470
+Comb Sort,500,57,0.00107260
+Comb Sort,500,58,0.00068540
+Comb Sort,500,59,0.00083650
+Comb Sort,500,60,0.00093010
+Comb Sort,500,61,0.00093170
+Comb Sort,500,62,0.00100960
+Comb Sort,500,63,0.00096270
+Comb Sort,500,64,0.00097610
+Comb Sort,500,65,0.00102390
+Comb Sort,500,66,0.00099550
+Comb Sort,500,67,0.00096710
+Comb Sort,500,68,0.00104650
+Comb Sort,500,69,0.00098930
+Comb Sort,500,70,0.00101270
+Comb Sort,500,71,0.00099200
+Comb Sort,500,72,0.00099730
+Comb Sort,500,73,0.00097180
+Comb Sort,500,74,0.00099370
+Comb Sort,500,75,0.00100160
+Comb Sort,500,76,0.00086710
+Comb Sort,500,77,0.00056780
+Comb Sort,500,78,0.00102640
+Comb Sort,500,79,0.00063770
+Comb Sort,500,80,0.00097550
+Comb Sort,500,81,0.00067540
+Comb Sort,500,82,0.00064290
+Comb Sort,500,83,0.00075990
+Comb Sort,500,84,0.00083260
+Comb Sort,500,85,0.00059550
+Comb Sort,500,86,0.00096060
+Comb Sort,500,87,0.00062790
+Comb Sort,500,88,0.00107470
+Comb Sort,500,89,0.00061930
+Comb Sort,500,90,0.00097930
+Comb Sort,500,91,0.00099990
+Comb Sort,500,92,0.00065460
+Comb Sort,500,93,0.00066010
+Comb Sort,500,94,0.00092960
+Comb Sort,500,95,0.00059750
+Comb Sort,500,96,0.00089220
+Comb Sort,500,97,0.00093230
+Comb Sort,500,98,0.00100200
+Comb Sort,500,99,0.00099610
+Comb Sort,500,100,0.00094260
+Comb Sort,500,101,0.00102330
+Comb Sort,500,102,0.00099060
+Comb Sort,500,103,0.00098010
+Comb Sort,500,104,0.00098840
+Comb Sort,500,105,0.00097630
+Comb Sort,500,106,0.00098690
+Comb Sort,500,107,0.00088640
+Comb Sort,500,108,0.00071050
+Comb Sort,500,109,0.00102700
+Comb Sort,500,110,0.00058320
+Comb Sort,500,111,0.00060000
+Comb Sort,500,112,0.00134980
+Comb Sort,500,113,0.00054300
+Comb Sort,500,114,0.00097390
+Comb Sort,500,115,0.00089760
+Comb Sort,500,116,0.00097560
+Comb Sort,500,117,0.00065240
+Comb Sort,500,118,0.00082020
+Comb Sort,500,119,0.00100070
+Comb Sort,500,120,0.00095010
+Comb Sort,500,121,0.00097500
+Comb Sort,500,122,0.00055910
+Comb Sort,500,123,0.00063750
+Comb Sort,500,124,0.00063020
+Comb Sort,500,125,0.00087300
+Comb Sort,500,126,0.00096890
+Comb Sort,500,127,0.00104470
+Comb Sort,500,128,0.00093890
+Comb Sort,500,129,0.00105250
+Comb Sort,500,130,0.00121420
+Comb Sort,500,131,0.00128130
+Comb Sort,500,132,0.00148110
+Comb Sort,500,133,0.00103970
+Comb Sort,500,134,0.00104060
+Comb Sort,500,135,0.00117030
+Comb Sort,500,136,0.00130450
+Comb Sort,500,137,0.00101900
+Comb Sort,500,138,0.00117350
+Comb Sort,500,139,0.00098930
+Comb Sort,500,140,0.00115080
+Comb Sort,500,141,0.00099990
+Comb Sort,500,142,0.00078160
+Comb Sort,500,143,0.00072830
+Comb Sort,500,144,0.00096970
+Comb Sort,500,145,0.00099550
+Comb Sort,500,146,0.00079290
+Comb Sort,500,147,0.00103530
+Comb Sort,500,148,0.00079800
+Comb Sort,500,149,0.00099940
+Comb Sort,500,150,0.00100200
+Comb Sort,500,151,0.00094050
+Comb Sort,500,152,0.00099560
+Comb Sort,500,153,0.00092270
+Comb Sort,500,154,0.00081710
+Comb Sort,500,155,0.00081210
+Comb Sort,500,156,0.00104790
+Comb Sort,500,157,0.00093720
+Comb Sort,500,158,0.00090430
+Comb Sort,500,159,0.00093870
+Comb Sort,500,160,0.00082690
+Comb Sort,500,161,0.00098670
+Comb Sort,500,162,0.00103580
+Comb Sort,500,163,0.00079610
+Comb Sort,500,164,0.00098930
+Comb Sort,500,165,0.00096350
+Comb Sort,500,166,0.00099000
+Comb Sort,500,167,0.00063050
+Comb Sort,500,168,0.00114870
+Comb Sort,500,169,0.00089850
+Comb Sort,500,170,0.00099200
+Comb Sort,500,171,0.00059620
+Comb Sort,500,172,0.00063010
+Comb Sort,500,173,0.00098540
+Comb Sort,500,174,0.00058890
+Comb Sort,500,175,0.00097470
+Comb Sort,500,176,0.00072590
+Comb Sort,500,177,0.00094490
+Comb Sort,500,178,0.00070150
+Comb Sort,500,179,0.00097550
+Comb Sort,500,180,0.00097990
+Comb Sort,500,181,0.00104130
+Comb Sort,500,182,0.00102230
+Comb Sort,500,183,0.00095360
+Comb Sort,500,184,0.00099930
+Comb Sort,500,185,0.00097290
+Comb Sort,500,186,0.00089360
+Comb Sort,500,187,0.00055050
+Comb Sort,500,188,0.00081990
+Comb Sort,500,189,0.00057830
+Comb Sort,500,190,0.00065440
+Comb Sort,500,191,0.00057730
+Comb Sort,500,192,0.00088650
+Comb Sort,500,193,0.00096470
+Comb Sort,500,194,0.00087050
+Comb Sort,500,195,0.00098430
+Comb Sort,500,196,0.00081630
+Comb Sort,500,197,0.00098300
+Comb Sort,500,198,0.00099730
+Comb Sort,500,199,0.00098000
+Comb Sort,500,200,0.00097590
+Comb Sort,500,201,0.00110840
+Comb Sort,500,202,0.00093050
+Comb Sort,500,203,0.00102190
+Comb Sort,500,204,0.00098050
+Comb Sort,500,205,0.00104150
+Comb Sort,500,206,0.00098730
+Comb Sort,500,207,0.00103300
+Comb Sort,500,208,0.00094300
+Comb Sort,500,209,0.00098030
+Comb Sort,500,210,0.00096300
+Comb Sort,500,211,0.00091090
+Comb Sort,500,212,0.00084580
+Comb Sort,500,213,0.00146110
+Comb Sort,500,214,0.00083720
+Comb Sort,500,215,0.00087060
+Comb Sort,500,216,0.00105920
+Comb Sort,500,217,0.00099100
+Comb Sort,500,218,0.00086690
+Comb Sort,500,219,0.00102310
+Comb Sort,500,220,0.00104950
+Comb Sort,500,221,0.00063260
+Comb Sort,500,222,0.00063100
+Comb Sort,500,223,0.00078150
+Comb Sort,500,224,0.00073200
+Comb Sort,500,225,0.00064150
+Comb Sort,500,226,0.00060450
+Comb Sort,500,227,0.00097430
+Comb Sort,500,228,0.00073570
+Comb Sort,500,229,0.00064450
+Comb Sort,500,230,0.00088110
+Comb Sort,500,231,0.00099710
+Comb Sort,500,232,0.00107950
+Comb Sort,500,233,0.00086000
+Comb Sort,500,234,0.00058580
+Comb Sort,500,235,0.00091050
+Comb Sort,500,236,0.00087690
+Comb Sort,500,237,0.00099580
+Comb Sort,500,238,0.00098740
+Comb Sort,500,239,0.00088830
+Comb Sort,500,240,0.00070600
+Comb Sort,500,241,0.00073570
+Comb Sort,500,242,0.00122320
+Comb Sort,500,243,0.00081420
+Comb Sort,500,244,0.00098440
+Comb Sort,500,245,0.00063580
+Comb Sort,500,246,0.00067370
+Comb Sort,500,247,0.00102740
+Comb Sort,500,248,0.00069400
+Comb Sort,500,249,0.00097610
+Comb Sort,500,250,0.00066460
+Comb Sort,500,251,0.00099260
+Comb Sort,500,252,0.00097050
+Comb Sort,500,253,0.00074350
+Comb Sort,500,254,0.00100960
+Comb Sort,500,255,0.00096290
+Comb Sort,500,256,0.00084800
+Comb Sort,500,257,0.00061980
+Comb Sort,500,258,0.00069620
+Comb Sort,500,259,0.00078250
+Comb Sort,500,260,0.00109360
+Comb Sort,500,261,0.00059540
+Comb Sort,500,262,0.00079010
+Comb Sort,500,263,0.00104200
+Comb Sort,500,264,0.00077170
+Comb Sort,500,265,0.00097120
+Comb Sort,500,266,0.00110680
+Comb Sort,500,267,0.00096090
+Comb Sort,500,268,0.00089430
+Comb Sort,500,269,0.00102110
+Comb Sort,500,270,0.00110670
+Comb Sort,500,271,0.00085370
+Comb Sort,500,272,0.00104100
+Comb Sort,500,273,0.00099990
+Comb Sort,500,274,0.00131220
+Comb Sort,500,275,0.00106990
+Comb Sort,500,276,0.00100270
+Comb Sort,500,277,0.00107310
+Comb Sort,500,278,0.00101100
+Comb Sort,500,279,0.00105740
+Comb Sort,500,280,0.00099970
+Comb Sort,500,281,0.00085630
+Comb Sort,500,282,0.00097920
+Comb Sort,500,283,0.00110110
+Comb Sort,500,284,0.00129960
+Comb Sort,500,285,0.00113330
+Comb Sort,500,286,0.00059540
+Comb Sort,500,287,0.00099150
+Comb Sort,500,288,0.00093420
+Comb Sort,500,289,0.00090070
+Comb Sort,500,290,0.00094300
+Comb Sort,500,291,0.00097660
+Comb Sort,500,292,0.00092540
+Comb Sort,500,293,0.00100650
+Comb Sort,500,294,0.00097770
+Comb Sort,500,295,0.00074510
+Comb Sort,500,296,0.00096940
+Comb Sort,500,297,0.00098080
+Comb Sort,500,298,0.00098950
+Comb Sort,500,299,0.00095120
+Comb Sort,500,300,0.00077920
+Comb Sort,500,301,0.00101640
+Comb Sort,500,302,0.00079330
+Comb Sort,500,303,0.00104450
+Comb Sort,500,304,0.00059250
+Comb Sort,500,305,0.00098280
+Comb Sort,500,306,0.00133930
+Comb Sort,500,307,0.00096870
+Comb Sort,500,308,0.00146810
+Comb Sort,500,309,0.00104060
+Comb Sort,500,310,0.00095550
+Comb Sort,500,311,0.00112750
+Comb Sort,500,312,0.00097110
+Comb Sort,500,313,0.00099970
+Comb Sort,500,314,0.00101750
+Comb Sort,500,315,0.00078220
+Comb Sort,500,316,0.00093070
+Comb Sort,500,317,0.00098970
+Comb Sort,500,318,0.00104050
+Comb Sort,500,319,0.00099190
+Comb Sort,500,320,0.00092950
+Comb Sort,500,321,0.00095350
+Comb Sort,500,322,0.00099830
+Comb Sort,500,323,0.00098510
+Comb Sort,500,324,0.00098200
+Comb Sort,500,325,0.00182140
+Comb Sort,500,326,0.00098360
+Comb Sort,500,327,0.00098840
+Comb Sort,500,328,0.00158770
+Comb Sort,500,329,0.00098630
+Comb Sort,500,330,0.00066590
+Comb Sort,500,331,0.00099530
+Comb Sort,500,332,0.00108660
+Comb Sort,500,333,0.00096210
+Comb Sort,500,334,0.00091720
+Comb Sort,500,335,0.00079520
+Comb Sort,500,336,0.00097910
+Comb Sort,500,337,0.00103080
+Comb Sort,500,338,0.00107970
+Comb Sort,500,339,0.00095690
+Comb Sort,500,340,0.00092230
+Comb Sort,500,341,0.00099200
+Comb Sort,500,342,0.00102380
+Comb Sort,500,343,0.00115780
+Comb Sort,500,344,0.00079260
+Comb Sort,500,345,0.00081540
+Comb Sort,500,346,0.00058430
+Comb Sort,500,347,0.00107730
+Comb Sort,500,348,0.00109550
+Comb Sort,500,349,0.00103900
+Comb Sort,500,350,0.00061750
+Comb Sort,500,351,0.00077580
+Comb Sort,500,352,0.00105470
+Comb Sort,500,353,0.00067010
+Comb Sort,500,354,0.00099800
+Comb Sort,500,355,0.00099660
+Comb Sort,500,356,0.00100460
+Comb Sort,500,357,0.00099050
+Comb Sort,500,358,0.00104450
+Comb Sort,500,359,0.00100590
+Comb Sort,500,360,0.00076440
+Comb Sort,500,361,0.00057620
+Comb Sort,500,362,0.00095690
+Comb Sort,500,363,0.00076160
+Comb Sort,500,364,0.00063360
+Comb Sort,500,365,0.00099210
+Comb Sort,500,366,0.00098760
+Comb Sort,500,367,0.00106210
+Comb Sort,500,368,0.00097610
+Comb Sort,500,369,0.00101300
+Comb Sort,500,370,0.00087830
+Comb Sort,500,371,0.00103710
+Comb Sort,500,372,0.00055390
+Comb Sort,500,373,0.00068310
+Comb Sort,500,374,0.00094820
+Comb Sort,500,375,0.00101170
+Comb Sort,500,376,0.00119740
+Comb Sort,500,377,0.00089470
+Comb Sort,500,378,0.00067020
+Comb Sort,500,379,0.00095810
+Comb Sort,500,380,0.00057240
+Comb Sort,500,381,0.00091100
+Comb Sort,500,382,0.00080030
+Comb Sort,500,383,0.00071200
+Comb Sort,500,384,0.00080780
+Comb Sort,500,385,0.00099290
+Comb Sort,500,386,0.00077810
+Comb Sort,500,387,0.00101730
+Comb Sort,500,388,0.00092450
+Comb Sort,500,389,0.00100500
+Comb Sort,500,390,0.00083760
+Comb Sort,500,391,0.00080040
+Comb Sort,500,392,0.00077440
+Comb Sort,500,393,0.00091350
+Comb Sort,500,394,0.00068560
+Comb Sort,500,395,0.00098770
+Comb Sort,500,396,0.00099030
+Comb Sort,500,397,0.00100150
+Comb Sort,500,398,0.00093180
+Comb Sort,500,399,0.00107490
+Comb Sort,500,400,0.00069290
+Comb Sort,500,401,0.00058200
+Comb Sort,500,402,0.00098180
+Comb Sort,500,403,0.00066280
+Comb Sort,500,404,0.00099310
+Comb Sort,500,405,0.00060070
+Comb Sort,500,406,0.00058280
+Comb Sort,500,407,0.00099230
+Comb Sort,500,408,0.00068390
+Comb Sort,500,409,0.00107750
+Comb Sort,500,410,0.00083360
+Comb Sort,500,411,0.00099080
+Comb Sort,500,412,0.00069810
+Comb Sort,500,413,0.00097290
+Comb Sort,500,414,0.00114630
+Comb Sort,500,415,0.00083070
+Comb Sort,500,416,0.00081860
+Comb Sort,500,417,0.00059970
+Comb Sort,500,418,0.00106240
+Comb Sort,500,419,0.00081310
+Comb Sort,500,420,0.00169560
+Comb Sort,500,421,0.00099850
+Comb Sort,500,422,0.00118370
+Comb Sort,500,423,0.00102080
+Comb Sort,500,424,0.00107960
+Comb Sort,500,425,0.00123410
+Comb Sort,500,426,0.00119650
+Comb Sort,500,427,0.00096730
+Comb Sort,500,428,0.00104250
+Comb Sort,500,429,0.00115100
+Comb Sort,500,430,0.00104390
+Comb Sort,500,431,0.00103870
+Comb Sort,500,432,0.00099810
+Comb Sort,500,433,0.00107860
+Comb Sort,500,434,0.00101590
+Comb Sort,500,435,0.00106770
+Comb Sort,500,436,0.00109000
+Comb Sort,500,437,0.00108450
+Comb Sort,500,438,0.00088790
+Comb Sort,500,439,0.00093930
+Comb Sort,500,440,0.00083450
+Comb Sort,500,441,0.00074440
+Comb Sort,500,442,0.00069180
+Comb Sort,500,443,0.00064550
+Comb Sort,500,444,0.00101020
+Comb Sort,500,445,0.00086720
+Comb Sort,500,446,0.00100070
+Comb Sort,500,447,0.00086900
+Comb Sort,500,448,0.00104190
+Comb Sort,500,449,0.00088430
+Comb Sort,500,450,0.00091350
+Comb Sort,500,451,0.00088800
+Comb Sort,500,452,0.00085050
+Comb Sort,500,453,0.00084300
+Comb Sort,500,454,0.00099530
+Comb Sort,500,455,0.00099820
+Comb Sort,500,456,0.00059950
+Comb Sort,500,457,0.00099040
+Comb Sort,500,458,0.00066720
+Comb Sort,500,459,0.00100890
+Comb Sort,500,460,0.00066540
+Comb Sort,500,461,0.00092400
+Comb Sort,500,462,0.00104350
+Comb Sort,500,463,0.00097520
+Comb Sort,500,464,0.00094810
+Comb Sort,500,465,0.00088750
+Comb Sort,500,466,0.00096690
+Comb Sort,500,467,0.00061610
+Comb Sort,500,468,0.00101200
+Comb Sort,500,469,0.00101300
+Comb Sort,500,470,0.00058770
+Comb Sort,500,471,0.00099680
+Comb Sort,500,472,0.00060900
+Comb Sort,500,473,0.00074750
+Comb Sort,500,474,0.00100130
+Comb Sort,500,475,0.00116630
+Comb Sort,500,476,0.00089000
+Comb Sort,500,477,0.00135990
+Comb Sort,500,478,0.00097810
+Comb Sort,500,479,0.00111320
+Comb Sort,500,480,0.00068750
+Comb Sort,500,481,0.00072790
+Comb Sort,500,482,0.00100050
+Comb Sort,500,483,0.00107970
+Comb Sort,500,484,0.00101550
+Comb Sort,500,485,0.00103560
+Comb Sort,500,486,0.00123070
+Comb Sort,500,487,0.00084150
+Comb Sort,500,488,0.00100340
+Comb Sort,500,489,0.00100510
+Comb Sort,500,490,0.00093340
+Comb Sort,500,491,0.00099170
+Comb Sort,500,492,0.00074750
+Comb Sort,500,493,0.00074540
+Comb Sort,500,494,0.00058690
+Comb Sort,500,495,0.00060770
+Comb Sort,500,496,0.00072750
+Comb Sort,500,497,0.00064500
+Comb Sort,500,498,0.00058300
+Comb Sort,500,499,0.00077200
+Comb Sort,500,500,0.00098740
+Counting Sort,500,1,0.22134920
+Counting Sort,500,2,0.22076090
+Counting Sort,500,3,0.20692080
+Counting Sort,500,4,0.21077250
+Counting Sort,500,5,0.22778110
+Counting Sort,500,6,0.22866470
+Counting Sort,500,7,0.20895010
+Counting Sort,500,8,0.20639300
+Counting Sort,500,9,0.21546530
+Counting Sort,500,10,0.20399580
+Counting Sort,500,11,0.20218230
+Counting Sort,500,12,0.21064430
+Counting Sort,500,13,0.21010400
+Counting Sort,500,14,0.21845250
+Counting Sort,500,15,0.22114680
+Counting Sort,500,16,0.22252750
+Counting Sort,500,17,0.19470600
+Counting Sort,500,18,0.20155160
+Counting Sort,500,19,0.19950650
+Counting Sort,500,20,0.20437180
+Counting Sort,500,21,0.21331310
+Counting Sort,500,22,0.23329920
+Counting Sort,500,23,0.23682180
+Counting Sort,500,24,0.23768660
+Counting Sort,500,25,0.22577430
+Counting Sort,500,26,0.22795600
+Counting Sort,500,27,0.21719330
+Counting Sort,500,28,0.21464340
+Counting Sort,500,29,0.21082720
+Counting Sort,500,30,0.22436560
+Counting Sort,500,31,0.22833480
+Counting Sort,500,32,0.21649900
+Counting Sort,500,33,0.21444350
+Counting Sort,500,34,0.20944950
+Counting Sort,500,35,0.21284420
+Counting Sort,500,36,0.19330680
+Counting Sort,500,37,0.19426450
+Counting Sort,500,38,0.19320750
+Counting Sort,500,39,0.20613380
+Counting Sort,500,40,0.19578520
+Counting Sort,500,41,0.20481180
+Counting Sort,500,42,0.20896400
+Counting Sort,500,43,0.20101160
+Counting Sort,500,44,0.20099720
+Counting Sort,500,45,0.21415730
+Counting Sort,500,46,0.21962820
+Counting Sort,500,47,0.20778990
+Counting Sort,500,48,0.21004110
+Counting Sort,500,49,0.20559460
+Counting Sort,500,50,0.21700550
+Counting Sort,500,51,0.19721290
+Counting Sort,500,52,0.20698010
+Counting Sort,500,53,0.19366610
+Counting Sort,500,54,0.20890380
+Counting Sort,500,55,0.21064200
+Counting Sort,500,56,0.21722630
+Counting Sort,500,57,0.20759000
+Counting Sort,500,58,0.20644910
+Counting Sort,500,59,0.19718160
+Counting Sort,500,60,0.18764290
+Counting Sort,500,61,0.22037860
+Counting Sort,500,62,0.22426230
+Counting Sort,500,63,0.21454450
+Counting Sort,500,64,0.20950560
+Counting Sort,500,65,0.20543200
+Counting Sort,500,66,0.21600500
+Counting Sort,500,67,0.21310660
+Counting Sort,500,68,0.22376030
+Counting Sort,500,69,0.19346400
+Counting Sort,500,70,0.20289530
+Counting Sort,500,71,0.22006690
+Counting Sort,500,72,0.22235150
+Counting Sort,500,73,0.19515300
+Counting Sort,500,74,0.19800470
+Counting Sort,500,75,0.19696580
+Counting Sort,500,76,0.20116130
+Counting Sort,500,77,0.21773710
+Counting Sort,500,78,0.21092940
+Counting Sort,500,79,0.19206530
+Counting Sort,500,80,0.18973620
+Counting Sort,500,81,0.19093890
+Counting Sort,500,82,0.21625000
+Counting Sort,500,83,0.20692800
+Counting Sort,500,84,0.21509230
+Counting Sort,500,85,0.21459740
+Counting Sort,500,86,0.21574940
+Counting Sort,500,87,0.19665830
+Counting Sort,500,88,0.20070430
+Counting Sort,500,89,0.19836190
+Counting Sort,500,90,0.23474260
+Counting Sort,500,91,0.26661600
+Counting Sort,500,92,0.25612040
+Counting Sort,500,93,0.22451980
+Counting Sort,500,94,0.19528610
+Counting Sort,500,95,0.20872030
+Counting Sort,500,96,0.19864930
+Counting Sort,500,97,0.21050640
+Counting Sort,500,98,0.20954470
+Counting Sort,500,99,0.21072020
+Counting Sort,500,100,0.21071930
+Counting Sort,500,101,0.20169080
+Counting Sort,500,102,0.25480180
+Counting Sort,500,103,0.23773450
+Counting Sort,500,104,0.23283950
+Counting Sort,500,105,0.21745540
+Counting Sort,500,106,0.21681390
+Counting Sort,500,107,0.21183960
+Counting Sort,500,108,0.20398790
+Counting Sort,500,109,0.21193720
+Counting Sort,500,110,0.19131750
+Counting Sort,500,111,0.21461590
+Counting Sort,500,112,0.20534590
+Counting Sort,500,113,0.19333580
+Counting Sort,500,114,0.20344990
+Counting Sort,500,115,0.20795530
+Counting Sort,500,116,0.21493660
+Counting Sort,500,117,0.20374860
+Counting Sort,500,118,0.19483130
+Counting Sort,500,119,0.18907960
+Counting Sort,500,120,0.19932100
+Counting Sort,500,121,0.20320150
+Counting Sort,500,122,0.22441190
+Counting Sort,500,123,0.21562920
+Counting Sort,500,124,0.22216140
+Counting Sort,500,125,0.22456100
+Counting Sort,500,126,0.21762490
+Counting Sort,500,127,0.22056800
+Counting Sort,500,128,0.22352900
+Counting Sort,500,129,0.21047510
+Counting Sort,500,130,0.21968790
+Counting Sort,500,131,0.21339670
+Counting Sort,500,132,0.21941510
+Counting Sort,500,133,0.21326040
+Counting Sort,500,134,0.21124850
+Counting Sort,500,135,0.21281520
+Counting Sort,500,136,0.21224480
+Counting Sort,500,137,0.19491380
+Counting Sort,500,138,0.20741670
+Counting Sort,500,139,0.21910600
+Counting Sort,500,140,0.20127570
+Counting Sort,500,141,0.21523970
+Counting Sort,500,142,0.21045980
+Counting Sort,500,143,0.20651800
+Counting Sort,500,144,0.21515090
+Counting Sort,500,145,0.19942610
+Counting Sort,500,146,0.20546450
+Counting Sort,500,147,0.20465260
+Counting Sort,500,148,0.23414550
+Counting Sort,500,149,0.19586210
+Counting Sort,500,150,0.21144100
+Counting Sort,500,151,0.21551180
+Counting Sort,500,152,0.20376280
+Counting Sort,500,153,0.23493030
+Counting Sort,500,154,0.21275830
+Counting Sort,500,155,0.22132250
+Counting Sort,500,156,0.21181780
+Counting Sort,500,157,0.19837520
+Counting Sort,500,158,0.21151120
+Counting Sort,500,159,0.20954130
+Counting Sort,500,160,0.19956110
+Counting Sort,500,161,0.20120610
+Counting Sort,500,162,0.21823880
+Counting Sort,500,163,0.20737570
+Counting Sort,500,164,0.20942000
+Counting Sort,500,165,0.19899890
+Counting Sort,500,166,0.21481860
+Counting Sort,500,167,0.20225780
+Counting Sort,500,168,0.21600480
+Counting Sort,500,169,0.19990150
+Counting Sort,500,170,0.21226730
+Counting Sort,500,171,0.20229950
+Counting Sort,500,172,0.21836060
+Counting Sort,500,173,0.20155340
+Counting Sort,500,174,0.22260720
+Counting Sort,500,175,0.22157610
+Counting Sort,500,176,0.21559790
+Counting Sort,500,177,0.20098130
+Counting Sort,500,178,0.22909260
+Counting Sort,500,179,0.21623530
+Counting Sort,500,180,0.19072230
+Counting Sort,500,181,0.20372950
+Counting Sort,500,182,0.18867620
+Counting Sort,500,183,0.20874720
+Counting Sort,500,184,0.20337850
+Counting Sort,500,185,0.21403270
+Counting Sort,500,186,0.20335970
+Counting Sort,500,187,0.20949630
+Counting Sort,500,188,0.22209130
+Counting Sort,500,189,0.20699740
+Counting Sort,500,190,0.19720370
+Counting Sort,500,191,0.20729000
+Counting Sort,500,192,0.21502270
+Counting Sort,500,193,0.21534140
+Counting Sort,500,194,0.22126500
+Counting Sort,500,195,0.22337910
+Counting Sort,500,196,0.21605590
+Counting Sort,500,197,0.22036720
+Counting Sort,500,198,0.21754460
+Counting Sort,500,199,0.20878710
+Counting Sort,500,200,0.20039850
+Counting Sort,500,201,0.20116250
+Counting Sort,500,202,0.19075930
+Counting Sort,500,203,0.20484040
+Counting Sort,500,204,0.21228410
+Counting Sort,500,205,0.20813180
+Counting Sort,500,206,0.21544370
+Counting Sort,500,207,0.20960510
+Counting Sort,500,208,0.21341200
+Counting Sort,500,209,0.20061970
+Counting Sort,500,210,0.19925680
+Counting Sort,500,211,0.20295200
+Counting Sort,500,212,0.20209440
+Counting Sort,500,213,0.19536600
+Counting Sort,500,214,0.21172960
+Counting Sort,500,215,0.20354320
+Counting Sort,500,216,0.20129610
+Counting Sort,500,217,0.21151940
+Counting Sort,500,218,0.24463860
+Counting Sort,500,219,0.24700390
+Counting Sort,500,220,0.24243270
+Counting Sort,500,221,0.23233780
+Counting Sort,500,222,0.22136060
+Counting Sort,500,223,0.21651540
+Counting Sort,500,224,0.21824690
+Counting Sort,500,225,0.22322370
+Counting Sort,500,226,0.20411920
+Counting Sort,500,227,0.20187230
+Counting Sort,500,228,0.20748550
+Counting Sort,500,229,0.22406650
+Counting Sort,500,230,0.24505760
+Counting Sort,500,231,0.24413610
+Counting Sort,500,232,0.24879530
+Counting Sort,500,233,0.24130170
+Counting Sort,500,234,0.22774650
+Counting Sort,500,235,0.22517130
+Counting Sort,500,236,0.22320500
+Counting Sort,500,237,0.21117260
+Counting Sort,500,238,0.22469030
+Counting Sort,500,239,0.22644070
+Counting Sort,500,240,0.21833580
+Counting Sort,500,241,0.22664720
+Counting Sort,500,242,0.23280090
+Counting Sort,500,243,0.21092560
+Counting Sort,500,244,0.20824160
+Counting Sort,500,245,0.21712050
+Counting Sort,500,246,0.22762350
+Counting Sort,500,247,0.22824540
+Counting Sort,500,248,0.22981960
+Counting Sort,500,249,0.22556690
+Counting Sort,500,250,0.23105050
+Counting Sort,500,251,0.23378320
+Counting Sort,500,252,0.23413880
+Counting Sort,500,253,0.23533640
+Counting Sort,500,254,0.22978830
+Counting Sort,500,255,0.21756540
+Counting Sort,500,256,0.21405790
+Counting Sort,500,257,0.21441500
+Counting Sort,500,258,0.22141390
+Counting Sort,500,259,0.21143910
+Counting Sort,500,260,0.20584520
+Counting Sort,500,261,0.20017190
+Counting Sort,500,262,0.20268690
+Counting Sort,500,263,0.22545520
+Counting Sort,500,264,0.21944150
+Counting Sort,500,265,0.21025000
+Counting Sort,500,266,0.20204480
+Counting Sort,500,267,0.19747360
+Counting Sort,500,268,0.20801360
+Counting Sort,500,269,0.18387230
+Counting Sort,500,270,0.20565450
+Counting Sort,500,271,0.21082580
+Counting Sort,500,272,0.22450570
+Counting Sort,500,273,0.21323850
+Counting Sort,500,274,0.21986590
+Counting Sort,500,275,0.21457180
+Counting Sort,500,276,0.21746090
+Counting Sort,500,277,0.21828660
+Counting Sort,500,278,0.19798940
+Counting Sort,500,279,0.20187370
+Counting Sort,500,280,0.20412020
+Counting Sort,500,281,0.21282810
+Counting Sort,500,282,0.19643840
+Counting Sort,500,283,0.21654900
+Counting Sort,500,284,0.21307830
+Counting Sort,500,285,0.20045300
+Counting Sort,500,286,0.21971890
+Counting Sort,500,287,0.21235750
+Counting Sort,500,288,0.19984610
+Counting Sort,500,289,0.22075360
+Counting Sort,500,290,0.20937120
+Counting Sort,500,291,0.18713970
+Counting Sort,500,292,0.21137790
+Counting Sort,500,293,0.20859440
+Counting Sort,500,294,0.20475410
+Counting Sort,500,295,0.19285050
+Counting Sort,500,296,0.19128680
+Counting Sort,500,297,0.21528540
+Counting Sort,500,298,0.19119690
+Counting Sort,500,299,0.20615050
+Counting Sort,500,300,0.19816050
+Counting Sort,500,301,0.20129680
+Counting Sort,500,302,0.21089520
+Counting Sort,500,303,0.20069000
+Counting Sort,500,304,0.21204130
+Counting Sort,500,305,0.20990060
+Counting Sort,500,306,0.20861630
+Counting Sort,500,307,0.21254690
+Counting Sort,500,308,0.20086020
+Counting Sort,500,309,0.20816130
+Counting Sort,500,310,0.19723940
+Counting Sort,500,311,0.20269790
+Counting Sort,500,312,0.20933070
+Counting Sort,500,313,0.21206180
+Counting Sort,500,314,0.20022520
+Counting Sort,500,315,0.20291530
+Counting Sort,500,316,0.20881200
+Counting Sort,500,317,0.21227570
+Counting Sort,500,318,0.20873040
+Counting Sort,500,319,0.19385430
+Counting Sort,500,320,0.20854500
+Counting Sort,500,321,0.20669820
+Counting Sort,500,322,0.19371280
+Counting Sort,500,323,0.20938110
+Counting Sort,500,324,0.21934550
+Counting Sort,500,325,0.21229290
+Counting Sort,500,326,0.20646890
+Counting Sort,500,327,0.20486840
+Counting Sort,500,328,0.21008610
+Counting Sort,500,329,0.21543370
+Counting Sort,500,330,0.22166710
+Counting Sort,500,331,0.21109150
+Counting Sort,500,332,0.23043470
+Counting Sort,500,333,0.22126180
+Counting Sort,500,334,0.22760440
+Counting Sort,500,335,0.23162540
+Counting Sort,500,336,0.22814140
+Counting Sort,500,337,0.23369140
+Counting Sort,500,338,0.21573870
+Counting Sort,500,339,0.21812060
+Counting Sort,500,340,0.22960240
+Counting Sort,500,341,0.22595790
+Counting Sort,500,342,0.22060700
+Counting Sort,500,343,0.21619310
+Counting Sort,500,344,0.20521080
+Counting Sort,500,345,0.20663510
+Counting Sort,500,346,0.19819600
+Counting Sort,500,347,0.20837770
+Counting Sort,500,348,0.22240120
+Counting Sort,500,349,0.19840490
+Counting Sort,500,350,0.19361710
+Counting Sort,500,351,0.20310350
+Counting Sort,500,352,0.21252540
+Counting Sort,500,353,0.21573990
+Counting Sort,500,354,0.22298550
+Counting Sort,500,355,0.21383870
+Counting Sort,500,356,0.20846690
+Counting Sort,500,357,0.21766250
+Counting Sort,500,358,0.22190420
+Counting Sort,500,359,0.20119560
+Counting Sort,500,360,0.21418820
+Counting Sort,500,361,0.20281680
+Counting Sort,500,362,0.22032980
+Counting Sort,500,363,0.21210140
+Counting Sort,500,364,0.22143510
+Counting Sort,500,365,0.20944710
+Counting Sort,500,366,0.20352560
+Counting Sort,500,367,0.21657640
+Counting Sort,500,368,0.22415130
+Counting Sort,500,369,0.23009980
+Counting Sort,500,370,0.25559190
+Counting Sort,500,371,0.24560890
+Counting Sort,500,372,0.25401630
+Counting Sort,500,373,0.24190310
+Counting Sort,500,374,0.21747310
+Counting Sort,500,375,0.21455760
+Counting Sort,500,376,0.21496220
+Counting Sort,500,377,0.22225000
+Counting Sort,500,378,0.20876390
+Counting Sort,500,379,0.21329770
+Counting Sort,500,380,0.21180410
+Counting Sort,500,381,0.19715240
+Counting Sort,500,382,0.23439440
+Counting Sort,500,383,0.22814240
+Counting Sort,500,384,0.24456890
+Counting Sort,500,385,0.23253780
+Counting Sort,500,386,0.20575400
+Counting Sort,500,387,0.21518580
+Counting Sort,500,388,0.22371210
+Counting Sort,500,389,0.20036220
+Counting Sort,500,390,0.20161830
+Counting Sort,500,391,0.22384230
+Counting Sort,500,392,0.22669660
+Counting Sort,500,393,0.21295990
+Counting Sort,500,394,0.22179940
+Counting Sort,500,395,0.20361710
+Counting Sort,500,396,0.21411090
+Counting Sort,500,397,0.22083060
+Counting Sort,500,398,0.20973290
+Counting Sort,500,399,0.21327240
+Counting Sort,500,400,0.21321840
+Counting Sort,500,401,0.21030360
+Counting Sort,500,402,0.20881210
+Counting Sort,500,403,0.19943150
+Counting Sort,500,404,0.21623030
+Counting Sort,500,405,0.22412870
+Counting Sort,500,406,0.21675890
+Counting Sort,500,407,0.21096960
+Counting Sort,500,408,0.20478580
+Counting Sort,500,409,0.21564680
+Counting Sort,500,410,0.22418860
+Counting Sort,500,411,0.22001030
+Counting Sort,500,412,0.21341160
+Counting Sort,500,413,0.21525300
+Counting Sort,500,414,0.20611570
+Counting Sort,500,415,0.21471660
+Counting Sort,500,416,0.22878150
+Counting Sort,500,417,0.21636300
+Counting Sort,500,418,0.22666720
+Counting Sort,500,419,0.22075690
+Counting Sort,500,420,0.22199720
+Counting Sort,500,421,0.22468430
+Counting Sort,500,422,0.22166050
+Counting Sort,500,423,0.20168920
+Counting Sort,500,424,0.21391900
+Counting Sort,500,425,0.21681530
+Counting Sort,500,426,0.20553100
+Counting Sort,500,427,0.20725190
+Counting Sort,500,428,0.22507200
+Counting Sort,500,429,0.22731580
+Counting Sort,500,430,0.22380140
+Counting Sort,500,431,0.22436220
+Counting Sort,500,432,0.20778700
+Counting Sort,500,433,0.21839990
+Counting Sort,500,434,0.21236140
+Counting Sort,500,435,0.21674310
+Counting Sort,500,436,0.22406010
+Counting Sort,500,437,0.22095830
+Counting Sort,500,438,0.22570310
+Counting Sort,500,439,0.20451930
+Counting Sort,500,440,0.20381100
+Counting Sort,500,441,0.22129030
+Counting Sort,500,442,0.21633270
+Counting Sort,500,443,0.21984410
+Counting Sort,500,444,0.20864920
+Counting Sort,500,445,0.22885100
+Counting Sort,500,446,0.21048280
+Counting Sort,500,447,0.21368960
+Counting Sort,500,448,0.21427640
+Counting Sort,500,449,0.20916770
+Counting Sort,500,450,0.21685550
+Counting Sort,500,451,0.20858420
+Counting Sort,500,452,0.20933680
+Counting Sort,500,453,0.20655850
+Counting Sort,500,454,0.23341070
+Counting Sort,500,455,0.22043330
+Counting Sort,500,456,0.20781230
+Counting Sort,500,457,0.20194750
+Counting Sort,500,458,0.21843260
+Counting Sort,500,459,0.21840430
+Counting Sort,500,460,0.21606390
+Counting Sort,500,461,0.20973930
+Counting Sort,500,462,0.21490490
+Counting Sort,500,463,0.21960170
+Counting Sort,500,464,0.22001350
+Counting Sort,500,465,0.22620510
+Counting Sort,500,466,0.21715090
+Counting Sort,500,467,0.21934350
+Counting Sort,500,468,0.22845650
+Counting Sort,500,469,0.21244510
+Counting Sort,500,470,0.20353010
+Counting Sort,500,471,0.20922580
+Counting Sort,500,472,0.21128940
+Counting Sort,500,473,0.20964130
+Counting Sort,500,474,0.21212750
+Counting Sort,500,475,0.21551310
+Counting Sort,500,476,0.22554240
+Counting Sort,500,477,0.21089820
+Counting Sort,500,478,0.20421260
+Counting Sort,500,479,0.22445670
+Counting Sort,500,480,0.22132190
+Counting Sort,500,481,0.21509150
+Counting Sort,500,482,0.23238750
+Counting Sort,500,483,0.22688370
+Counting Sort,500,484,0.21575230
+Counting Sort,500,485,0.21416840
+Counting Sort,500,486,0.23125190
+Counting Sort,500,487,0.22485480
+Counting Sort,500,488,0.23276680
+Counting Sort,500,489,0.22331770
+Counting Sort,500,490,0.20681940
+Counting Sort,500,491,0.22294330
+Counting Sort,500,492,0.21068240
+Counting Sort,500,493,0.21122940
+Counting Sort,500,494,0.21699450
+Counting Sort,500,495,0.23152470
+Counting Sort,500,496,0.21683770
+Counting Sort,500,497,0.22528790
+Counting Sort,500,498,0.20493340
+Counting Sort,500,499,0.22298540
+Counting Sort,500,500,0.23920680
+Cubesort,500,1,0.00016000
+Cubesort,500,2,0.00014880
+Cubesort,500,3,0.00013690
+Cubesort,500,4,0.00019660
+Cubesort,500,5,0.00013720
+Cubesort,500,6,0.00013270
+Cubesort,500,7,0.00014250
+Cubesort,500,8,0.00013790
+Cubesort,500,9,0.00013570
+Cubesort,500,10,0.00014630
+Cubesort,500,11,0.00022340
+Cubesort,500,12,0.00013550
+Cubesort,500,13,0.00015230
+Cubesort,500,14,0.00013270
+Cubesort,500,15,0.00015260
+Cubesort,500,16,0.00013270
+Cubesort,500,17,0.00013110
+Cubesort,500,18,0.00021620
+Cubesort,500,19,0.00020040
+Cubesort,500,20,0.00019650
+Cubesort,500,21,0.00024790
+Cubesort,500,22,0.00021480
+Cubesort,500,23,0.00021450
+Cubesort,500,24,0.00021760
+Cubesort,500,25,0.00020340
+Cubesort,500,26,0.00021990
+Cubesort,500,27,0.00022130
+Cubesort,500,28,0.00021440
+Cubesort,500,29,0.00013610
+Cubesort,500,30,0.00014860
+Cubesort,500,31,0.00022100
+Cubesort,500,32,0.00020930
+Cubesort,500,33,0.00019420
+Cubesort,500,34,0.00023650
+Cubesort,500,35,0.00014980
+Cubesort,500,36,0.00028700
+Cubesort,500,37,0.00022250
+Cubesort,500,38,0.00021640
+Cubesort,500,39,0.00017240
+Cubesort,500,40,0.00037290
+Cubesort,500,41,0.00030720
+Cubesort,500,42,0.00028620
+Cubesort,500,43,0.00021930
+Cubesort,500,44,0.00015640
+Cubesort,500,45,0.00013960
+Cubesort,500,46,0.00013900
+Cubesort,500,47,0.00014570
+Cubesort,500,48,0.00021510
+Cubesort,500,49,0.00022140
+Cubesort,500,50,0.00021920
+Cubesort,500,51,0.00019520
+Cubesort,500,52,0.00021730
+Cubesort,500,53,0.00030690
+Cubesort,500,54,0.00018430
+Cubesort,500,55,0.00018140
+Cubesort,500,56,0.00022040
+Cubesort,500,57,0.00017860
+Cubesort,500,58,0.00021920
+Cubesort,500,59,0.00018440
+Cubesort,500,60,0.00023560
+Cubesort,500,61,0.00026070
+Cubesort,500,62,0.00022460
+Cubesort,500,63,0.00024220
+Cubesort,500,64,0.00020890
+Cubesort,500,65,0.00022760
+Cubesort,500,66,0.00013690
+Cubesort,500,67,0.00022330
+Cubesort,500,68,0.00021390
+Cubesort,500,69,0.00016960
+Cubesort,500,70,0.00021070
+Cubesort,500,71,0.00013560
+Cubesort,500,72,0.00020800
+Cubesort,500,73,0.00013360
+Cubesort,500,74,0.00020570
+Cubesort,500,75,0.00014170
+Cubesort,500,76,0.00013290
+Cubesort,500,77,0.00027630
+Cubesort,500,78,0.00024170
+Cubesort,500,79,0.00021360
+Cubesort,500,80,0.00021570
+Cubesort,500,81,0.00021060
+Cubesort,500,82,0.00021600
+Cubesort,500,83,0.00021110
+Cubesort,500,84,0.00022360
+Cubesort,500,85,0.00022580
+Cubesort,500,86,0.00021380
+Cubesort,500,87,0.00021840
+Cubesort,500,88,0.00021590
+Cubesort,500,89,0.00020670
+Cubesort,500,90,0.00021730
+Cubesort,500,91,0.00020820
+Cubesort,500,92,0.00021320
+Cubesort,500,93,0.00020490
+Cubesort,500,94,0.00019810
+Cubesort,500,95,0.00013400
+Cubesort,500,96,0.00018270
+Cubesort,500,97,0.00013710
+Cubesort,500,98,0.00021070
+Cubesort,500,99,0.00021220
+Cubesort,500,100,0.00023870
+Cubesort,500,101,0.00025510
+Cubesort,500,102,0.00021170
+Cubesort,500,103,0.00021740
+Cubesort,500,104,0.00021920
+Cubesort,500,105,0.00021660
+Cubesort,500,106,0.00021060
+Cubesort,500,107,0.00016540
+Cubesort,500,108,0.00013960
+Cubesort,500,109,0.00014050
+Cubesort,500,110,0.00013660
+Cubesort,500,111,0.00013310
+Cubesort,500,112,0.00013510
+Cubesort,500,113,0.00020820
+Cubesort,500,114,0.00021250
+Cubesort,500,115,0.00020220
+Cubesort,500,116,0.00013160
+Cubesort,500,117,0.00021470
+Cubesort,500,118,0.00013140
+Cubesort,500,119,0.00015330
+Cubesort,500,120,0.00014890
+Cubesort,500,121,0.00013460
+Cubesort,500,122,0.00024360
+Cubesort,500,123,0.00022590
+Cubesort,500,124,0.00014050
+Cubesort,500,125,0.00013420
+Cubesort,500,126,0.00020110
+Cubesort,500,127,0.00019790
+Cubesort,500,128,0.00024170
+Cubesort,500,129,0.00022340
+Cubesort,500,130,0.00016280
+Cubesort,500,131,0.00023690
+Cubesort,500,132,0.00013450
+Cubesort,500,133,0.00021690
+Cubesort,500,134,0.00013600
+Cubesort,500,135,0.00017880
+Cubesort,500,136,0.00021300
+Cubesort,500,137,0.00021900
+Cubesort,500,138,0.00023580
+Cubesort,500,139,0.00022240
+Cubesort,500,140,0.00015100
+Cubesort,500,141,0.00014380
+Cubesort,500,142,0.00020690
+Cubesort,500,143,0.00021610
+Cubesort,500,144,0.00013710
+Cubesort,500,145,0.00019920
+Cubesort,500,146,0.00013870
+Cubesort,500,147,0.00021490
+Cubesort,500,148,0.00021930
+Cubesort,500,149,0.00019100
+Cubesort,500,150,0.00024060
+Cubesort,500,151,0.00024560
+Cubesort,500,152,0.00021800
+Cubesort,500,153,0.00027180
+Cubesort,500,154,0.00021950
+Cubesort,500,155,0.00021500
+Cubesort,500,156,0.00022010
+Cubesort,500,157,0.00021510
+Cubesort,500,158,0.00023230
+Cubesort,500,159,0.00020360
+Cubesort,500,160,0.00027480
+Cubesort,500,161,0.00021850
+Cubesort,500,162,0.00021910
+Cubesort,500,163,0.00021840
+Cubesort,500,164,0.00021350
+Cubesort,500,165,0.00019820
+Cubesort,500,166,0.00021940
+Cubesort,500,167,0.00021870
+Cubesort,500,168,0.00021730
+Cubesort,500,169,0.00021580
+Cubesort,500,170,0.00020910
+Cubesort,500,171,0.00013650
+Cubesort,500,172,0.00013740
+Cubesort,500,173,0.00021660
+Cubesort,500,174,0.00013770
+Cubesort,500,175,0.00020770
+Cubesort,500,176,0.00014390
+Cubesort,500,177,0.00024750
+Cubesort,500,178,0.00015700
+Cubesort,500,179,0.00021760
+Cubesort,500,180,0.00019350
+Cubesort,500,181,0.00019720
+Cubesort,500,182,0.00015790
+Cubesort,500,183,0.00019760
+Cubesort,500,184,0.00022460
+Cubesort,500,185,0.00021840
+Cubesort,500,186,0.00021900
+Cubesort,500,187,0.00021910
+Cubesort,500,188,0.00020730
+Cubesort,500,189,0.00021450
+Cubesort,500,190,0.00023290
+Cubesort,500,191,0.00013810
+Cubesort,500,192,0.00022980
+Cubesort,500,193,0.00022960
+Cubesort,500,194,0.00023310
+Cubesort,500,195,0.00021530
+Cubesort,500,196,0.00027770
+Cubesort,500,197,0.00024180
+Cubesort,500,198,0.00033750
+Cubesort,500,199,0.00015140
+Cubesort,500,200,0.00018700
+Cubesort,500,201,0.00020690
+Cubesort,500,202,0.00021910
+Cubesort,500,203,0.00021360
+Cubesort,500,204,0.00021340
+Cubesort,500,205,0.00019690
+Cubesort,500,206,0.00024130
+Cubesort,500,207,0.00022310
+Cubesort,500,208,0.00023100
+Cubesort,500,209,0.00013750
+Cubesort,500,210,0.00015030
+Cubesort,500,211,0.00021490
+Cubesort,500,212,0.00022670
+Cubesort,500,213,0.00021510
+Cubesort,500,214,0.00020810
+Cubesort,500,215,0.00021700
+Cubesort,500,216,0.00013710
+Cubesort,500,217,0.00025980
+Cubesort,500,218,0.00022330
+Cubesort,500,219,0.00021810
+Cubesort,500,220,0.00021900
+Cubesort,500,221,0.00023170
+Cubesort,500,222,0.00014400
+Cubesort,500,223,0.00021240
+Cubesort,500,224,0.00021730
+Cubesort,500,225,0.00022190
+Cubesort,500,226,0.00021290
+Cubesort,500,227,0.00021570
+Cubesort,500,228,0.00022480
+Cubesort,500,229,0.00023070
+Cubesort,500,230,0.00014040
+Cubesort,500,231,0.00021840
+Cubesort,500,232,0.00023390
+Cubesort,500,233,0.00022390
+Cubesort,500,234,0.00022780
+Cubesort,500,235,0.00021070
+Cubesort,500,236,0.00021960
+Cubesort,500,237,0.00020740
+Cubesort,500,238,0.00021670
+Cubesort,500,239,0.00023050
+Cubesort,500,240,0.00021430
+Cubesort,500,241,0.00019000
+Cubesort,500,242,0.00022480
+Cubesort,500,243,0.00021430
+Cubesort,500,244,0.00023130
+Cubesort,500,245,0.00022860
+Cubesort,500,246,0.00021020
+Cubesort,500,247,0.00020870
+Cubesort,500,248,0.00018400
+Cubesort,500,249,0.00020610
+Cubesort,500,250,0.00021890
+Cubesort,500,251,0.00021060
+Cubesort,500,252,0.00026930
+Cubesort,500,253,0.00024490
+Cubesort,500,254,0.00014130
+Cubesort,500,255,0.00021830
+Cubesort,500,256,0.00021250
+Cubesort,500,257,0.00020840
+Cubesort,500,258,0.00022250
+Cubesort,500,259,0.00021910
+Cubesort,500,260,0.00013880
+Cubesort,500,261,0.00023530
+Cubesort,500,262,0.00022560
+Cubesort,500,263,0.00021760
+Cubesort,500,264,0.00022230
+Cubesort,500,265,0.00022120
+Cubesort,500,266,0.00021910
+Cubesort,500,267,0.00022470
+Cubesort,500,268,0.00022030
+Cubesort,500,269,0.00015630
+Cubesort,500,270,0.00023250
+Cubesort,500,271,0.00023460
+Cubesort,500,272,0.00019440
+Cubesort,500,273,0.00018510
+Cubesort,500,274,0.00022930
+Cubesort,500,275,0.00016390
+Cubesort,500,276,0.00023660
+Cubesort,500,277,0.00022980
+Cubesort,500,278,0.00017690
+Cubesort,500,279,0.00015240
+Cubesort,500,280,0.00022430
+Cubesort,500,281,0.00021330
+Cubesort,500,282,0.00014360
+Cubesort,500,283,0.00021230
+Cubesort,500,284,0.00019670
+Cubesort,500,285,0.00022850
+Cubesort,500,286,0.00013870
+Cubesort,500,287,0.00023830
+Cubesort,500,288,0.00021830
+Cubesort,500,289,0.00021710
+Cubesort,500,290,0.00022670
+Cubesort,500,291,0.00014060
+Cubesort,500,292,0.00023640
+Cubesort,500,293,0.00020070
+Cubesort,500,294,0.00021250
+Cubesort,500,295,0.00024130
+Cubesort,500,296,0.00025530
+Cubesort,500,297,0.00025320
+Cubesort,500,298,0.00024670
+Cubesort,500,299,0.00018520
+Cubesort,500,300,0.00014790
+Cubesort,500,301,0.00024970
+Cubesort,500,302,0.00014820
+Cubesort,500,303,0.00023450
+Cubesort,500,304,0.00025390
+Cubesort,500,305,0.00023400
+Cubesort,500,306,0.00022020
+Cubesort,500,307,0.00017430
+Cubesort,500,308,0.00021800
+Cubesort,500,309,0.00022460
+Cubesort,500,310,0.00021570
+Cubesort,500,311,0.00021810
+Cubesort,500,312,0.00021870
+Cubesort,500,313,0.00020680
+Cubesort,500,314,0.00024310
+Cubesort,500,315,0.00022070
+Cubesort,500,316,0.00023260
+Cubesort,500,317,0.00017210
+Cubesort,500,318,0.00023720
+Cubesort,500,319,0.00022050
+Cubesort,500,320,0.00019020
+Cubesort,500,321,0.00025720
+Cubesort,500,322,0.00021630
+Cubesort,500,323,0.00013190
+Cubesort,500,324,0.00021230
+Cubesort,500,325,0.00022310
+Cubesort,500,326,0.00023210
+Cubesort,500,327,0.00023360
+Cubesort,500,328,0.00025490
+Cubesort,500,329,0.00022290
+Cubesort,500,330,0.00013540
+Cubesort,500,331,0.00022010
+Cubesort,500,332,0.00024530
+Cubesort,500,333,0.00015910
+Cubesort,500,334,0.00014190
+Cubesort,500,335,0.00013550
+Cubesort,500,336,0.00022530
+Cubesort,500,337,0.00013230
+Cubesort,500,338,0.00013110
+Cubesort,500,339,0.00027240
+Cubesort,500,340,0.00022950
+Cubesort,500,341,0.00022280
+Cubesort,500,342,0.00022550
+Cubesort,500,343,0.00022240
+Cubesort,500,344,0.00021850
+Cubesort,500,345,0.00021290
+Cubesort,500,346,0.00021350
+Cubesort,500,347,0.00020810
+Cubesort,500,348,0.00022170
+Cubesort,500,349,0.00015490
+Cubesort,500,350,0.00021250
+Cubesort,500,351,0.00014750
+Cubesort,500,352,0.00016850
+Cubesort,500,353,0.00021070
+Cubesort,500,354,0.00013950
+Cubesort,500,355,0.00018620
+Cubesort,500,356,0.00023560
+Cubesort,500,357,0.00021730
+Cubesort,500,358,0.00023920
+Cubesort,500,359,0.00024030
+Cubesort,500,360,0.00023720
+Cubesort,500,361,0.00022810
+Cubesort,500,362,0.00021750
+Cubesort,500,363,0.00023580
+Cubesort,500,364,0.00022460
+Cubesort,500,365,0.00021970
+Cubesort,500,366,0.00025330
+Cubesort,500,367,0.00022060
+Cubesort,500,368,0.00022400
+Cubesort,500,369,0.00023200
+Cubesort,500,370,0.00022120
+Cubesort,500,371,0.00022260
+Cubesort,500,372,0.00027080
+Cubesort,500,373,0.00023360
+Cubesort,500,374,0.00024600
+Cubesort,500,375,0.00021970
+Cubesort,500,376,0.00022550
+Cubesort,500,377,0.00021000
+Cubesort,500,378,0.00021300
+Cubesort,500,379,0.00020710
+Cubesort,500,380,0.00023760
+Cubesort,500,381,0.00014250
+Cubesort,500,382,0.00024630
+Cubesort,500,383,0.00020140
+Cubesort,500,384,0.00023940
+Cubesort,500,385,0.00021520
+Cubesort,500,386,0.00014310
+Cubesort,500,387,0.00022070
+Cubesort,500,388,0.00023770
+Cubesort,500,389,0.00013600
+Cubesort,500,390,0.00022410
+Cubesort,500,391,0.00013670
+Cubesort,500,392,0.00022970
+Cubesort,500,393,0.00021620
+Cubesort,500,394,0.00013540
+Cubesort,500,395,0.00021820
+Cubesort,500,396,0.00014430
+Cubesort,500,397,0.00021350
+Cubesort,500,398,0.00016640
+Cubesort,500,399,0.00022530
+Cubesort,500,400,0.00023270
+Cubesort,500,401,0.00022260
+Cubesort,500,402,0.00018740
+Cubesort,500,403,0.00015300
+Cubesort,500,404,0.00013630
+Cubesort,500,405,0.00022460
+Cubesort,500,406,0.00013860
+Cubesort,500,407,0.00020840
+Cubesort,500,408,0.00023410
+Cubesort,500,409,0.00022020
+Cubesort,500,410,0.00022890
+Cubesort,500,411,0.00021310
+Cubesort,500,412,0.00021280
+Cubesort,500,413,0.00021610
+Cubesort,500,414,0.00023270
+Cubesort,500,415,0.00022570
+Cubesort,500,416,0.00021510
+Cubesort,500,417,0.00020480
+Cubesort,500,418,0.00013490
+Cubesort,500,419,0.00021690
+Cubesort,500,420,0.00013290
+Cubesort,500,421,0.00015020
+Cubesort,500,422,0.00013440
+Cubesort,500,423,0.00021320
+Cubesort,500,424,0.00013340
+Cubesort,500,425,0.00013450
+Cubesort,500,426,0.00022040
+Cubesort,500,427,0.00021690
+Cubesort,500,428,0.00013880
+Cubesort,500,429,0.00028870
+Cubesort,500,430,0.00023710
+Cubesort,500,431,0.00021750
+Cubesort,500,432,0.00022460
+Cubesort,500,433,0.00020850
+Cubesort,500,434,0.00022260
+Cubesort,500,435,0.00019950
+Cubesort,500,436,0.00037390
+Cubesort,500,437,0.00022810
+Cubesort,500,438,0.00022820
+Cubesort,500,439,0.00021850
+Cubesort,500,440,0.00022840
+Cubesort,500,441,0.00022980
+Cubesort,500,442,0.00021020
+Cubesort,500,443,0.00019930
+Cubesort,500,444,0.00021710
+Cubesort,500,445,0.00037810
+Cubesort,500,446,0.00019240
+Cubesort,500,447,0.00024420
+Cubesort,500,448,0.00022900
+Cubesort,500,449,0.00019890
+Cubesort,500,450,0.00020910
+Cubesort,500,451,0.00014290
+Cubesort,500,452,0.00019260
+Cubesort,500,453,0.00015150
+Cubesort,500,454,0.00021660
+Cubesort,500,455,0.00019160
+Cubesort,500,456,0.00013550
+Cubesort,500,457,0.00019470
+Cubesort,500,458,0.00021210
+Cubesort,500,459,0.00013420
+Cubesort,500,460,0.00015050
+Cubesort,500,461,0.00020940
+Cubesort,500,462,0.00025620
+Cubesort,500,463,0.00039920
+Cubesort,500,464,0.00024140
+Cubesort,500,465,0.00023710
+Cubesort,500,466,0.00015210
+Cubesort,500,467,0.00021680
+Cubesort,500,468,0.00024530
+Cubesort,500,469,0.00021670
+Cubesort,500,470,0.00013620
+Cubesort,500,471,0.00021480
+Cubesort,500,472,0.00021270
+Cubesort,500,473,0.00013190
+Cubesort,500,474,0.00022040
+Cubesort,500,475,0.00024060
+Cubesort,500,476,0.00022610
+Cubesort,500,477,0.00029240
+Cubesort,500,478,0.00024350
+Cubesort,500,479,0.00021800
+Cubesort,500,480,0.00020670
+Cubesort,500,481,0.00031100
+Cubesort,500,482,0.00020480
+Cubesort,500,483,0.00014730
+Cubesort,500,484,0.00013450
+Cubesort,500,485,0.00014800
+Cubesort,500,486,0.00013220
+Cubesort,500,487,0.00015440
+Cubesort,500,488,0.00019450
+Cubesort,500,489,0.00013250
+Cubesort,500,490,0.00022660
+Cubesort,500,491,0.00013620
+Cubesort,500,492,0.00020040
+Cubesort,500,493,0.00015900
+Cubesort,500,494,0.00014130
+Cubesort,500,495,0.00022940
+Cubesort,500,496,0.00021970
+Cubesort,500,497,0.00015200
+Cubesort,500,498,0.00018070
+Cubesort,500,499,0.00013960
+Cubesort,500,500,0.00021660
+Cycle Sort,500,1,0.01833940
+Cycle Sort,500,2,0.01986750
+Cycle Sort,500,3,0.01979230
+Cycle Sort,500,4,0.02101150
+Cycle Sort,500,5,0.01624030
+Cycle Sort,500,6,0.02069770
+Cycle Sort,500,7,0.02277270
+Cycle Sort,500,8,0.02154860
+Cycle Sort,500,9,0.02007590
+Cycle Sort,500,10,0.02095530
+Cycle Sort,500,11,0.02050100
+Cycle Sort,500,12,0.01826370
+Cycle Sort,500,13,0.02039200
+Cycle Sort,500,14,0.01861470
+Cycle Sort,500,15,0.02042890
+Cycle Sort,500,16,0.02092720
+Cycle Sort,500,17,0.02111770
+Cycle Sort,500,18,0.02248080
+Cycle Sort,500,19,0.02296530
+Cycle Sort,500,20,0.02254880
+Cycle Sort,500,21,0.02132660
+Cycle Sort,500,22,0.01864040
+Cycle Sort,500,23,0.02204680
+Cycle Sort,500,24,0.02233610
+Cycle Sort,500,25,0.02266350
+Cycle Sort,500,26,0.02142120
+Cycle Sort,500,27,0.02183870
+Cycle Sort,500,28,0.02136930
+Cycle Sort,500,29,0.02170470
+Cycle Sort,500,30,0.01998630
+Cycle Sort,500,31,0.02052600
+Cycle Sort,500,32,0.01997080
+Cycle Sort,500,33,0.02055310
+Cycle Sort,500,34,0.02004430
+Cycle Sort,500,35,0.02049580
+Cycle Sort,500,36,0.01864380
+Cycle Sort,500,37,0.02149270
+Cycle Sort,500,38,0.01711020
+Cycle Sort,500,39,0.02101640
+Cycle Sort,500,40,0.02092950
+Cycle Sort,500,41,0.01931640
+Cycle Sort,500,42,0.01881600
+Cycle Sort,500,43,0.01940320
+Cycle Sort,500,44,0.02004350
+Cycle Sort,500,45,0.02065650
+Cycle Sort,500,46,0.02106670
+Cycle Sort,500,47,0.01920720
+Cycle Sort,500,48,0.02179200
+Cycle Sort,500,49,0.02148870
+Cycle Sort,500,50,0.01773180
+Cycle Sort,500,51,0.01880970
+Cycle Sort,500,52,0.02293090
+Cycle Sort,500,53,0.01971420
+Cycle Sort,500,54,0.02098280
+Cycle Sort,500,55,0.02012020
+Cycle Sort,500,56,0.02012350
+Cycle Sort,500,57,0.02073360
+Cycle Sort,500,58,0.02234680
+Cycle Sort,500,59,0.02036700
+Cycle Sort,500,60,0.02152150
+Cycle Sort,500,61,0.02143360
+Cycle Sort,500,62,0.01801520
+Cycle Sort,500,63,0.01827540
+Cycle Sort,500,64,0.01917530
+Cycle Sort,500,65,0.01943650
+Cycle Sort,500,66,0.01927890
+Cycle Sort,500,67,0.01844280
+Cycle Sort,500,68,0.02092840
+Cycle Sort,500,69,0.01930510
+Cycle Sort,500,70,0.02237080
+Cycle Sort,500,71,0.01917650
+Cycle Sort,500,72,0.01853040
+Cycle Sort,500,73,0.02006700
+Cycle Sort,500,74,0.02015610
+Cycle Sort,500,75,0.01953310
+Cycle Sort,500,76,0.01783050
+Cycle Sort,500,77,0.01941340
+Cycle Sort,500,78,0.01998370
+Cycle Sort,500,79,0.02037380
+Cycle Sort,500,80,0.02071110
+Cycle Sort,500,81,0.02074920
+Cycle Sort,500,82,0.02064920
+Cycle Sort,500,83,0.02145650
+Cycle Sort,500,84,0.02056860
+Cycle Sort,500,85,0.02179650
+Cycle Sort,500,86,0.02285280
+Cycle Sort,500,87,0.02001000
+Cycle Sort,500,88,0.02008710
+Cycle Sort,500,89,0.01785100
+Cycle Sort,500,90,0.01819630
+Cycle Sort,500,91,0.01818750
+Cycle Sort,500,92,0.01944080
+Cycle Sort,500,93,0.01897410
+Cycle Sort,500,94,0.01917690
+Cycle Sort,500,95,0.01568200
+Cycle Sort,500,96,0.01857810
+Cycle Sort,500,97,0.01899480
+Cycle Sort,500,98,0.02061560
+Cycle Sort,500,99,0.01786340
+Cycle Sort,500,100,0.01936100
+Cycle Sort,500,101,0.02007050
+Cycle Sort,500,102,0.01860420
+Cycle Sort,500,103,0.02032760
+Cycle Sort,500,104,0.01942540
+Cycle Sort,500,105,0.02104040
+Cycle Sort,500,106,0.02242660
+Cycle Sort,500,107,0.02011500
+Cycle Sort,500,108,0.02009430
+Cycle Sort,500,109,0.01638710
+Cycle Sort,500,110,0.02167980
+Cycle Sort,500,111,0.02116370
+Cycle Sort,500,112,0.02149310
+Cycle Sort,500,113,0.01961630
+Cycle Sort,500,114,0.01785660
+Cycle Sort,500,115,0.01659240
+Cycle Sort,500,116,0.02099290
+Cycle Sort,500,117,0.02043900
+Cycle Sort,500,118,0.02026420
+Cycle Sort,500,119,0.01917220
+Cycle Sort,500,120,0.02219060
+Cycle Sort,500,121,0.02242850
+Cycle Sort,500,122,0.02175800
+Cycle Sort,500,123,0.01950910
+Cycle Sort,500,124,0.02020570
+Cycle Sort,500,125,0.01943630
+Cycle Sort,500,126,0.01827990
+Cycle Sort,500,127,0.01758010
+Cycle Sort,500,128,0.01643890
+Cycle Sort,500,129,0.02073100
+Cycle Sort,500,130,0.01587520
+Cycle Sort,500,131,0.01954190
+Cycle Sort,500,132,0.01721250
+Cycle Sort,500,133,0.02017330
+Cycle Sort,500,134,0.02150130
+Cycle Sort,500,135,0.02171680
+Cycle Sort,500,136,0.01769250
+Cycle Sort,500,137,0.01549010
+Cycle Sort,500,138,0.01854690
+Cycle Sort,500,139,0.01989140
+Cycle Sort,500,140,0.01699590
+Cycle Sort,500,141,0.02136610
+Cycle Sort,500,142,0.01782870
+Cycle Sort,500,143,0.01535210
+Cycle Sort,500,144,0.01770630
+Cycle Sort,500,145,0.01970320
+Cycle Sort,500,146,0.01833910
+Cycle Sort,500,147,0.02057040
+Cycle Sort,500,148,0.01713990
+Cycle Sort,500,149,0.02014280
+Cycle Sort,500,150,0.01782320
+Cycle Sort,500,151,0.01773570
+Cycle Sort,500,152,0.02081970
+Cycle Sort,500,153,0.01712840
+Cycle Sort,500,154,0.01930680
+Cycle Sort,500,155,0.02257910
+Cycle Sort,500,156,0.01856800
+Cycle Sort,500,157,0.02136300
+Cycle Sort,500,158,0.01907180
+Cycle Sort,500,159,0.02070700
+Cycle Sort,500,160,0.02230170
+Cycle Sort,500,161,0.02264930
+Cycle Sort,500,162,0.01890770
+Cycle Sort,500,163,0.01833360
+Cycle Sort,500,164,0.02049300
+Cycle Sort,500,165,0.01801240
+Cycle Sort,500,166,0.02279640
+Cycle Sort,500,167,0.01760670
+Cycle Sort,500,168,0.01845140
+Cycle Sort,500,169,0.01967120
+Cycle Sort,500,170,0.01966550
+Cycle Sort,500,171,0.01736750
+Cycle Sort,500,172,0.01985760
+Cycle Sort,500,173,0.02236320
+Cycle Sort,500,174,0.02093270
+Cycle Sort,500,175,0.01904600
+Cycle Sort,500,176,0.02159900
+Cycle Sort,500,177,0.02149320
+Cycle Sort,500,178,0.01756700
+Cycle Sort,500,179,0.01848520
+Cycle Sort,500,180,0.01888090
+Cycle Sort,500,181,0.01902860
+Cycle Sort,500,182,0.02113290
+Cycle Sort,500,183,0.01599910
+Cycle Sort,500,184,0.01939680
+Cycle Sort,500,185,0.02070490
+Cycle Sort,500,186,0.01891530
+Cycle Sort,500,187,0.02096190
+Cycle Sort,500,188,0.02174080
+Cycle Sort,500,189,0.02005240
+Cycle Sort,500,190,0.02200400
+Cycle Sort,500,191,0.02184680
+Cycle Sort,500,192,0.02082960
+Cycle Sort,500,193,0.02019140
+Cycle Sort,500,194,0.01949260
+Cycle Sort,500,195,0.02261680
+Cycle Sort,500,196,0.02202330
+Cycle Sort,500,197,0.01808850
+Cycle Sort,500,198,0.02219560
+Cycle Sort,500,199,0.01728790
+Cycle Sort,500,200,0.01863570
+Cycle Sort,500,201,0.02121110
+Cycle Sort,500,202,0.01775450
+Cycle Sort,500,203,0.02098160
+Cycle Sort,500,204,0.02084130
+Cycle Sort,500,205,0.01899860
+Cycle Sort,500,206,0.02086920
+Cycle Sort,500,207,0.02040530
+Cycle Sort,500,208,0.02035730
+Cycle Sort,500,209,0.01937160
+Cycle Sort,500,210,0.01764510
+Cycle Sort,500,211,0.01577030
+Cycle Sort,500,212,0.02296570
+Cycle Sort,500,213,0.01880720
+Cycle Sort,500,214,0.01787560
+Cycle Sort,500,215,0.01784450
+Cycle Sort,500,216,0.01864400
+Cycle Sort,500,217,0.01833220
+Cycle Sort,500,218,0.01797290
+Cycle Sort,500,219,0.01778770
+Cycle Sort,500,220,0.02252340
+Cycle Sort,500,221,0.01985800
+Cycle Sort,500,222,0.02124230
+Cycle Sort,500,223,0.02228930
+Cycle Sort,500,224,0.02009420
+Cycle Sort,500,225,0.01676280
+Cycle Sort,500,226,0.01802890
+Cycle Sort,500,227,0.02015270
+Cycle Sort,500,228,0.02180950
+Cycle Sort,500,229,0.01884420
+Cycle Sort,500,230,0.02020770
+Cycle Sort,500,231,0.01910890
+Cycle Sort,500,232,0.01823750
+Cycle Sort,500,233,0.02077900
+Cycle Sort,500,234,0.01860010
+Cycle Sort,500,235,0.01909050
+Cycle Sort,500,236,0.01617960
+Cycle Sort,500,237,0.02044620
+Cycle Sort,500,238,0.01923240
+Cycle Sort,500,239,0.01647350
+Cycle Sort,500,240,0.01494340
+Cycle Sort,500,241,0.02084690
+Cycle Sort,500,242,0.01842360
+Cycle Sort,500,243,0.02077150
+Cycle Sort,500,244,0.01993290
+Cycle Sort,500,245,0.01959620
+Cycle Sort,500,246,0.01980680
+Cycle Sort,500,247,0.02211860
+Cycle Sort,500,248,0.01751980
+Cycle Sort,500,249,0.02070380
+Cycle Sort,500,250,0.01907730
+Cycle Sort,500,251,0.01953500
+Cycle Sort,500,252,0.01539350
+Cycle Sort,500,253,0.02082180
+Cycle Sort,500,254,0.02099780
+Cycle Sort,500,255,0.01911140
+Cycle Sort,500,256,0.02019700
+Cycle Sort,500,257,0.01866740
+Cycle Sort,500,258,0.02060150
+Cycle Sort,500,259,0.02073120
+Cycle Sort,500,260,0.02213530
+Cycle Sort,500,261,0.01757260
+Cycle Sort,500,262,0.02054580
+Cycle Sort,500,263,0.01961780
+Cycle Sort,500,264,0.01981320
+Cycle Sort,500,265,0.01809930
+Cycle Sort,500,266,0.02038020
+Cycle Sort,500,267,0.02012170
+Cycle Sort,500,268,0.02133660
+Cycle Sort,500,269,0.02119360
+Cycle Sort,500,270,0.02001060
+Cycle Sort,500,271,0.02039600
+Cycle Sort,500,272,0.01774970
+Cycle Sort,500,273,0.01907890
+Cycle Sort,500,274,0.01939180
+Cycle Sort,500,275,0.01775220
+Cycle Sort,500,276,0.01591590
+Cycle Sort,500,277,0.02074820
+Cycle Sort,500,278,0.01672180
+Cycle Sort,500,279,0.02245640
+Cycle Sort,500,280,0.02267090
+Cycle Sort,500,281,0.02032310
+Cycle Sort,500,282,0.02021630
+Cycle Sort,500,283,0.01998310
+Cycle Sort,500,284,0.02044380
+Cycle Sort,500,285,0.01712520
+Cycle Sort,500,286,0.01922560
+Cycle Sort,500,287,0.01906360
+Cycle Sort,500,288,0.02251870
+Cycle Sort,500,289,0.01899540
+Cycle Sort,500,290,0.01899000
+Cycle Sort,500,291,0.01662440
+Cycle Sort,500,292,0.01735430
+Cycle Sort,500,293,0.01932210
+Cycle Sort,500,294,0.02002750
+Cycle Sort,500,295,0.02104760
+Cycle Sort,500,296,0.01917300
+Cycle Sort,500,297,0.02210650
+Cycle Sort,500,298,0.02037140
+Cycle Sort,500,299,0.01878980
+Cycle Sort,500,300,0.01874770
+Cycle Sort,500,301,0.02138460
+Cycle Sort,500,302,0.02087460
+Cycle Sort,500,303,0.02042090
+Cycle Sort,500,304,0.02036490
+Cycle Sort,500,305,0.01857120
+Cycle Sort,500,306,0.01999140
+Cycle Sort,500,307,0.01759420
+Cycle Sort,500,308,0.01914310
+Cycle Sort,500,309,0.02282740
+Cycle Sort,500,310,0.01775500
+Cycle Sort,500,311,0.02037220
+Cycle Sort,500,312,0.02103910
+Cycle Sort,500,313,0.01969800
+Cycle Sort,500,314,0.01941470
+Cycle Sort,500,315,0.01912550
+Cycle Sort,500,316,0.01929250
+Cycle Sort,500,317,0.01945040
+Cycle Sort,500,318,0.01811370
+Cycle Sort,500,319,0.01984960
+Cycle Sort,500,320,0.01896980
+Cycle Sort,500,321,0.01811690
+Cycle Sort,500,322,0.01887180
+Cycle Sort,500,323,0.02178120
+Cycle Sort,500,324,0.01994720
+Cycle Sort,500,325,0.01978870
+Cycle Sort,500,326,0.02060130
+Cycle Sort,500,327,0.02056280
+Cycle Sort,500,328,0.01798610
+Cycle Sort,500,329,0.01855320
+Cycle Sort,500,330,0.01933790
+Cycle Sort,500,331,0.02037680
+Cycle Sort,500,332,0.02116540
+Cycle Sort,500,333,0.02009430
+Cycle Sort,500,334,0.02090720
+Cycle Sort,500,335,0.01884790
+Cycle Sort,500,336,0.01980990
+Cycle Sort,500,337,0.02211730
+Cycle Sort,500,338,0.02060210
+Cycle Sort,500,339,0.01941130
+Cycle Sort,500,340,0.01803630
+Cycle Sort,500,341,0.01546400
+Cycle Sort,500,342,0.02104250
+Cycle Sort,500,343,0.01719720
+Cycle Sort,500,344,0.02020120
+Cycle Sort,500,345,0.01696510
+Cycle Sort,500,346,0.01833720
+Cycle Sort,500,347,0.02119740
+Cycle Sort,500,348,0.01774200
+Cycle Sort,500,349,0.01919400
+Cycle Sort,500,350,0.01854910
+Cycle Sort,500,351,0.02286420
+Cycle Sort,500,352,0.01607090
+Cycle Sort,500,353,0.01935630
+Cycle Sort,500,354,0.01933090
+Cycle Sort,500,355,0.01785990
+Cycle Sort,500,356,0.01863570
+Cycle Sort,500,357,0.02059290
+Cycle Sort,500,358,0.01858820
+Cycle Sort,500,359,0.01721570
+Cycle Sort,500,360,0.01793110
+Cycle Sort,500,361,0.02497870
+Cycle Sort,500,362,0.03138230
+Cycle Sort,500,363,0.03293700
+Cycle Sort,500,364,0.04275840
+Cycle Sort,500,365,0.02318050
+Cycle Sort,500,366,0.02670240
+Cycle Sort,500,367,0.02317730
+Cycle Sort,500,368,0.02240830
+Cycle Sort,500,369,0.02532160
+Cycle Sort,500,370,0.03233980
+Cycle Sort,500,371,0.02397900
+Cycle Sort,500,372,0.02524490
+Cycle Sort,500,373,0.02319290
+Cycle Sort,500,374,0.02225450
+Cycle Sort,500,375,0.02241750
+Cycle Sort,500,376,0.02183180
+Cycle Sort,500,377,0.02410300
+Cycle Sort,500,378,0.02113520
+Cycle Sort,500,379,0.02112450
+Cycle Sort,500,380,0.02036150
+Cycle Sort,500,381,0.02193630
+Cycle Sort,500,382,0.01887980
+Cycle Sort,500,383,0.01647860
+Cycle Sort,500,384,0.01888590
+Cycle Sort,500,385,0.01993670
+Cycle Sort,500,386,0.01711350
+Cycle Sort,500,387,0.01699770
+Cycle Sort,500,388,0.01837110
+Cycle Sort,500,389,0.01839050
+Cycle Sort,500,390,0.01871430
+Cycle Sort,500,391,0.01712570
+Cycle Sort,500,392,0.01830370
+Cycle Sort,500,393,0.02274630
+Cycle Sort,500,394,0.01806030
+Cycle Sort,500,395,0.02137650
+Cycle Sort,500,396,0.02296970
+Cycle Sort,500,397,0.02180770
+Cycle Sort,500,398,0.01884330
+Cycle Sort,500,399,0.02119520
+Cycle Sort,500,400,0.01961220
+Cycle Sort,500,401,0.01846940
+Cycle Sort,500,402,0.01879430
+Cycle Sort,500,403,0.01849400
+Cycle Sort,500,404,0.02030220
+Cycle Sort,500,405,0.01740270
+Cycle Sort,500,406,0.01946490
+Cycle Sort,500,407,0.02035030
+Cycle Sort,500,408,0.02208020
+Cycle Sort,500,409,0.01912980
+Cycle Sort,500,410,0.02131990
+Cycle Sort,500,411,0.02131980
+Cycle Sort,500,412,0.02139970
+Cycle Sort,500,413,0.02165170
+Cycle Sort,500,414,0.01966370
+Cycle Sort,500,415,0.01826530
+Cycle Sort,500,416,0.02032240
+Cycle Sort,500,417,0.01823680
+Cycle Sort,500,418,0.01810930
+Cycle Sort,500,419,0.01821850
+Cycle Sort,500,420,0.02096450
+Cycle Sort,500,421,0.01921370
+Cycle Sort,500,422,0.02044030
+Cycle Sort,500,423,0.01810790
+Cycle Sort,500,424,0.01935080
+Cycle Sort,500,425,0.01608270
+Cycle Sort,500,426,0.01661470
+Cycle Sort,500,427,0.01950800
+Cycle Sort,500,428,0.01843700
+Cycle Sort,500,429,0.02105140
+Cycle Sort,500,430,0.01784170
+Cycle Sort,500,431,0.01832340
+Cycle Sort,500,432,0.02027900
+Cycle Sort,500,433,0.01923600
+Cycle Sort,500,434,0.02175480
+Cycle Sort,500,435,0.01982670
+Cycle Sort,500,436,0.02884340
+Cycle Sort,500,437,0.02093710
+Cycle Sort,500,438,0.03173520
+Cycle Sort,500,439,0.06582780
+Cycle Sort,500,440,0.03655050
+Cycle Sort,500,441,0.02923950
+Cycle Sort,500,442,0.03189580
+Cycle Sort,500,443,0.02807530
+Cycle Sort,500,444,0.02430510
+Cycle Sort,500,445,0.02533380
+Cycle Sort,500,446,0.03806440
+Cycle Sort,500,447,0.02231330
+Cycle Sort,500,448,0.02145940
+Cycle Sort,500,449,0.02530890
+Cycle Sort,500,450,0.02599600
+Cycle Sort,500,451,0.02484900
+Cycle Sort,500,452,0.02521280
+Cycle Sort,500,453,0.02057160
+Cycle Sort,500,454,0.01915860
+Cycle Sort,500,455,0.01926020
+Cycle Sort,500,456,0.02064120
+Cycle Sort,500,457,0.02123080
+Cycle Sort,500,458,0.01877350
+Cycle Sort,500,459,0.01885370
+Cycle Sort,500,460,0.02187010
+Cycle Sort,500,461,0.02075830
+Cycle Sort,500,462,0.01839350
+Cycle Sort,500,463,0.01970890
+Cycle Sort,500,464,0.01922430
+Cycle Sort,500,465,0.02090070
+Cycle Sort,500,466,0.01872700
+Cycle Sort,500,467,0.02083010
+Cycle Sort,500,468,0.02042400
+Cycle Sort,500,469,0.02029980
+Cycle Sort,500,470,0.02040890
+Cycle Sort,500,471,0.02163330
+Cycle Sort,500,472,0.01976090
+Cycle Sort,500,473,0.02055270
+Cycle Sort,500,474,0.02086270
+Cycle Sort,500,475,0.02028930
+Cycle Sort,500,476,0.01958420
+Cycle Sort,500,477,0.01810770
+Cycle Sort,500,478,0.01855090
+Cycle Sort,500,479,0.01647590
+Cycle Sort,500,480,0.02160370
+Cycle Sort,500,481,0.02163660
+Cycle Sort,500,482,0.01957410
+Cycle Sort,500,483,0.01727520
+Cycle Sort,500,484,0.01970840
+Cycle Sort,500,485,0.01990890
+Cycle Sort,500,486,0.01952420
+Cycle Sort,500,487,0.02006770
+Cycle Sort,500,488,0.02075470
+Cycle Sort,500,489,0.01792200
+Cycle Sort,500,490,0.02067270
+Cycle Sort,500,491,0.01966760
+Cycle Sort,500,492,0.01793030
+Cycle Sort,500,493,0.01531200
+Cycle Sort,500,494,0.01729570
+Cycle Sort,500,495,0.02249910
+Cycle Sort,500,496,0.01861880
+Cycle Sort,500,497,0.01458650
+Cycle Sort,500,498,0.01828150
+Cycle Sort,500,499,0.02143090
+Cycle Sort,500,500,0.01943630
+Exchange Sort,500,1,0.00919190
+Exchange Sort,500,2,0.00982950
+Exchange Sort,500,3,0.00963000
+Exchange Sort,500,4,0.01111900
+Exchange Sort,500,5,0.01074460
+Exchange Sort,500,6,0.00829280
+Exchange Sort,500,7,0.00898670
+Exchange Sort,500,8,0.00970040
+Exchange Sort,500,9,0.00969530
+Exchange Sort,500,10,0.01083050
+Exchange Sort,500,11,0.01119250
+Exchange Sort,500,12,0.01152890
+Exchange Sort,500,13,0.00899140
+Exchange Sort,500,14,0.01075500
+Exchange Sort,500,15,0.00991690
+Exchange Sort,500,16,0.00998700
+Exchange Sort,500,17,0.01045790
+Exchange Sort,500,18,0.00997840
+Exchange Sort,500,19,0.01026220
+Exchange Sort,500,20,0.01038910
+Exchange Sort,500,21,0.01203520
+Exchange Sort,500,22,0.00801980
+Exchange Sort,500,23,0.01028300
+Exchange Sort,500,24,0.00971340
+Exchange Sort,500,25,0.01002520
+Exchange Sort,500,26,0.00956400
+Exchange Sort,500,27,0.00823870
+Exchange Sort,500,28,0.01023350
+Exchange Sort,500,29,0.00850470
+Exchange Sort,500,30,0.01170810
+Exchange Sort,500,31,0.00929600
+Exchange Sort,500,32,0.01081580
+Exchange Sort,500,33,0.00950520
+Exchange Sort,500,34,0.01057380
+Exchange Sort,500,35,0.00898090
+Exchange Sort,500,36,0.00888430
+Exchange Sort,500,37,0.00879810
+Exchange Sort,500,38,0.00891140
+Exchange Sort,500,39,0.00801140
+Exchange Sort,500,40,0.00939220
+Exchange Sort,500,41,0.01020350
+Exchange Sort,500,42,0.00861590
+Exchange Sort,500,43,0.01077460
+Exchange Sort,500,44,0.00954230
+Exchange Sort,500,45,0.01227280
+Exchange Sort,500,46,0.00953600
+Exchange Sort,500,47,0.01053450
+Exchange Sort,500,48,0.01071240
+Exchange Sort,500,49,0.00883180
+Exchange Sort,500,50,0.00827190
+Exchange Sort,500,51,0.01087030
+Exchange Sort,500,52,0.01215000
+Exchange Sort,500,53,0.00744360
+Exchange Sort,500,54,0.00807020
+Exchange Sort,500,55,0.00990110
+Exchange Sort,500,56,0.00913090
+Exchange Sort,500,57,0.00803660
+Exchange Sort,500,58,0.01050380
+Exchange Sort,500,59,0.01052010
+Exchange Sort,500,60,0.00939530
+Exchange Sort,500,61,0.00852320
+Exchange Sort,500,62,0.00917190
+Exchange Sort,500,63,0.01117040
+Exchange Sort,500,64,0.01108350
+Exchange Sort,500,65,0.00939670
+Exchange Sort,500,66,0.00914410
+Exchange Sort,500,67,0.01112220
+Exchange Sort,500,68,0.00853820
+Exchange Sort,500,69,0.00999330
+Exchange Sort,500,70,0.01041860
+Exchange Sort,500,71,0.01036480
+Exchange Sort,500,72,0.01034790
+Exchange Sort,500,73,0.00877040
+Exchange Sort,500,74,0.01101410
+Exchange Sort,500,75,0.00956060
+Exchange Sort,500,76,0.01013140
+Exchange Sort,500,77,0.01108790
+Exchange Sort,500,78,0.01019620
+Exchange Sort,500,79,0.01151520
+Exchange Sort,500,80,0.00858250
+Exchange Sort,500,81,0.01036620
+Exchange Sort,500,82,0.01115650
+Exchange Sort,500,83,0.00999660
+Exchange Sort,500,84,0.00941150
+Exchange Sort,500,85,0.01056210
+Exchange Sort,500,86,0.01121540
+Exchange Sort,500,87,0.01155460
+Exchange Sort,500,88,0.00982880
+Exchange Sort,500,89,0.01056070
+Exchange Sort,500,90,0.01023820
+Exchange Sort,500,91,0.01058380
+Exchange Sort,500,92,0.01096120
+Exchange Sort,500,93,0.01148820
+Exchange Sort,500,94,0.01178680
+Exchange Sort,500,95,0.01227990
+Exchange Sort,500,96,0.01135590
+Exchange Sort,500,97,0.01110500
+Exchange Sort,500,98,0.01072760
+Exchange Sort,500,99,0.01071830
+Exchange Sort,500,100,0.01218840
+Exchange Sort,500,101,0.01085980
+Exchange Sort,500,102,0.01038590
+Exchange Sort,500,103,0.01214970
+Exchange Sort,500,104,0.00960940
+Exchange Sort,500,105,0.00907840
+Exchange Sort,500,106,0.00984450
+Exchange Sort,500,107,0.01014490
+Exchange Sort,500,108,0.01170540
+Exchange Sort,500,109,0.01085980
+Exchange Sort,500,110,0.01030030
+Exchange Sort,500,111,0.01074180
+Exchange Sort,500,112,0.00929400
+Exchange Sort,500,113,0.00813830
+Exchange Sort,500,114,0.00817530
+Exchange Sort,500,115,0.00937170
+Exchange Sort,500,116,0.00995980
+Exchange Sort,500,117,0.01109480
+Exchange Sort,500,118,0.00983090
+Exchange Sort,500,119,0.01171410
+Exchange Sort,500,120,0.00844630
+Exchange Sort,500,121,0.01054080
+Exchange Sort,500,122,0.00846610
+Exchange Sort,500,123,0.00900350
+Exchange Sort,500,124,0.01169050
+Exchange Sort,500,125,0.00785800
+Exchange Sort,500,126,0.01015070
+Exchange Sort,500,127,0.01048510
+Exchange Sort,500,128,0.00813450
+Exchange Sort,500,129,0.00981680
+Exchange Sort,500,130,0.01094860
+Exchange Sort,500,131,0.00972700
+Exchange Sort,500,132,0.01011420
+Exchange Sort,500,133,0.00908890
+Exchange Sort,500,134,0.00866690
+Exchange Sort,500,135,0.00807570
+Exchange Sort,500,136,0.00944380
+Exchange Sort,500,137,0.00876970
+Exchange Sort,500,138,0.01089510
+Exchange Sort,500,139,0.01014100
+Exchange Sort,500,140,0.01005990
+Exchange Sort,500,141,0.00906020
+Exchange Sort,500,142,0.00771790
+Exchange Sort,500,143,0.00980260
+Exchange Sort,500,144,0.00806180
+Exchange Sort,500,145,0.00842890
+Exchange Sort,500,146,0.00785350
+Exchange Sort,500,147,0.01012440
+Exchange Sort,500,148,0.00809660
+Exchange Sort,500,149,0.00907340
+Exchange Sort,500,150,0.00819130
+Exchange Sort,500,151,0.01059680
+Exchange Sort,500,152,0.00842950
+Exchange Sort,500,153,0.00856850
+Exchange Sort,500,154,0.00837170
+Exchange Sort,500,155,0.01028900
+Exchange Sort,500,156,0.01159460
+Exchange Sort,500,157,0.00973910
+Exchange Sort,500,158,0.00806880
+Exchange Sort,500,159,0.01107190
+Exchange Sort,500,160,0.00997970
+Exchange Sort,500,161,0.00842360
+Exchange Sort,500,162,0.01130000
+Exchange Sort,500,163,0.01171340
+Exchange Sort,500,164,0.01105300
+Exchange Sort,500,165,0.00948360
+Exchange Sort,500,166,0.01088990
+Exchange Sort,500,167,0.00962550
+Exchange Sort,500,168,0.01000660
+Exchange Sort,500,169,0.00981900
+Exchange Sort,500,170,0.00884090
+Exchange Sort,500,171,0.00926460
+Exchange Sort,500,172,0.01173450
+Exchange Sort,500,173,0.01124280
+Exchange Sort,500,174,0.01015590
+Exchange Sort,500,175,0.00965090
+Exchange Sort,500,176,0.01038980
+Exchange Sort,500,177,0.00895390
+Exchange Sort,500,178,0.01070070
+Exchange Sort,500,179,0.00782550
+Exchange Sort,500,180,0.01051120
+Exchange Sort,500,181,0.00861170
+Exchange Sort,500,182,0.01007080
+Exchange Sort,500,183,0.00862920
+Exchange Sort,500,184,0.01040280
+Exchange Sort,500,185,0.01187880
+Exchange Sort,500,186,0.00868190
+Exchange Sort,500,187,0.00942460
+Exchange Sort,500,188,0.01118340
+Exchange Sort,500,189,0.01112840
+Exchange Sort,500,190,0.00840920
+Exchange Sort,500,191,0.00744340
+Exchange Sort,500,192,0.00791350
+Exchange Sort,500,193,0.01060860
+Exchange Sort,500,194,0.01046570
+Exchange Sort,500,195,0.00779260
+Exchange Sort,500,196,0.00925860
+Exchange Sort,500,197,0.01092030
+Exchange Sort,500,198,0.01110740
+Exchange Sort,500,199,0.00934720
+Exchange Sort,500,200,0.00884250
+Exchange Sort,500,201,0.00967540
+Exchange Sort,500,202,0.01056910
+Exchange Sort,500,203,0.00808730
+Exchange Sort,500,204,0.00996910
+Exchange Sort,500,205,0.00985520
+Exchange Sort,500,206,0.00903750
+Exchange Sort,500,207,0.00925430
+Exchange Sort,500,208,0.00930750
+Exchange Sort,500,209,0.01144690
+Exchange Sort,500,210,0.01015170
+Exchange Sort,500,211,0.00824010
+Exchange Sort,500,212,0.01007200
+Exchange Sort,500,213,0.00910150
+Exchange Sort,500,214,0.00785970
+Exchange Sort,500,215,0.01122980
+Exchange Sort,500,216,0.01079440
+Exchange Sort,500,217,0.00996010
+Exchange Sort,500,218,0.00841820
+Exchange Sort,500,219,0.01134050
+Exchange Sort,500,220,0.00978910
+Exchange Sort,500,221,0.01135560
+Exchange Sort,500,222,0.00940020
+Exchange Sort,500,223,0.01111850
+Exchange Sort,500,224,0.01014070
+Exchange Sort,500,225,0.01165110
+Exchange Sort,500,226,0.00841440
+Exchange Sort,500,227,0.01008540
+Exchange Sort,500,228,0.01066920
+Exchange Sort,500,229,0.01007760
+Exchange Sort,500,230,0.00909520
+Exchange Sort,500,231,0.01100130
+Exchange Sort,500,232,0.01150130
+Exchange Sort,500,233,0.01029720
+Exchange Sort,500,234,0.00907080
+Exchange Sort,500,235,0.01109620
+Exchange Sort,500,236,0.01135100
+Exchange Sort,500,237,0.01147540
+Exchange Sort,500,238,0.01167340
+Exchange Sort,500,239,0.01061220
+Exchange Sort,500,240,0.00804860
+Exchange Sort,500,241,0.00954540
+Exchange Sort,500,242,0.01156470
+Exchange Sort,500,243,0.00957910
+Exchange Sort,500,244,0.00950480
+Exchange Sort,500,245,0.00961330
+Exchange Sort,500,246,0.01018420
+Exchange Sort,500,247,0.01095110
+Exchange Sort,500,248,0.00844160
+Exchange Sort,500,249,0.00935710
+Exchange Sort,500,250,0.01054720
+Exchange Sort,500,251,0.00861730
+Exchange Sort,500,252,0.00994860
+Exchange Sort,500,253,0.00856020
+Exchange Sort,500,254,0.01064620
+Exchange Sort,500,255,0.00988950
+Exchange Sort,500,256,0.00988110
+Exchange Sort,500,257,0.00936930
+Exchange Sort,500,258,0.00886030
+Exchange Sort,500,259,0.01130060
+Exchange Sort,500,260,0.00766420
+Exchange Sort,500,261,0.00927070
+Exchange Sort,500,262,0.00785300
+Exchange Sort,500,263,0.00760410
+Exchange Sort,500,264,0.00901310
+Exchange Sort,500,265,0.01227070
+Exchange Sort,500,266,0.00845820
+Exchange Sort,500,267,0.00926650
+Exchange Sort,500,268,0.00922980
+Exchange Sort,500,269,0.00930540
+Exchange Sort,500,270,0.00941610
+Exchange Sort,500,271,0.00874670
+Exchange Sort,500,272,0.00902730
+Exchange Sort,500,273,0.00894140
+Exchange Sort,500,274,0.00858860
+Exchange Sort,500,275,0.01098620
+Exchange Sort,500,276,0.00899810
+Exchange Sort,500,277,0.00862490
+Exchange Sort,500,278,0.00842080
+Exchange Sort,500,279,0.01055110
+Exchange Sort,500,280,0.00847580
+Exchange Sort,500,281,0.00948600
+Exchange Sort,500,282,0.01054400
+Exchange Sort,500,283,0.01086840
+Exchange Sort,500,284,0.01180640
+Exchange Sort,500,285,0.01212730
+Exchange Sort,500,286,0.01195470
+Exchange Sort,500,287,0.01052150
+Exchange Sort,500,288,0.00903910
+Exchange Sort,500,289,0.01001510
+Exchange Sort,500,290,0.00934950
+Exchange Sort,500,291,0.00983260
+Exchange Sort,500,292,0.01046910
+Exchange Sort,500,293,0.00967180
+Exchange Sort,500,294,0.00962620
+Exchange Sort,500,295,0.01106760
+Exchange Sort,500,296,0.01099050
+Exchange Sort,500,297,0.01119220
+Exchange Sort,500,298,0.01098140
+Exchange Sort,500,299,0.00921900
+Exchange Sort,500,300,0.01062810
+Exchange Sort,500,301,0.01079950
+Exchange Sort,500,302,0.01049550
+Exchange Sort,500,303,0.01198200
+Exchange Sort,500,304,0.01117120
+Exchange Sort,500,305,0.01184300
+Exchange Sort,500,306,0.01259800
+Exchange Sort,500,307,0.01132210
+Exchange Sort,500,308,0.00892490
+Exchange Sort,500,309,0.01047220
+Exchange Sort,500,310,0.01010460
+Exchange Sort,500,311,0.00975760
+Exchange Sort,500,312,0.01146710
+Exchange Sort,500,313,0.00782970
+Exchange Sort,500,314,0.01119010
+Exchange Sort,500,315,0.00843960
+Exchange Sort,500,316,0.00783520
+Exchange Sort,500,317,0.00790540
+Exchange Sort,500,318,0.01083250
+Exchange Sort,500,319,0.00857200
+Exchange Sort,500,320,0.00848830
+Exchange Sort,500,321,0.01024870
+Exchange Sort,500,322,0.00990730
+Exchange Sort,500,323,0.01197100
+Exchange Sort,500,324,0.00756200
+Exchange Sort,500,325,0.01117010
+Exchange Sort,500,326,0.01030220
+Exchange Sort,500,327,0.01034380
+Exchange Sort,500,328,0.00903570
+Exchange Sort,500,329,0.01080060
+Exchange Sort,500,330,0.00798220
+Exchange Sort,500,331,0.00915750
+Exchange Sort,500,332,0.00884200
+Exchange Sort,500,333,0.01109650
+Exchange Sort,500,334,0.01058290
+Exchange Sort,500,335,0.00942600
+Exchange Sort,500,336,0.00989580
+Exchange Sort,500,337,0.00940990
+Exchange Sort,500,338,0.01145990
+Exchange Sort,500,339,0.00898590
+Exchange Sort,500,340,0.00937520
+Exchange Sort,500,341,0.00926520
+Exchange Sort,500,342,0.01061320
+Exchange Sort,500,343,0.01029130
+Exchange Sort,500,344,0.01077820
+Exchange Sort,500,345,0.00953830
+Exchange Sort,500,346,0.01038610
+Exchange Sort,500,347,0.00821910
+Exchange Sort,500,348,0.00838840
+Exchange Sort,500,349,0.00995200
+Exchange Sort,500,350,0.00777420
+Exchange Sort,500,351,0.00890900
+Exchange Sort,500,352,0.01192440
+Exchange Sort,500,353,0.01023640
+Exchange Sort,500,354,0.00946510
+Exchange Sort,500,355,0.00978140
+Exchange Sort,500,356,0.00921950
+Exchange Sort,500,357,0.01151690
+Exchange Sort,500,358,0.00831090
+Exchange Sort,500,359,0.00994620
+Exchange Sort,500,360,0.00987720
+Exchange Sort,500,361,0.01084600
+Exchange Sort,500,362,0.00986430
+Exchange Sort,500,363,0.01086070
+Exchange Sort,500,364,0.01086550
+Exchange Sort,500,365,0.00975550
+Exchange Sort,500,366,0.00957900
+Exchange Sort,500,367,0.01190710
+Exchange Sort,500,368,0.00848820
+Exchange Sort,500,369,0.01021230
+Exchange Sort,500,370,0.00967000
+Exchange Sort,500,371,0.01090050
+Exchange Sort,500,372,0.01059000
+Exchange Sort,500,373,0.01160570
+Exchange Sort,500,374,0.01088230
+Exchange Sort,500,375,0.01134950
+Exchange Sort,500,376,0.01183910
+Exchange Sort,500,377,0.01048040
+Exchange Sort,500,378,0.01048570
+Exchange Sort,500,379,0.00915320
+Exchange Sort,500,380,0.01141940
+Exchange Sort,500,381,0.00856980
+Exchange Sort,500,382,0.01017950
+Exchange Sort,500,383,0.00890490
+Exchange Sort,500,384,0.00964520
+Exchange Sort,500,385,0.01043100
+Exchange Sort,500,386,0.00791820
+Exchange Sort,500,387,0.00976950
+Exchange Sort,500,388,0.00984310
+Exchange Sort,500,389,0.00842190
+Exchange Sort,500,390,0.00923940
+Exchange Sort,500,391,0.00972320
+Exchange Sort,500,392,0.01039100
+Exchange Sort,500,393,0.01200670
+Exchange Sort,500,394,0.01094970
+Exchange Sort,500,395,0.00865140
+Exchange Sort,500,396,0.00921020
+Exchange Sort,500,397,0.01088100
+Exchange Sort,500,398,0.01085540
+Exchange Sort,500,399,0.01101130
+Exchange Sort,500,400,0.00825900
+Exchange Sort,500,401,0.00893470
+Exchange Sort,500,402,0.00755800
+Exchange Sort,500,403,0.00949510
+Exchange Sort,500,404,0.01035980
+Exchange Sort,500,405,0.00865900
+Exchange Sort,500,406,0.00982280
+Exchange Sort,500,407,0.00988460
+Exchange Sort,500,408,0.00746060
+Exchange Sort,500,409,0.01132500
+Exchange Sort,500,410,0.00840940
+Exchange Sort,500,411,0.00849600
+Exchange Sort,500,412,0.00773240
+Exchange Sort,500,413,0.01030310
+Exchange Sort,500,414,0.01026280
+Exchange Sort,500,415,0.00878970
+Exchange Sort,500,416,0.01051680
+Exchange Sort,500,417,0.01125980
+Exchange Sort,500,418,0.01125290
+Exchange Sort,500,419,0.01087100
+Exchange Sort,500,420,0.01097580
+Exchange Sort,500,421,0.01362220
+Exchange Sort,500,422,0.01480020
+Exchange Sort,500,423,0.01388080
+Exchange Sort,500,424,0.01481490
+Exchange Sort,500,425,0.01553340
+Exchange Sort,500,426,0.01317190
+Exchange Sort,500,427,0.01467720
+Exchange Sort,500,428,0.02119650
+Exchange Sort,500,429,0.01210300
+Exchange Sort,500,430,0.01300060
+Exchange Sort,500,431,0.01605810
+Exchange Sort,500,432,0.01353310
+Exchange Sort,500,433,0.01189560
+Exchange Sort,500,434,0.01590970
+Exchange Sort,500,435,0.01423420
+Exchange Sort,500,436,0.01148780
+Exchange Sort,500,437,0.01175430
+Exchange Sort,500,438,0.01207300
+Exchange Sort,500,439,0.01169310
+Exchange Sort,500,440,0.01057790
+Exchange Sort,500,441,0.01015780
+Exchange Sort,500,442,0.01020580
+Exchange Sort,500,443,0.00928970
+Exchange Sort,500,444,0.01149760
+Exchange Sort,500,445,0.01109410
+Exchange Sort,500,446,0.01125120
+Exchange Sort,500,447,0.01001430
+Exchange Sort,500,448,0.01062980
+Exchange Sort,500,449,0.01003200
+Exchange Sort,500,450,0.00886480
+Exchange Sort,500,451,0.01053070
+Exchange Sort,500,452,0.01065230
+Exchange Sort,500,453,0.01023490
+Exchange Sort,500,454,0.01162640
+Exchange Sort,500,455,0.01183510
+Exchange Sort,500,456,0.01180530
+Exchange Sort,500,457,0.01113520
+Exchange Sort,500,458,0.01005950
+Exchange Sort,500,459,0.00998470
+Exchange Sort,500,460,0.00913630
+Exchange Sort,500,461,0.01083740
+Exchange Sort,500,462,0.01091340
+Exchange Sort,500,463,0.00906670
+Exchange Sort,500,464,0.01158720
+Exchange Sort,500,465,0.01008140
+Exchange Sort,500,466,0.01110200
+Exchange Sort,500,467,0.01036070
+Exchange Sort,500,468,0.01102990
+Exchange Sort,500,469,0.01225800
+Exchange Sort,500,470,0.01172110
+Exchange Sort,500,471,0.01226020
+Exchange Sort,500,472,0.01143620
+Exchange Sort,500,473,0.01244870
+Exchange Sort,500,474,0.01064220
+Exchange Sort,500,475,0.01252320
+Exchange Sort,500,476,0.01126680
+Exchange Sort,500,477,0.01030050
+Exchange Sort,500,478,0.01046850
+Exchange Sort,500,479,0.01146960
+Exchange Sort,500,480,0.00978330
+Exchange Sort,500,481,0.01053360
+Exchange Sort,500,482,0.01152520
+Exchange Sort,500,483,0.01143030
+Exchange Sort,500,484,0.01028920
+Exchange Sort,500,485,0.01009730
+Exchange Sort,500,486,0.00870860
+Exchange Sort,500,487,0.01219550
+Exchange Sort,500,488,0.01018140
+Exchange Sort,500,489,0.01175470
+Exchange Sort,500,490,0.00870820
+Exchange Sort,500,491,0.01066010
+Exchange Sort,500,492,0.00852120
+Exchange Sort,500,493,0.00888210
+Exchange Sort,500,494,0.01150750
+Exchange Sort,500,495,0.00874220
+Exchange Sort,500,496,0.00966510
+Exchange Sort,500,497,0.01001280
+Exchange Sort,500,498,0.01139850
+Exchange Sort,500,499,0.00957830
+Exchange Sort,500,500,0.01163070
+Flash Sort,500,1,0.00038160
+Flash Sort,500,2,0.00044190
+Flash Sort,500,3,0.00043040
+Flash Sort,500,4,0.00043770
+Flash Sort,500,5,0.00056580
+Flash Sort,500,6,0.00047330
+Flash Sort,500,7,0.00042580
+Flash Sort,500,8,0.00044440
+Flash Sort,500,9,0.00045110
+Flash Sort,500,10,0.00049120
+Flash Sort,500,11,0.00031540
+Flash Sort,500,12,0.00051260
+Flash Sort,500,13,0.00044860
+Flash Sort,500,14,0.00024910
+Flash Sort,500,15,0.00044610
+Flash Sort,500,16,0.00047900
+Flash Sort,500,17,0.00026580
+Flash Sort,500,18,0.00043860
+Flash Sort,500,19,0.00039660
+Flash Sort,500,20,0.00031600
+Flash Sort,500,21,0.00043310
+Flash Sort,500,22,0.00044510
+Flash Sort,500,23,0.00027290
+Flash Sort,500,24,0.00026050
+Flash Sort,500,25,0.00043900
+Flash Sort,500,26,0.00030280
+Flash Sort,500,27,0.00043220
+Flash Sort,500,28,0.00043720
+Flash Sort,500,29,0.00026190
+Flash Sort,500,30,0.00044090
+Flash Sort,500,31,0.00056030
+Flash Sort,500,32,0.00043940
+Flash Sort,500,33,0.00052410
+Flash Sort,500,34,0.00043300
+Flash Sort,500,35,0.00044260
+Flash Sort,500,36,0.00024260
+Flash Sort,500,37,0.00024690
+Flash Sort,500,38,0.00044440
+Flash Sort,500,39,0.00024420
+Flash Sort,500,40,0.00026200
+Flash Sort,500,41,0.00043820
+Flash Sort,500,42,0.00035110
+Flash Sort,500,43,0.00024830
+Flash Sort,500,44,0.00045860
+Flash Sort,500,45,0.00032960
+Flash Sort,500,46,0.00032280
+Flash Sort,500,47,0.00044900
+Flash Sort,500,48,0.00025130
+Flash Sort,500,49,0.00045160
+Flash Sort,500,50,0.00033860
+Flash Sort,500,51,0.00046070
+Flash Sort,500,52,0.00038760
+Flash Sort,500,53,0.00042560
+Flash Sort,500,54,0.00045000
+Flash Sort,500,55,0.00037710
+Flash Sort,500,56,0.00045420
+Flash Sort,500,57,0.00025030
+Flash Sort,500,58,0.00044580
+Flash Sort,500,59,0.00028870
+Flash Sort,500,60,0.00045570
+Flash Sort,500,61,0.00026420
+Flash Sort,500,62,0.00031250
+Flash Sort,500,63,0.00045040
+Flash Sort,500,64,0.00024330
+Flash Sort,500,65,0.00045170
+Flash Sort,500,66,0.00038670
+Flash Sort,500,67,0.00062890
+Flash Sort,500,68,0.00027670
+Flash Sort,500,69,0.00041080
+Flash Sort,500,70,0.00044360
+Flash Sort,500,71,0.00047320
+Flash Sort,500,72,0.00045550
+Flash Sort,500,73,0.00043140
+Flash Sort,500,74,0.00042880
+Flash Sort,500,75,0.00039040
+Flash Sort,500,76,0.00025960
+Flash Sort,500,77,0.00043410
+Flash Sort,500,78,0.00042160
+Flash Sort,500,79,0.00031470
+Flash Sort,500,80,0.00036780
+Flash Sort,500,81,0.00051950
+Flash Sort,500,82,0.00043410
+Flash Sort,500,83,0.00041890
+Flash Sort,500,84,0.00038620
+Flash Sort,500,85,0.00043720
+Flash Sort,500,86,0.00039530
+Flash Sort,500,87,0.00051950
+Flash Sort,500,88,0.00042570
+Flash Sort,500,89,0.00042310
+Flash Sort,500,90,0.00036740
+Flash Sort,500,91,0.00042780
+Flash Sort,500,92,0.00025310
+Flash Sort,500,93,0.00043720
+Flash Sort,500,94,0.00032280
+Flash Sort,500,95,0.00046520
+Flash Sort,500,96,0.00045620
+Flash Sort,500,97,0.00042570
+Flash Sort,500,98,0.00042170
+Flash Sort,500,99,0.00045820
+Flash Sort,500,100,0.00035610
+Flash Sort,500,101,0.00042190
+Flash Sort,500,102,0.00046220
+Flash Sort,500,103,0.00027800
+Flash Sort,500,104,0.00026660
+Flash Sort,500,105,0.00045290
+Flash Sort,500,106,0.00032940
+Flash Sort,500,107,0.00042760
+Flash Sort,500,108,0.00045410
+Flash Sort,500,109,0.00042520
+Flash Sort,500,110,0.00038500
+Flash Sort,500,111,0.00038490
+Flash Sort,500,112,0.00045740
+Flash Sort,500,113,0.00045980
+Flash Sort,500,114,0.00042580
+Flash Sort,500,115,0.00034470
+Flash Sort,500,116,0.00045910
+Flash Sort,500,117,0.00038460
+Flash Sort,500,118,0.00039590
+Flash Sort,500,119,0.00046280
+Flash Sort,500,120,0.00045150
+Flash Sort,500,121,0.00042760
+Flash Sort,500,122,0.00028230
+Flash Sort,500,123,0.00044770
+Flash Sort,500,124,0.00071560
+Flash Sort,500,125,0.00043070
+Flash Sort,500,126,0.00043090
+Flash Sort,500,127,0.00043940
+Flash Sort,500,128,0.00045930
+Flash Sort,500,129,0.00039700
+Flash Sort,500,130,0.00033650
+Flash Sort,500,131,0.00044040
+Flash Sort,500,132,0.00042580
+Flash Sort,500,133,0.00035030
+Flash Sort,500,134,0.00045790
+Flash Sort,500,135,0.00036370
+Flash Sort,500,136,0.00044630
+Flash Sort,500,137,0.00025070
+Flash Sort,500,138,0.00045420
+Flash Sort,500,139,0.00062260
+Flash Sort,500,140,0.00045810
+Flash Sort,500,141,0.00044570
+Flash Sort,500,142,0.00045550
+Flash Sort,500,143,0.00039620
+Flash Sort,500,144,0.00044240
+Flash Sort,500,145,0.00042380
+Flash Sort,500,146,0.00043800
+Flash Sort,500,147,0.00042760
+Flash Sort,500,148,0.00048040
+Flash Sort,500,149,0.00044440
+Flash Sort,500,150,0.00039880
+Flash Sort,500,151,0.00042380
+Flash Sort,500,152,0.00042170
+Flash Sort,500,153,0.00023930
+Flash Sort,500,154,0.00039640
+Flash Sort,500,155,0.00047550
+Flash Sort,500,156,0.00042670
+Flash Sort,500,157,0.00042300
+Flash Sort,500,158,0.00042290
+Flash Sort,500,159,0.00025090
+Flash Sort,500,160,0.00043210
+Flash Sort,500,161,0.00028610
+Flash Sort,500,162,0.00025500
+Flash Sort,500,163,0.00042490
+Flash Sort,500,164,0.00034500
+Flash Sort,500,165,0.00025770
+Flash Sort,500,166,0.00043020
+Flash Sort,500,167,0.00042010
+Flash Sort,500,168,0.00025030
+Flash Sort,500,169,0.00024980
+Flash Sort,500,170,0.00042670
+Flash Sort,500,171,0.00024810
+Flash Sort,500,172,0.00026060
+Flash Sort,500,173,0.00045130
+Flash Sort,500,174,0.00032810
+Flash Sort,500,175,0.00029380
+Flash Sort,500,176,0.00043910
+Flash Sort,500,177,0.00040470
+Flash Sort,500,178,0.00024210
+Flash Sort,500,179,0.00025290
+Flash Sort,500,180,0.00025620
+Flash Sort,500,181,0.00040670
+Flash Sort,500,182,0.00028490
+Flash Sort,500,183,0.00024000
+Flash Sort,500,184,0.00029710
+Flash Sort,500,185,0.00025480
+Flash Sort,500,186,0.00025200
+Flash Sort,500,187,0.00034310
+Flash Sort,500,188,0.00030210
+Flash Sort,500,189,0.00025330
+Flash Sort,500,190,0.00024060
+Flash Sort,500,191,0.00031880
+Flash Sort,500,192,0.00024940
+Flash Sort,500,193,0.00025580
+Flash Sort,500,194,0.00025200
+Flash Sort,500,195,0.00023900
+Flash Sort,500,196,0.00026350
+Flash Sort,500,197,0.00036850
+Flash Sort,500,198,0.00035300
+Flash Sort,500,199,0.00024110
+Flash Sort,500,200,0.00024590
+Flash Sort,500,201,0.00034120
+Flash Sort,500,202,0.00027190
+Flash Sort,500,203,0.00023950
+Flash Sort,500,204,0.00023920
+Flash Sort,500,205,0.00025650
+Flash Sort,500,206,0.00042380
+Flash Sort,500,207,0.00042260
+Flash Sort,500,208,0.00030290
+Flash Sort,500,209,0.00026600
+Flash Sort,500,210,0.00037970
+Flash Sort,500,211,0.00030260
+Flash Sort,500,212,0.00047110
+Flash Sort,500,213,0.00023900
+Flash Sort,500,214,0.00029500
+Flash Sort,500,215,0.00024160
+Flash Sort,500,216,0.00023620
+Flash Sort,500,217,0.00047120
+Flash Sort,500,218,0.00033650
+Flash Sort,500,219,0.00028960
+Flash Sort,500,220,0.00036180
+Flash Sort,500,221,0.00025660
+Flash Sort,500,222,0.00026320
+Flash Sort,500,223,0.00047830
+Flash Sort,500,224,0.00038530
+Flash Sort,500,225,0.00024750
+Flash Sort,500,226,0.00042170
+Flash Sort,500,227,0.00025370
+Flash Sort,500,228,0.00047010
+Flash Sort,500,229,0.00023600
+Flash Sort,500,230,0.00042070
+Flash Sort,500,231,0.00034910
+Flash Sort,500,232,0.00028870
+Flash Sort,500,233,0.00050380
+Flash Sort,500,234,0.00040020
+Flash Sort,500,235,0.00027770
+Flash Sort,500,236,0.00043660
+Flash Sort,500,237,0.00025140
+Flash Sort,500,238,0.00025050
+Flash Sort,500,239,0.00040920
+Flash Sort,500,240,0.00028640
+Flash Sort,500,241,0.00025460
+Flash Sort,500,242,0.00042420
+Flash Sort,500,243,0.00043310
+Flash Sort,500,244,0.00027970
+Flash Sort,500,245,0.00028090
+Flash Sort,500,246,0.00044060
+Flash Sort,500,247,0.00045420
+Flash Sort,500,248,0.00024210
+Flash Sort,500,249,0.00042110
+Flash Sort,500,250,0.00023640
+Flash Sort,500,251,0.00034900
+Flash Sort,500,252,0.00035470
+Flash Sort,500,253,0.00043470
+Flash Sort,500,254,0.00024150
+Flash Sort,500,255,0.00035940
+Flash Sort,500,256,0.00024170
+Flash Sort,500,257,0.00026150
+Flash Sort,500,258,0.00045570
+Flash Sort,500,259,0.00024380
+Flash Sort,500,260,0.00033570
+Flash Sort,500,261,0.00044740
+Flash Sort,500,262,0.00041790
+Flash Sort,500,263,0.00043690
+Flash Sort,500,264,0.00032510
+Flash Sort,500,265,0.00024260
+Flash Sort,500,266,0.00031240
+Flash Sort,500,267,0.00024720
+Flash Sort,500,268,0.00044550
+Flash Sort,500,269,0.00023950
+Flash Sort,500,270,0.00039100
+Flash Sort,500,271,0.00040000
+Flash Sort,500,272,0.00035050
+Flash Sort,500,273,0.00041800
+Flash Sort,500,274,0.00043130
+Flash Sort,500,275,0.00042060
+Flash Sort,500,276,0.00043130
+Flash Sort,500,277,0.00035040
+Flash Sort,500,278,0.00045490
+Flash Sort,500,279,0.00047130
+Flash Sort,500,280,0.00031130
+Flash Sort,500,281,0.00045780
+Flash Sort,500,282,0.00043000
+Flash Sort,500,283,0.00043300
+Flash Sort,500,284,0.00028150
+Flash Sort,500,285,0.00043480
+Flash Sort,500,286,0.00041710
+Flash Sort,500,287,0.00043430
+Flash Sort,500,288,0.00043110
+Flash Sort,500,289,0.00043090
+Flash Sort,500,290,0.00024800
+Flash Sort,500,291,0.00043380
+Flash Sort,500,292,0.00043310
+Flash Sort,500,293,0.00042820
+Flash Sort,500,294,0.00024950
+Flash Sort,500,295,0.00024580
+Flash Sort,500,296,0.00042490
+Flash Sort,500,297,0.00034320
+Flash Sort,500,298,0.00032750
+Flash Sort,500,299,0.00027810
+Flash Sort,500,300,0.00042800
+Flash Sort,500,301,0.00026790
+Flash Sort,500,302,0.00030590
+Flash Sort,500,303,0.00024550
+Flash Sort,500,304,0.00044630
+Flash Sort,500,305,0.00054280
+Flash Sort,500,306,0.00046500
+Flash Sort,500,307,0.00042770
+Flash Sort,500,308,0.00043580
+Flash Sort,500,309,0.00040380
+Flash Sort,500,310,0.00047590
+Flash Sort,500,311,0.00045520
+Flash Sort,500,312,0.00043280
+Flash Sort,500,313,0.00032710
+Flash Sort,500,314,0.00053020
+Flash Sort,500,315,0.00043650
+Flash Sort,500,316,0.00042340
+Flash Sort,500,317,0.00026970
+Flash Sort,500,318,0.00024140
+Flash Sort,500,319,0.00051170
+Flash Sort,500,320,0.00043240
+Flash Sort,500,321,0.00043100
+Flash Sort,500,322,0.00029230
+Flash Sort,500,323,0.00047290
+Flash Sort,500,324,0.00047350
+Flash Sort,500,325,0.00028040
+Flash Sort,500,326,0.00042930
+Flash Sort,500,327,0.00042990
+Flash Sort,500,328,0.00024710
+Flash Sort,500,329,0.00031100
+Flash Sort,500,330,0.00037670
+Flash Sort,500,331,0.00025710
+Flash Sort,500,332,0.00024310
+Flash Sort,500,333,0.00044910
+Flash Sort,500,334,0.00035090
+Flash Sort,500,335,0.00043750
+Flash Sort,500,336,0.00037680
+Flash Sort,500,337,0.00023930
+Flash Sort,500,338,0.00038140
+Flash Sort,500,339,0.00024100
+Flash Sort,500,340,0.00042990
+Flash Sort,500,341,0.00026760
+Flash Sort,500,342,0.00042660
+Flash Sort,500,343,0.00044870
+Flash Sort,500,344,0.00024920
+Flash Sort,500,345,0.00023980
+Flash Sort,500,346,0.00036200
+Flash Sort,500,347,0.00044450
+Flash Sort,500,348,0.00026630
+Flash Sort,500,349,0.00039540
+Flash Sort,500,350,0.00024910
+Flash Sort,500,351,0.00038880
+Flash Sort,500,352,0.00043920
+Flash Sort,500,353,0.00024210
+Flash Sort,500,354,0.00031170
+Flash Sort,500,355,0.00041840
+Flash Sort,500,356,0.00046320
+Flash Sort,500,357,0.00044810
+Flash Sort,500,358,0.00027760
+Flash Sort,500,359,0.00043060
+Flash Sort,500,360,0.00041250
+Flash Sort,500,361,0.00042920
+Flash Sort,500,362,0.00043850
+Flash Sort,500,363,0.00032830
+Flash Sort,500,364,0.00043350
+Flash Sort,500,365,0.00042670
+Flash Sort,500,366,0.00024280
+Flash Sort,500,367,0.00026540
+Flash Sort,500,368,0.00025550
+Flash Sort,500,369,0.00043960
+Flash Sort,500,370,0.00051710
+Flash Sort,500,371,0.00043030
+Flash Sort,500,372,0.00023860
+Flash Sort,500,373,0.00039510
+Flash Sort,500,374,0.00027840
+Flash Sort,500,375,0.00043940
+Flash Sort,500,376,0.00043510
+Flash Sort,500,377,0.00038050
+Flash Sort,500,378,0.00029900
+Flash Sort,500,379,0.00045140
+Flash Sort,500,380,0.00042800
+Flash Sort,500,381,0.00029570
+Flash Sort,500,382,0.00045180
+Flash Sort,500,383,0.00045280
+Flash Sort,500,384,0.00042340
+Flash Sort,500,385,0.00036680
+Flash Sort,500,386,0.00044680
+Flash Sort,500,387,0.00045570
+Flash Sort,500,388,0.00033170
+Flash Sort,500,389,0.00045040
+Flash Sort,500,390,0.00045250
+Flash Sort,500,391,0.00043630
+Flash Sort,500,392,0.00045980
+Flash Sort,500,393,0.00045030
+Flash Sort,500,394,0.00044760
+Flash Sort,500,395,0.00038160
+Flash Sort,500,396,0.00046160
+Flash Sort,500,397,0.00046230
+Flash Sort,500,398,0.00053340
+Flash Sort,500,399,0.00044050
+Flash Sort,500,400,0.00046890
+Flash Sort,500,401,0.00044820
+Flash Sort,500,402,0.00043120
+Flash Sort,500,403,0.00043320
+Flash Sort,500,404,0.00041500
+Flash Sort,500,405,0.00047230
+Flash Sort,500,406,0.00046660
+Flash Sort,500,407,0.00047040
+Flash Sort,500,408,0.00034960
+Flash Sort,500,409,0.00042910
+Flash Sort,500,410,0.00036680
+Flash Sort,500,411,0.00042350
+Flash Sort,500,412,0.00031210
+Flash Sort,500,413,0.00043680
+Flash Sort,500,414,0.00024290
+Flash Sort,500,415,0.00030290
+Flash Sort,500,416,0.00050970
+Flash Sort,500,417,0.00046210
+Flash Sort,500,418,0.00045990
+Flash Sort,500,419,0.00043030
+Flash Sort,500,420,0.00043230
+Flash Sort,500,421,0.00034660
+Flash Sort,500,422,0.00045670
+Flash Sort,500,423,0.00043380
+Flash Sort,500,424,0.00035410
+Flash Sort,500,425,0.00044380
+Flash Sort,500,426,0.00041850
+Flash Sort,500,427,0.00040090
+Flash Sort,500,428,0.00043270
+Flash Sort,500,429,0.00025520
+Flash Sort,500,430,0.00037050
+Flash Sort,500,431,0.00037490
+Flash Sort,500,432,0.00042960
+Flash Sort,500,433,0.00025080
+Flash Sort,500,434,0.00043540
+Flash Sort,500,435,0.00043300
+Flash Sort,500,436,0.00026940
+Flash Sort,500,437,0.00042990
+Flash Sort,500,438,0.00024670
+Flash Sort,500,439,0.00042460
+Flash Sort,500,440,0.00044280
+Flash Sort,500,441,0.00032240
+Flash Sort,500,442,0.00046770
+Flash Sort,500,443,0.00042450
+Flash Sort,500,444,0.00039600
+Flash Sort,500,445,0.00026770
+Flash Sort,500,446,0.00039580
+Flash Sort,500,447,0.00029340
+Flash Sort,500,448,0.00042740
+Flash Sort,500,449,0.00038230
+Flash Sort,500,450,0.00039170
+Flash Sort,500,451,0.00024420
+Flash Sort,500,452,0.00043400
+Flash Sort,500,453,0.00042590
+Flash Sort,500,454,0.00025340
+Flash Sort,500,455,0.00040110
+Flash Sort,500,456,0.00024470
+Flash Sort,500,457,0.00044820
+Flash Sort,500,458,0.00027010
+Flash Sort,500,459,0.00024730
+Flash Sort,500,460,0.00035790
+Flash Sort,500,461,0.00024190
+Flash Sort,500,462,0.00037880
+Flash Sort,500,463,0.00045080
+Flash Sort,500,464,0.00024440
+Flash Sort,500,465,0.00043370
+Flash Sort,500,466,0.00042360
+Flash Sort,500,467,0.00024120
+Flash Sort,500,468,0.00046280
+Flash Sort,500,469,0.00043760
+Flash Sort,500,470,0.00031600
+Flash Sort,500,471,0.00025420
+Flash Sort,500,472,0.00035250
+Flash Sort,500,473,0.00043430
+Flash Sort,500,474,0.00035340
+Flash Sort,500,475,0.00027770
+Flash Sort,500,476,0.00035970
+Flash Sort,500,477,0.00025200
+Flash Sort,500,478,0.00028620
+Flash Sort,500,479,0.00043090
+Flash Sort,500,480,0.00035330
+Flash Sort,500,481,0.00044180
+Flash Sort,500,482,0.00040290
+Flash Sort,500,483,0.00039870
+Flash Sort,500,484,0.00043180
+Flash Sort,500,485,0.00043730
+Flash Sort,500,486,0.00043140
+Flash Sort,500,487,0.00038630
+Flash Sort,500,488,0.00042580
+Flash Sort,500,489,0.00038900
+Flash Sort,500,490,0.00051080
+Flash Sort,500,491,0.00060420
+Flash Sort,500,492,0.00027720
+Flash Sort,500,493,0.00041860
+Flash Sort,500,494,0.00044300
+Flash Sort,500,495,0.00027480
+Flash Sort,500,496,0.00039890
+Flash Sort,500,497,0.00039050
+Flash Sort,500,498,0.00056300
+Flash Sort,500,499,0.00069920
+Flash Sort,500,500,0.00043690
+Franceschini's Method,500,1,0.00093640
+Franceschini's Method,500,2,0.00110620
+Franceschini's Method,500,3,0.00092670
+Franceschini's Method,500,4,0.00105230
+Franceschini's Method,500,5,0.00095790
+Franceschini's Method,500,6,0.00094450
+Franceschini's Method,500,7,0.00093450
+Franceschini's Method,500,8,0.00094900
+Franceschini's Method,500,9,0.00096660
+Franceschini's Method,500,10,0.00139700
+Franceschini's Method,500,11,0.00110760
+Franceschini's Method,500,12,0.00081130
+Franceschini's Method,500,13,0.00125540
+Franceschini's Method,500,14,0.00095750
+Franceschini's Method,500,15,0.00115870
+Franceschini's Method,500,16,0.00103020
+Franceschini's Method,500,17,0.00114580
+Franceschini's Method,500,18,0.00085210
+Franceschini's Method,500,19,0.00089710
+Franceschini's Method,500,20,0.00093300
+Franceschini's Method,500,21,0.00079770
+Franceschini's Method,500,22,0.00073490
+Franceschini's Method,500,23,0.00099010
+Franceschini's Method,500,24,0.00096240
+Franceschini's Method,500,25,0.00078890
+Franceschini's Method,500,26,0.00082240
+Franceschini's Method,500,27,0.00088510
+Franceschini's Method,500,28,0.00083000
+Franceschini's Method,500,29,0.00096310
+Franceschini's Method,500,30,0.00100610
+Franceschini's Method,500,31,0.00100150
+Franceschini's Method,500,32,0.00104970
+Franceschini's Method,500,33,0.00099170
+Franceschini's Method,500,34,0.00098490
+Franceschini's Method,500,35,0.00082690
+Franceschini's Method,500,36,0.00098760
+Franceschini's Method,500,37,0.00087160
+Franceschini's Method,500,38,0.00102900
+Franceschini's Method,500,39,0.00094030
+Franceschini's Method,500,40,0.00095250
+Franceschini's Method,500,41,0.00090410
+Franceschini's Method,500,42,0.00095360
+Franceschini's Method,500,43,0.00086040
+Franceschini's Method,500,44,0.00097230
+Franceschini's Method,500,45,0.00100690
+Franceschini's Method,500,46,0.00109380
+Franceschini's Method,500,47,0.00087920
+Franceschini's Method,500,48,0.00110580
+Franceschini's Method,500,49,0.00092110
+Franceschini's Method,500,50,0.00089320
+Franceschini's Method,500,51,0.00110190
+Franceschini's Method,500,52,0.00086930
+Franceschini's Method,500,53,0.00101320
+Franceschini's Method,500,54,0.00094520
+Franceschini's Method,500,55,0.00090030
+Franceschini's Method,500,56,0.00101310
+Franceschini's Method,500,57,0.00089940
+Franceschini's Method,500,58,0.00089350
+Franceschini's Method,500,59,0.00093450
+Franceschini's Method,500,60,0.00098090
+Franceschini's Method,500,61,0.00100570
+Franceschini's Method,500,62,0.00090890
+Franceschini's Method,500,63,0.00085740
+Franceschini's Method,500,64,0.00082600
+Franceschini's Method,500,65,0.00092710
+Franceschini's Method,500,66,0.00087490
+Franceschini's Method,500,67,0.00099160
+Franceschini's Method,500,68,0.00102320
+Franceschini's Method,500,69,0.00096830
+Franceschini's Method,500,70,0.00076570
+Franceschini's Method,500,71,0.00093530
+Franceschini's Method,500,72,0.00096740
+Franceschini's Method,500,73,0.00094630
+Franceschini's Method,500,74,0.00091870
+Franceschini's Method,500,75,0.00088070
+Franceschini's Method,500,76,0.00083200
+Franceschini's Method,500,77,0.00095720
+Franceschini's Method,500,78,0.00093200
+Franceschini's Method,500,79,0.00098630
+Franceschini's Method,500,80,0.00067880
+Franceschini's Method,500,81,0.00104690
+Franceschini's Method,500,82,0.00102160
+Franceschini's Method,500,83,0.00109410
+Franceschini's Method,500,84,0.00100160
+Franceschini's Method,500,85,0.00097450
+Franceschini's Method,500,86,0.00097380
+Franceschini's Method,500,87,0.00100030
+Franceschini's Method,500,88,0.00091360
+Franceschini's Method,500,89,0.00155860
+Franceschini's Method,500,90,0.00113240
+Franceschini's Method,500,91,0.00093680
+Franceschini's Method,500,92,0.00097250
+Franceschini's Method,500,93,0.00097330
+Franceschini's Method,500,94,0.00101950
+Franceschini's Method,500,95,0.00106850
+Franceschini's Method,500,96,0.00085720
+Franceschini's Method,500,97,0.00062660
+Franceschini's Method,500,98,0.00090040
+Franceschini's Method,500,99,0.00085740
+Franceschini's Method,500,100,0.00098280
+Franceschini's Method,500,101,0.00089160
+Franceschini's Method,500,102,0.00087840
+Franceschini's Method,500,103,0.00083610
+Franceschini's Method,500,104,0.00062680
+Franceschini's Method,500,105,0.00089950
+Franceschini's Method,500,106,0.00090320
+Franceschini's Method,500,107,0.00092320
+Franceschini's Method,500,108,0.00098350
+Franceschini's Method,500,109,0.00098850
+Franceschini's Method,500,110,0.00110920
+Franceschini's Method,500,111,0.00087840
+Franceschini's Method,500,112,0.00095460
+Franceschini's Method,500,113,0.00091130
+Franceschini's Method,500,114,0.00095580
+Franceschini's Method,500,115,0.00069480
+Franceschini's Method,500,116,0.00092840
+Franceschini's Method,500,117,0.00101020
+Franceschini's Method,500,118,0.00092630
+Franceschini's Method,500,119,0.00087500
+Franceschini's Method,500,120,0.00092300
+Franceschini's Method,500,121,0.00074570
+Franceschini's Method,500,122,0.00086150
+Franceschini's Method,500,123,0.00097750
+Franceschini's Method,500,124,0.00098350
+Franceschini's Method,500,125,0.00092750
+Franceschini's Method,500,126,0.00102410
+Franceschini's Method,500,127,0.00107370
+Franceschini's Method,500,128,0.00091160
+Franceschini's Method,500,129,0.00083950
+Franceschini's Method,500,130,0.00097020
+Franceschini's Method,500,131,0.00086110
+Franceschini's Method,500,132,0.00104190
+Franceschini's Method,500,133,0.00091040
+Franceschini's Method,500,134,0.00096710
+Franceschini's Method,500,135,0.00066620
+Franceschini's Method,500,136,0.00098300
+Franceschini's Method,500,137,0.00082750
+Franceschini's Method,500,138,0.00091120
+Franceschini's Method,500,139,0.00090380
+Franceschini's Method,500,140,0.00076180
+Franceschini's Method,500,141,0.00092280
+Franceschini's Method,500,142,0.00086830
+Franceschini's Method,500,143,0.00095370
+Franceschini's Method,500,144,0.00092500
+Franceschini's Method,500,145,0.00058300
+Franceschini's Method,500,146,0.00078720
+Franceschini's Method,500,147,0.00077180
+Franceschini's Method,500,148,0.00089980
+Franceschini's Method,500,149,0.00058710
+Franceschini's Method,500,150,0.00065020
+Franceschini's Method,500,151,0.00072830
+Franceschini's Method,500,152,0.00093420
+Franceschini's Method,500,153,0.00103770
+Franceschini's Method,500,154,0.00075470
+Franceschini's Method,500,155,0.00069610
+Franceschini's Method,500,156,0.00100090
+Franceschini's Method,500,157,0.00069760
+Franceschini's Method,500,158,0.00066580
+Franceschini's Method,500,159,0.00087460
+Franceschini's Method,500,160,0.00085800
+Franceschini's Method,500,161,0.00057420
+Franceschini's Method,500,162,0.00064060
+Franceschini's Method,500,163,0.00054500
+Franceschini's Method,500,164,0.00063240
+Franceschini's Method,500,165,0.00101850
+Franceschini's Method,500,166,0.00111830
+Franceschini's Method,500,167,0.00059400
+Franceschini's Method,500,168,0.00074040
+Franceschini's Method,500,169,0.00094290
+Franceschini's Method,500,170,0.00061640
+Franceschini's Method,500,171,0.00095790
+Franceschini's Method,500,172,0.00068250
+Franceschini's Method,500,173,0.00069570
+Franceschini's Method,500,174,0.00092680
+Franceschini's Method,500,175,0.00077430
+Franceschini's Method,500,176,0.00108040
+Franceschini's Method,500,177,0.00124730
+Franceschini's Method,500,178,0.00079930
+Franceschini's Method,500,179,0.00090200
+Franceschini's Method,500,180,0.00100390
+Franceschini's Method,500,181,0.00079150
+Franceschini's Method,500,182,0.00110360
+Franceschini's Method,500,183,0.00093680
+Franceschini's Method,500,184,0.00102530
+Franceschini's Method,500,185,0.00100110
+Franceschini's Method,500,186,0.00098910
+Franceschini's Method,500,187,0.00085930
+Franceschini's Method,500,188,0.00100310
+Franceschini's Method,500,189,0.00114730
+Franceschini's Method,500,190,0.00112550
+Franceschini's Method,500,191,0.00102490
+Franceschini's Method,500,192,0.00097520
+Franceschini's Method,500,193,0.00095150
+Franceschini's Method,500,194,0.00098060
+Franceschini's Method,500,195,0.00092370
+Franceschini's Method,500,196,0.00096370
+Franceschini's Method,500,197,0.00138350
+Franceschini's Method,500,198,0.00091970
+Franceschini's Method,500,199,0.00112750
+Franceschini's Method,500,200,0.00098610
+Franceschini's Method,500,201,0.00088350
+Franceschini's Method,500,202,0.00076970
+Franceschini's Method,500,203,0.00085950
+Franceschini's Method,500,204,0.00084000
+Franceschini's Method,500,205,0.00093090
+Franceschini's Method,500,206,0.00089860
+Franceschini's Method,500,207,0.00083890
+Franceschini's Method,500,208,0.00065390
+Franceschini's Method,500,209,0.00095220
+Franceschini's Method,500,210,0.00084300
+Franceschini's Method,500,211,0.00066020
+Franceschini's Method,500,212,0.00095920
+Franceschini's Method,500,213,0.00085840
+Franceschini's Method,500,214,0.00102650
+Franceschini's Method,500,215,0.00085280
+Franceschini's Method,500,216,0.00108530
+Franceschini's Method,500,217,0.00101820
+Franceschini's Method,500,218,0.00099350
+Franceschini's Method,500,219,0.00091190
+Franceschini's Method,500,220,0.00165130
+Franceschini's Method,500,221,0.00086200
+Franceschini's Method,500,222,0.00091410
+Franceschini's Method,500,223,0.00076280
+Franceschini's Method,500,224,0.00092050
+Franceschini's Method,500,225,0.00091450
+Franceschini's Method,500,226,0.00066860
+Franceschini's Method,500,227,0.00067070
+Franceschini's Method,500,228,0.00088430
+Franceschini's Method,500,229,0.00074010
+Franceschini's Method,500,230,0.00102130
+Franceschini's Method,500,231,0.00079900
+Franceschini's Method,500,232,0.00105630
+Franceschini's Method,500,233,0.00092160
+Franceschini's Method,500,234,0.00084960
+Franceschini's Method,500,235,0.00083280
+Franceschini's Method,500,236,0.00088200
+Franceschini's Method,500,237,0.00060090
+Franceschini's Method,500,238,0.00097540
+Franceschini's Method,500,239,0.00070290
+Franceschini's Method,500,240,0.00057690
+Franceschini's Method,500,241,0.00074460
+Franceschini's Method,500,242,0.00102040
+Franceschini's Method,500,243,0.00098360
+Franceschini's Method,500,244,0.00086650
+Franceschini's Method,500,245,0.00083840
+Franceschini's Method,500,246,0.00098600
+Franceschini's Method,500,247,0.00098230
+Franceschini's Method,500,248,0.00074770
+Franceschini's Method,500,249,0.00094360
+Franceschini's Method,500,250,0.00093100
+Franceschini's Method,500,251,0.00088430
+Franceschini's Method,500,252,0.00095820
+Franceschini's Method,500,253,0.00080250
+Franceschini's Method,500,254,0.00098840
+Franceschini's Method,500,255,0.00090910
+Franceschini's Method,500,256,0.00102230
+Franceschini's Method,500,257,0.00096680
+Franceschini's Method,500,258,0.00095450
+Franceschini's Method,500,259,0.00091360
+Franceschini's Method,500,260,0.00094800
+Franceschini's Method,500,261,0.00103700
+Franceschini's Method,500,262,0.00098850
+Franceschini's Method,500,263,0.00093470
+Franceschini's Method,500,264,0.00095810
+Franceschini's Method,500,265,0.00058800
+Franceschini's Method,500,266,0.00098670
+Franceschini's Method,500,267,0.00099640
+Franceschini's Method,500,268,0.00067290
+Franceschini's Method,500,269,0.00090670
+Franceschini's Method,500,270,0.00086140
+Franceschini's Method,500,271,0.00112520
+Franceschini's Method,500,272,0.00104490
+Franceschini's Method,500,273,0.00107470
+Franceschini's Method,500,274,0.00098100
+Franceschini's Method,500,275,0.00109960
+Franceschini's Method,500,276,0.00086700
+Franceschini's Method,500,277,0.00120560
+Franceschini's Method,500,278,0.00095990
+Franceschini's Method,500,279,0.00101970
+Franceschini's Method,500,280,0.00071620
+Franceschini's Method,500,281,0.00109180
+Franceschini's Method,500,282,0.00078870
+Franceschini's Method,500,283,0.00097800
+Franceschini's Method,500,284,0.00087420
+Franceschini's Method,500,285,0.00096520
+Franceschini's Method,500,286,0.00090750
+Franceschini's Method,500,287,0.00089930
+Franceschini's Method,500,288,0.00087260
+Franceschini's Method,500,289,0.00103440
+Franceschini's Method,500,290,0.00112340
+Franceschini's Method,500,291,0.00084870
+Franceschini's Method,500,292,0.00061780
+Franceschini's Method,500,293,0.00101440
+Franceschini's Method,500,294,0.00084080
+Franceschini's Method,500,295,0.00083090
+Franceschini's Method,500,296,0.00112300
+Franceschini's Method,500,297,0.00069770
+Franceschini's Method,500,298,0.00081980
+Franceschini's Method,500,299,0.00092710
+Franceschini's Method,500,300,0.00070100
+Franceschini's Method,500,301,0.00081390
+Franceschini's Method,500,302,0.00074440
+Franceschini's Method,500,303,0.00090190
+Franceschini's Method,500,304,0.00094960
+Franceschini's Method,500,305,0.00086550
+Franceschini's Method,500,306,0.00093220
+Franceschini's Method,500,307,0.00088260
+Franceschini's Method,500,308,0.00102170
+Franceschini's Method,500,309,0.00059400
+Franceschini's Method,500,310,0.00086160
+Franceschini's Method,500,311,0.00091890
+Franceschini's Method,500,312,0.00060010
+Franceschini's Method,500,313,0.00089150
+Franceschini's Method,500,314,0.00093310
+Franceschini's Method,500,315,0.00062850
+Franceschini's Method,500,316,0.00125100
+Franceschini's Method,500,317,0.00085880
+Franceschini's Method,500,318,0.00055570
+Franceschini's Method,500,319,0.00089180
+Franceschini's Method,500,320,0.00060050
+Franceschini's Method,500,321,0.00093230
+Franceschini's Method,500,322,0.00092110
+Franceschini's Method,500,323,0.00092780
+Franceschini's Method,500,324,0.00067930
+Franceschini's Method,500,325,0.00090170
+Franceschini's Method,500,326,0.00090970
+Franceschini's Method,500,327,0.00091100
+Franceschini's Method,500,328,0.00067440
+Franceschini's Method,500,329,0.00086810
+Franceschini's Method,500,330,0.00055150
+Franceschini's Method,500,331,0.00069080
+Franceschini's Method,500,332,0.00080770
+Franceschini's Method,500,333,0.00062920
+Franceschini's Method,500,334,0.00077820
+Franceschini's Method,500,335,0.00091330
+Franceschini's Method,500,336,0.00074120
+Franceschini's Method,500,337,0.00062180
+Franceschini's Method,500,338,0.00120790
+Franceschini's Method,500,339,0.00078450
+Franceschini's Method,500,340,0.00084410
+Franceschini's Method,500,341,0.00080610
+Franceschini's Method,500,342,0.00059530
+Franceschini's Method,500,343,0.00060090
+Franceschini's Method,500,344,0.00091840
+Franceschini's Method,500,345,0.00086770
+Franceschini's Method,500,346,0.00055150
+Franceschini's Method,500,347,0.00059460
+Franceschini's Method,500,348,0.00103690
+Franceschini's Method,500,349,0.00055070
+Franceschini's Method,500,350,0.00061470
+Franceschini's Method,500,351,0.00062330
+Franceschini's Method,500,352,0.00067770
+Franceschini's Method,500,353,0.00086000
+Franceschini's Method,500,354,0.00077720
+Franceschini's Method,500,355,0.00090590
+Franceschini's Method,500,356,0.00062880
+Franceschini's Method,500,357,0.00065640
+Franceschini's Method,500,358,0.00074500
+Franceschini's Method,500,359,0.00091920
+Franceschini's Method,500,360,0.00065560
+Franceschini's Method,500,361,0.00095490
+Franceschini's Method,500,362,0.00094740
+Franceschini's Method,500,363,0.00061150
+Franceschini's Method,500,364,0.00087480
+Franceschini's Method,500,365,0.00096850
+Franceschini's Method,500,366,0.00071380
+Franceschini's Method,500,367,0.00098440
+Franceschini's Method,500,368,0.00077520
+Franceschini's Method,500,369,0.00060010
+Franceschini's Method,500,370,0.00056540
+Franceschini's Method,500,371,0.00102020
+Franceschini's Method,500,372,0.00090740
+Franceschini's Method,500,373,0.00090660
+Franceschini's Method,500,374,0.00057350
+Franceschini's Method,500,375,0.00062030
+Franceschini's Method,500,376,0.00096260
+Franceschini's Method,500,377,0.00058420
+Franceschini's Method,500,378,0.00087030
+Franceschini's Method,500,379,0.00112950
+Franceschini's Method,500,380,0.00101450
+Franceschini's Method,500,381,0.00095020
+Franceschini's Method,500,382,0.00096200
+Franceschini's Method,500,383,0.00090820
+Franceschini's Method,500,384,0.00085460
+Franceschini's Method,500,385,0.00095610
+Franceschini's Method,500,386,0.00065030
+Franceschini's Method,500,387,0.00085570
+Franceschini's Method,500,388,0.00071710
+Franceschini's Method,500,389,0.00070670
+Franceschini's Method,500,390,0.00072820
+Franceschini's Method,500,391,0.00064680
+Franceschini's Method,500,392,0.00070020
+Franceschini's Method,500,393,0.00096390
+Franceschini's Method,500,394,0.00065380
+Franceschini's Method,500,395,0.00093320
+Franceschini's Method,500,396,0.00054650
+Franceschini's Method,500,397,0.00092800
+Franceschini's Method,500,398,0.00066450
+Franceschini's Method,500,399,0.00082240
+Franceschini's Method,500,400,0.00081680
+Franceschini's Method,500,401,0.00082820
+Franceschini's Method,500,402,0.00082420
+Franceschini's Method,500,403,0.00056630
+Franceschini's Method,500,404,0.00090830
+Franceschini's Method,500,405,0.00102590
+Franceschini's Method,500,406,0.00097550
+Franceschini's Method,500,407,0.00059230
+Franceschini's Method,500,408,0.00064440
+Franceschini's Method,500,409,0.00059170
+Franceschini's Method,500,410,0.00088690
+Franceschini's Method,500,411,0.00055630
+Franceschini's Method,500,412,0.00075870
+Franceschini's Method,500,413,0.00057260
+Franceschini's Method,500,414,0.00065790
+Franceschini's Method,500,415,0.00075800
+Franceschini's Method,500,416,0.00089430
+Franceschini's Method,500,417,0.00092740
+Franceschini's Method,500,418,0.00091110
+Franceschini's Method,500,419,0.00069110
+Franceschini's Method,500,420,0.00073720
+Franceschini's Method,500,421,0.00087410
+Franceschini's Method,500,422,0.00064220
+Franceschini's Method,500,423,0.00065140
+Franceschini's Method,500,424,0.00057470
+Franceschini's Method,500,425,0.00058580
+Franceschini's Method,500,426,0.00093270
+Franceschini's Method,500,427,0.00077780
+Franceschini's Method,500,428,0.00063010
+Franceschini's Method,500,429,0.00060910
+Franceschini's Method,500,430,0.00080640
+Franceschini's Method,500,431,0.00095300
+Franceschini's Method,500,432,0.00094730
+Franceschini's Method,500,433,0.00092140
+Franceschini's Method,500,434,0.00087630
+Franceschini's Method,500,435,0.00091570
+Franceschini's Method,500,436,0.00084970
+Franceschini's Method,500,437,0.00093750
+Franceschini's Method,500,438,0.00085900
+Franceschini's Method,500,439,0.00100710
+Franceschini's Method,500,440,0.00068590
+Franceschini's Method,500,441,0.00094130
+Franceschini's Method,500,442,0.00062310
+Franceschini's Method,500,443,0.00060620
+Franceschini's Method,500,444,0.00089940
+Franceschini's Method,500,445,0.00092140
+Franceschini's Method,500,446,0.00061650
+Franceschini's Method,500,447,0.00054170
+Franceschini's Method,500,448,0.00086280
+Franceschini's Method,500,449,0.00054810
+Franceschini's Method,500,450,0.00054580
+Franceschini's Method,500,451,0.00085840
+Franceschini's Method,500,452,0.00095580
+Franceschini's Method,500,453,0.00072090
+Franceschini's Method,500,454,0.00095960
+Franceschini's Method,500,455,0.00093910
+Franceschini's Method,500,456,0.00092180
+Franceschini's Method,500,457,0.00101610
+Franceschini's Method,500,458,0.00103970
+Franceschini's Method,500,459,0.00084110
+Franceschini's Method,500,460,0.00102050
+Franceschini's Method,500,461,0.00109590
+Franceschini's Method,500,462,0.00088890
+Franceschini's Method,500,463,0.00087060
+Franceschini's Method,500,464,0.00073610
+Franceschini's Method,500,465,0.00081770
+Franceschini's Method,500,466,0.00066080
+Franceschini's Method,500,467,0.00082550
+Franceschini's Method,500,468,0.00074170
+Franceschini's Method,500,469,0.00073200
+Franceschini's Method,500,470,0.00070350
+Franceschini's Method,500,471,0.00105680
+Franceschini's Method,500,472,0.00059300
+Franceschini's Method,500,473,0.00101660
+Franceschini's Method,500,474,0.00095660
+Franceschini's Method,500,475,0.00094860
+Franceschini's Method,500,476,0.00086970
+Franceschini's Method,500,477,0.00088610
+Franceschini's Method,500,478,0.00085340
+Franceschini's Method,500,479,0.00078480
+Franceschini's Method,500,480,0.00085780
+Franceschini's Method,500,481,0.00092940
+Franceschini's Method,500,482,0.00074080
+Franceschini's Method,500,483,0.00104400
+Franceschini's Method,500,484,0.00115750
+Franceschini's Method,500,485,0.00092230
+Franceschini's Method,500,486,0.00124600
+Franceschini's Method,500,487,0.00079960
+Franceschini's Method,500,488,0.00091250
+Franceschini's Method,500,489,0.00069990
+Franceschini's Method,500,490,0.00090870
+Franceschini's Method,500,491,0.00061430
+Franceschini's Method,500,492,0.00090640
+Franceschini's Method,500,493,0.00061790
+Franceschini's Method,500,494,0.00063820
+Franceschini's Method,500,495,0.00090340
+Franceschini's Method,500,496,0.00057370
+Franceschini's Method,500,497,0.00068900
+Franceschini's Method,500,498,0.00097820
+Franceschini's Method,500,499,0.00094520
+Franceschini's Method,500,500,0.00100830
+Gnome Sort,500,1,0.01947890
+Gnome Sort,500,2,0.01724560
+Gnome Sort,500,3,0.01858120
+Gnome Sort,500,4,0.01922830
+Gnome Sort,500,5,0.02173620
+Gnome Sort,500,6,0.02095510
+Gnome Sort,500,7,0.02057740
+Gnome Sort,500,8,0.02056650
+Gnome Sort,500,9,0.01890760
+Gnome Sort,500,10,0.01987000
+Gnome Sort,500,11,0.01696840
+Gnome Sort,500,12,0.01976360
+Gnome Sort,500,13,0.02126430
+Gnome Sort,500,14,0.01910360
+Gnome Sort,500,15,0.02218170
+Gnome Sort,500,16,0.02164300
+Gnome Sort,500,17,0.02247620
+Gnome Sort,500,18,0.02154610
+Gnome Sort,500,19,0.02128570
+Gnome Sort,500,20,0.02017570
+Gnome Sort,500,21,0.01914910
+Gnome Sort,500,22,0.02065570
+Gnome Sort,500,23,0.01910740
+Gnome Sort,500,24,0.02097230
+Gnome Sort,500,25,0.02109480
+Gnome Sort,500,26,0.01747590
+Gnome Sort,500,27,0.01980520
+Gnome Sort,500,28,0.01901920
+Gnome Sort,500,29,0.02166930
+Gnome Sort,500,30,0.02057050
+Gnome Sort,500,31,0.01933270
+Gnome Sort,500,32,0.02021480
+Gnome Sort,500,33,0.01905840
+Gnome Sort,500,34,0.01973820
+Gnome Sort,500,35,0.02088920
+Gnome Sort,500,36,0.01865590
+Gnome Sort,500,37,0.02152620
+Gnome Sort,500,38,0.02059210
+Gnome Sort,500,39,0.02314700
+Gnome Sort,500,40,0.01753810
+Gnome Sort,500,41,0.01900940
+Gnome Sort,500,42,0.01729000
+Gnome Sort,500,43,0.01758090
+Gnome Sort,500,44,0.01683410
+Gnome Sort,500,45,0.02183840
+Gnome Sort,500,46,0.02096660
+Gnome Sort,500,47,0.01595010
+Gnome Sort,500,48,0.01855280
+Gnome Sort,500,49,0.01501620
+Gnome Sort,500,50,0.01956350
+Gnome Sort,500,51,0.01593680
+Gnome Sort,500,52,0.01440210
+Gnome Sort,500,53,0.01999490
+Gnome Sort,500,54,0.01930450
+Gnome Sort,500,55,0.02153190
+Gnome Sort,500,56,0.01936620
+Gnome Sort,500,57,0.01724980
+Gnome Sort,500,58,0.01864480
+Gnome Sort,500,59,0.01433680
+Gnome Sort,500,60,0.01461960
+Gnome Sort,500,61,0.01410630
+Gnome Sort,500,62,0.01596750
+Gnome Sort,500,63,0.01687590
+Gnome Sort,500,64,0.02010130
+Gnome Sort,500,65,0.01988480
+Gnome Sort,500,66,0.01468100
+Gnome Sort,500,67,0.01832420
+Gnome Sort,500,68,0.01567890
+Gnome Sort,500,69,0.02001480
+Gnome Sort,500,70,0.02006860
+Gnome Sort,500,71,0.02162520
+Gnome Sort,500,72,0.01442730
+Gnome Sort,500,73,0.01901950
+Gnome Sort,500,74,0.01716800
+Gnome Sort,500,75,0.01761270
+Gnome Sort,500,76,0.01789690
+Gnome Sort,500,77,0.01519660
+Gnome Sort,500,78,0.01582360
+Gnome Sort,500,79,0.01672460
+Gnome Sort,500,80,0.01551250
+Gnome Sort,500,81,0.01836320
+Gnome Sort,500,82,0.01586620
+Gnome Sort,500,83,0.01459730
+Gnome Sort,500,84,0.01936210
+Gnome Sort,500,85,0.01846110
+Gnome Sort,500,86,0.01586150
+Gnome Sort,500,87,0.01529140
+Gnome Sort,500,88,0.01781060
+Gnome Sort,500,89,0.01710350
+Gnome Sort,500,90,0.01688790
+Gnome Sort,500,91,0.01545690
+Gnome Sort,500,92,0.02146000
+Gnome Sort,500,93,0.02013830
+Gnome Sort,500,94,0.02013340
+Gnome Sort,500,95,0.01859380
+Gnome Sort,500,96,0.01791420
+Gnome Sort,500,97,0.01742360
+Gnome Sort,500,98,0.01824210
+Gnome Sort,500,99,0.01668640
+Gnome Sort,500,100,0.01835260
+Gnome Sort,500,101,0.01813580
+Gnome Sort,500,102,0.01841480
+Gnome Sort,500,103,0.01955530
+Gnome Sort,500,104,0.01766030
+Gnome Sort,500,105,0.01893390
+Gnome Sort,500,106,0.01644210
+Gnome Sort,500,107,0.01899030
+Gnome Sort,500,108,0.02134260
+Gnome Sort,500,109,0.01876740
+Gnome Sort,500,110,0.01668810
+Gnome Sort,500,111,0.01896010
+Gnome Sort,500,112,0.01757240
+Gnome Sort,500,113,0.02026230
+Gnome Sort,500,114,0.01835030
+Gnome Sort,500,115,0.01939000
+Gnome Sort,500,116,0.01657510
+Gnome Sort,500,117,0.01852470
+Gnome Sort,500,118,0.01977050
+Gnome Sort,500,119,0.01707440
+Gnome Sort,500,120,0.01863140
+Gnome Sort,500,121,0.02039100
+Gnome Sort,500,122,0.01804910
+Gnome Sort,500,123,0.01855030
+Gnome Sort,500,124,0.01854680
+Gnome Sort,500,125,0.01962270
+Gnome Sort,500,126,0.01773580
+Gnome Sort,500,127,0.01899220
+Gnome Sort,500,128,0.01939290
+Gnome Sort,500,129,0.01850900
+Gnome Sort,500,130,0.02004570
+Gnome Sort,500,131,0.01848440
+Gnome Sort,500,132,0.01801290
+Gnome Sort,500,133,0.01924200
+Gnome Sort,500,134,0.01577200
+Gnome Sort,500,135,0.01963100
+Gnome Sort,500,136,0.01761970
+Gnome Sort,500,137,0.01643020
+Gnome Sort,500,138,0.01486510
+Gnome Sort,500,139,0.01503650
+Gnome Sort,500,140,0.02094740
+Gnome Sort,500,141,0.02142100
+Gnome Sort,500,142,0.02146600
+Gnome Sort,500,143,0.02039090
+Gnome Sort,500,144,0.02145610
+Gnome Sort,500,145,0.02071880
+Gnome Sort,500,146,0.02307550
+Gnome Sort,500,147,0.02422240
+Gnome Sort,500,148,0.01965290
+Gnome Sort,500,149,0.02138150
+Gnome Sort,500,150,0.01956350
+Gnome Sort,500,151,0.02058000
+Gnome Sort,500,152,0.02004530
+Gnome Sort,500,153,0.02146830
+Gnome Sort,500,154,0.02000750
+Gnome Sort,500,155,0.02114790
+Gnome Sort,500,156,0.01991850
+Gnome Sort,500,157,0.02097410
+Gnome Sort,500,158,0.02074040
+Gnome Sort,500,159,0.01985450
+Gnome Sort,500,160,0.02130060
+Gnome Sort,500,161,0.01908070
+Gnome Sort,500,162,0.02024880
+Gnome Sort,500,163,0.01958160
+Gnome Sort,500,164,0.02170920
+Gnome Sort,500,165,0.01835710
+Gnome Sort,500,166,0.01747280
+Gnome Sort,500,167,0.02086630
+Gnome Sort,500,168,0.01878080
+Gnome Sort,500,169,0.01694630
+Gnome Sort,500,170,0.01664100
+Gnome Sort,500,171,0.02064580
+Gnome Sort,500,172,0.02135060
+Gnome Sort,500,173,0.02070880
+Gnome Sort,500,174,0.02324610
+Gnome Sort,500,175,0.01993860
+Gnome Sort,500,176,0.01919680
+Gnome Sort,500,177,0.01830550
+Gnome Sort,500,178,0.02087940
+Gnome Sort,500,179,0.01859470
+Gnome Sort,500,180,0.01778980
+Gnome Sort,500,181,0.01921620
+Gnome Sort,500,182,0.01593050
+Gnome Sort,500,183,0.01853500
+Gnome Sort,500,184,0.01742210
+Gnome Sort,500,185,0.02078180
+Gnome Sort,500,186,0.01497730
+Gnome Sort,500,187,0.01620570
+Gnome Sort,500,188,0.01791650
+Gnome Sort,500,189,0.01580130
+Gnome Sort,500,190,0.01643060
+Gnome Sort,500,191,0.01574640
+Gnome Sort,500,192,0.01995740
+Gnome Sort,500,193,0.01932700
+Gnome Sort,500,194,0.01641900
+Gnome Sort,500,195,0.01623760
+Gnome Sort,500,196,0.01658850
+Gnome Sort,500,197,0.01747740
+Gnome Sort,500,198,0.01637150
+Gnome Sort,500,199,0.01358700
+Gnome Sort,500,200,0.01780620
+Gnome Sort,500,201,0.01880830
+Gnome Sort,500,202,0.01715710
+Gnome Sort,500,203,0.01906440
+Gnome Sort,500,204,0.01578760
+Gnome Sort,500,205,0.01636190
+Gnome Sort,500,206,0.01637870
+Gnome Sort,500,207,0.01702480
+Gnome Sort,500,208,0.01847630
+Gnome Sort,500,209,0.01754210
+Gnome Sort,500,210,0.02064200
+Gnome Sort,500,211,0.01949010
+Gnome Sort,500,212,0.01671500
+Gnome Sort,500,213,0.01898790
+Gnome Sort,500,214,0.01847460
+Gnome Sort,500,215,0.01726860
+Gnome Sort,500,216,0.01880970
+Gnome Sort,500,217,0.01716860
+Gnome Sort,500,218,0.01804220
+Gnome Sort,500,219,0.01648230
+Gnome Sort,500,220,0.01932810
+Gnome Sort,500,221,0.01691870
+Gnome Sort,500,222,0.02077860
+Gnome Sort,500,223,0.01738720
+Gnome Sort,500,224,0.02032290
+Gnome Sort,500,225,0.01769150
+Gnome Sort,500,226,0.02011620
+Gnome Sort,500,227,0.01987300
+Gnome Sort,500,228,0.02114520
+Gnome Sort,500,229,0.01846940
+Gnome Sort,500,230,0.01995910
+Gnome Sort,500,231,0.02203220
+Gnome Sort,500,232,0.01903940
+Gnome Sort,500,233,0.01961980
+Gnome Sort,500,234,0.01993460
+Gnome Sort,500,235,0.01956210
+Gnome Sort,500,236,0.02049410
+Gnome Sort,500,237,0.02117620
+Gnome Sort,500,238,0.01720700
+Gnome Sort,500,239,0.01701020
+Gnome Sort,500,240,0.01916190
+Gnome Sort,500,241,0.01877340
+Gnome Sort,500,242,0.01774100
+Gnome Sort,500,243,0.02076700
+Gnome Sort,500,244,0.01907770
+Gnome Sort,500,245,0.01499070
+Gnome Sort,500,246,0.01660940
+Gnome Sort,500,247,0.01724960
+Gnome Sort,500,248,0.02013350
+Gnome Sort,500,249,0.02068080
+Gnome Sort,500,250,0.01871070
+Gnome Sort,500,251,0.01774700
+Gnome Sort,500,252,0.01893280
+Gnome Sort,500,253,0.01606570
+Gnome Sort,500,254,0.01491740
+Gnome Sort,500,255,0.01559230
+Gnome Sort,500,256,0.01467160
+Gnome Sort,500,257,0.01398180
+Gnome Sort,500,258,0.01334440
+Gnome Sort,500,259,0.01812750
+Gnome Sort,500,260,0.01873300
+Gnome Sort,500,261,0.01905460
+Gnome Sort,500,262,0.01754540
+Gnome Sort,500,263,0.01548380
+Gnome Sort,500,264,0.01712690
+Gnome Sort,500,265,0.02120450
+Gnome Sort,500,266,0.01912120
+Gnome Sort,500,267,0.01611090
+Gnome Sort,500,268,0.01665590
+Gnome Sort,500,269,0.01655360
+Gnome Sort,500,270,0.01923940
+Gnome Sort,500,271,0.01640560
+Gnome Sort,500,272,0.01605250
+Gnome Sort,500,273,0.01776450
+Gnome Sort,500,274,0.01982310
+Gnome Sort,500,275,0.01915390
+Gnome Sort,500,276,0.01725250
+Gnome Sort,500,277,0.01911780
+Gnome Sort,500,278,0.01934940
+Gnome Sort,500,279,0.01743250
+Gnome Sort,500,280,0.01657380
+Gnome Sort,500,281,0.01729450
+Gnome Sort,500,282,0.02030180
+Gnome Sort,500,283,0.02036620
+Gnome Sort,500,284,0.01909700
+Gnome Sort,500,285,0.01965130
+Gnome Sort,500,286,0.01652570
+Gnome Sort,500,287,0.01510110
+Gnome Sort,500,288,0.01738180
+Gnome Sort,500,289,0.01959680
+Gnome Sort,500,290,0.01801310
+Gnome Sort,500,291,0.01902750
+Gnome Sort,500,292,0.01932660
+Gnome Sort,500,293,0.01904020
+Gnome Sort,500,294,0.01719500
+Gnome Sort,500,295,0.01595910
+Gnome Sort,500,296,0.01967650
+Gnome Sort,500,297,0.01456260
+Gnome Sort,500,298,0.01670950
+Gnome Sort,500,299,0.01886400
+Gnome Sort,500,300,0.01831520
+Gnome Sort,500,301,0.01757340
+Gnome Sort,500,302,0.01733530
+Gnome Sort,500,303,0.01779130
+Gnome Sort,500,304,0.02033640
+Gnome Sort,500,305,0.02039450
+Gnome Sort,500,306,0.01646170
+Gnome Sort,500,307,0.01768190
+Gnome Sort,500,308,0.02064570
+Gnome Sort,500,309,0.01502270
+Gnome Sort,500,310,0.01727680
+Gnome Sort,500,311,0.01687230
+Gnome Sort,500,312,0.01590900
+Gnome Sort,500,313,0.02057190
+Gnome Sort,500,314,0.01719130
+Gnome Sort,500,315,0.01688330
+Gnome Sort,500,316,0.01875670
+Gnome Sort,500,317,0.01789970
+Gnome Sort,500,318,0.01568830
+Gnome Sort,500,319,0.02003810
+Gnome Sort,500,320,0.01584010
+Gnome Sort,500,321,0.01599790
+Gnome Sort,500,322,0.01774000
+Gnome Sort,500,323,0.01646360
+Gnome Sort,500,324,0.01700240
+Gnome Sort,500,325,0.01985280
+Gnome Sort,500,326,0.02016630
+Gnome Sort,500,327,0.01619280
+Gnome Sort,500,328,0.01495830
+Gnome Sort,500,329,0.01772600
+Gnome Sort,500,330,0.01309830
+Gnome Sort,500,331,0.01759910
+Gnome Sort,500,332,0.01791080
+Gnome Sort,500,333,0.01507960
+Gnome Sort,500,334,0.01508340
+Gnome Sort,500,335,0.01837860
+Gnome Sort,500,336,0.01499990
+Gnome Sort,500,337,0.01424810
+Gnome Sort,500,338,0.01692130
+Gnome Sort,500,339,0.01642700
+Gnome Sort,500,340,0.01912500
+Gnome Sort,500,341,0.01663630
+Gnome Sort,500,342,0.01617580
+Gnome Sort,500,343,0.01615410
+Gnome Sort,500,344,0.01943740
+Gnome Sort,500,345,0.01769990
+Gnome Sort,500,346,0.01566150
+Gnome Sort,500,347,0.01796780
+Gnome Sort,500,348,0.01528340
+Gnome Sort,500,349,0.01629360
+Gnome Sort,500,350,0.01735340
+Gnome Sort,500,351,0.01699260
+Gnome Sort,500,352,0.01690460
+Gnome Sort,500,353,0.01465250
+Gnome Sort,500,354,0.01938540
+Gnome Sort,500,355,0.01931640
+Gnome Sort,500,356,0.02028420
+Gnome Sort,500,357,0.01954150
+Gnome Sort,500,358,0.02153940
+Gnome Sort,500,359,0.02055580
+Gnome Sort,500,360,0.01955840
+Gnome Sort,500,361,0.01838690
+Gnome Sort,500,362,0.01726500
+Gnome Sort,500,363,0.01793930
+Gnome Sort,500,364,0.01404980
+Gnome Sort,500,365,0.01561900
+Gnome Sort,500,366,0.01655110
+Gnome Sort,500,367,0.01556130
+Gnome Sort,500,368,0.01743410
+Gnome Sort,500,369,0.01535710
+Gnome Sort,500,370,0.01655730
+Gnome Sort,500,371,0.01762320
+Gnome Sort,500,372,0.01777140
+Gnome Sort,500,373,0.01430880
+Gnome Sort,500,374,0.01539120
+Gnome Sort,500,375,0.01853330
+Gnome Sort,500,376,0.01772920
+Gnome Sort,500,377,0.01850140
+Gnome Sort,500,378,0.01883580
+Gnome Sort,500,379,0.01749190
+Gnome Sort,500,380,0.01829020
+Gnome Sort,500,381,0.01762450
+Gnome Sort,500,382,0.01913620
+Gnome Sort,500,383,0.01987600
+Gnome Sort,500,384,0.02051860
+Gnome Sort,500,385,0.02106170
+Gnome Sort,500,386,0.01806080
+Gnome Sort,500,387,0.01802710
+Gnome Sort,500,388,0.01635750
+Gnome Sort,500,389,0.01750600
+Gnome Sort,500,390,0.01667520
+Gnome Sort,500,391,0.01843260
+Gnome Sort,500,392,0.01816660
+Gnome Sort,500,393,0.01884510
+Gnome Sort,500,394,0.02061460
+Gnome Sort,500,395,0.01991770
+Gnome Sort,500,396,0.01799450
+Gnome Sort,500,397,0.01898510
+Gnome Sort,500,398,0.01923550
+Gnome Sort,500,399,0.01986880
+Gnome Sort,500,400,0.01980070
+Gnome Sort,500,401,0.01828770
+Gnome Sort,500,402,0.02026820
+Gnome Sort,500,403,0.01580510
+Gnome Sort,500,404,0.01543010
+Gnome Sort,500,405,0.01584360
+Gnome Sort,500,406,0.01405160
+Gnome Sort,500,407,0.01593140
+Gnome Sort,500,408,0.01837620
+Gnome Sort,500,409,0.01677340
+Gnome Sort,500,410,0.01677680
+Gnome Sort,500,411,0.01809630
+Gnome Sort,500,412,0.01606510
+Gnome Sort,500,413,0.01762400
+Gnome Sort,500,414,0.01884530
+Gnome Sort,500,415,0.01641310
+Gnome Sort,500,416,0.01691740
+Gnome Sort,500,417,0.01757030
+Gnome Sort,500,418,0.01392200
+Gnome Sort,500,419,0.01372480
+Gnome Sort,500,420,0.01476940
+Gnome Sort,500,421,0.01650430
+Gnome Sort,500,422,0.01286970
+Gnome Sort,500,423,0.01675840
+Gnome Sort,500,424,0.01671510
+Gnome Sort,500,425,0.02044670
+Gnome Sort,500,426,0.01538540
+Gnome Sort,500,427,0.01875480
+Gnome Sort,500,428,0.01990100
+Gnome Sort,500,429,0.01866580
+Gnome Sort,500,430,0.01664570
+Gnome Sort,500,431,0.01603030
+Gnome Sort,500,432,0.01751000
+Gnome Sort,500,433,0.01890680
+Gnome Sort,500,434,0.01966560
+Gnome Sort,500,435,0.01931530
+Gnome Sort,500,436,0.01686570
+Gnome Sort,500,437,0.01844570
+Gnome Sort,500,438,0.01948490
+Gnome Sort,500,439,0.01907680
+Gnome Sort,500,440,0.01568420
+Gnome Sort,500,441,0.01888890
+Gnome Sort,500,442,0.01614290
+Gnome Sort,500,443,0.01604930
+Gnome Sort,500,444,0.01813600
+Gnome Sort,500,445,0.01965030
+Gnome Sort,500,446,0.01994070
+Gnome Sort,500,447,0.02230420
+Gnome Sort,500,448,0.02288340
+Gnome Sort,500,449,0.02245700
+Gnome Sort,500,450,0.02333020
+Gnome Sort,500,451,0.02317260
+Gnome Sort,500,452,0.02360610
+Gnome Sort,500,453,0.02085040
+Gnome Sort,500,454,0.02092230
+Gnome Sort,500,455,0.02287710
+Gnome Sort,500,456,0.02179900
+Gnome Sort,500,457,0.02095020
+Gnome Sort,500,458,0.02209930
+Gnome Sort,500,459,0.02017590
+Gnome Sort,500,460,0.02084000
+Gnome Sort,500,461,0.02000980
+Gnome Sort,500,462,0.02122890
+Gnome Sort,500,463,0.02027190
+Gnome Sort,500,464,0.02376410
+Gnome Sort,500,465,0.02159770
+Gnome Sort,500,466,0.02322640
+Gnome Sort,500,467,0.02174800
+Gnome Sort,500,468,0.02181380
+Gnome Sort,500,469,0.02287700
+Gnome Sort,500,470,0.02360060
+Gnome Sort,500,471,0.02260860
+Gnome Sort,500,472,0.02188600
+Gnome Sort,500,473,0.02223540
+Gnome Sort,500,474,0.01794540
+Gnome Sort,500,475,0.01888060
+Gnome Sort,500,476,0.01887510
+Gnome Sort,500,477,0.01657500
+Gnome Sort,500,478,0.02071670
+Gnome Sort,500,479,0.01631510
+Gnome Sort,500,480,0.01897570
+Gnome Sort,500,481,0.02023930
+Gnome Sort,500,482,0.02031600
+Gnome Sort,500,483,0.01875380
+Gnome Sort,500,484,0.02063910
+Gnome Sort,500,485,0.01710280
+Gnome Sort,500,486,0.01839300
+Gnome Sort,500,487,0.01628820
+Gnome Sort,500,488,0.01671400
+Gnome Sort,500,489,0.01685290
+Gnome Sort,500,490,0.02021610
+Gnome Sort,500,491,0.01740310
+Gnome Sort,500,492,0.01818490
+Gnome Sort,500,493,0.01603190
+Gnome Sort,500,494,0.01791170
+Gnome Sort,500,495,0.01813290
+Gnome Sort,500,496,0.01905350
+Gnome Sort,500,497,0.01698210
+Gnome Sort,500,498,0.01769030
+Gnome Sort,500,499,0.01966270
+Gnome Sort,500,500,0.01767220
+Heap Sort,500,1,0.00107570
+Heap Sort,500,2,0.00138350
+Heap Sort,500,3,0.00135890
+Heap Sort,500,4,0.00144560
+Heap Sort,500,5,0.00148710
+Heap Sort,500,6,0.00118950
+Heap Sort,500,7,0.00144220
+Heap Sort,500,8,0.00144390
+Heap Sort,500,9,0.00146910
+Heap Sort,500,10,0.00110930
+Heap Sort,500,11,0.00087700
+Heap Sort,500,12,0.00132710
+Heap Sort,500,13,0.00119000
+Heap Sort,500,14,0.00126150
+Heap Sort,500,15,0.00149510
+Heap Sort,500,16,0.00140110
+Heap Sort,500,17,0.00083030
+Heap Sort,500,18,0.00083480
+Heap Sort,500,19,0.00154490
+Heap Sort,500,20,0.00110910
+Heap Sort,500,21,0.00138220
+Heap Sort,500,22,0.00140660
+Heap Sort,500,23,0.00144260
+Heap Sort,500,24,0.00144950
+Heap Sort,500,25,0.00128250
+Heap Sort,500,26,0.00141820
+Heap Sort,500,27,0.00113060
+Heap Sort,500,28,0.00147830
+Heap Sort,500,29,0.00112190
+Heap Sort,500,30,0.00155080
+Heap Sort,500,31,0.00148970
+Heap Sort,500,32,0.00105500
+Heap Sort,500,33,0.00166510
+Heap Sort,500,34,0.00153020
+Heap Sort,500,35,0.00091100
+Heap Sort,500,36,0.00159890
+Heap Sort,500,37,0.00147670
+Heap Sort,500,38,0.00150620
+Heap Sort,500,39,0.00143460
+Heap Sort,500,40,0.00096130
+Heap Sort,500,41,0.00115800
+Heap Sort,500,42,0.00116550
+Heap Sort,500,43,0.00141870
+Heap Sort,500,44,0.00095360
+Heap Sort,500,45,0.00143440
+Heap Sort,500,46,0.00147690
+Heap Sort,500,47,0.00093990
+Heap Sort,500,48,0.00143300
+Heap Sort,500,49,0.00124100
+Heap Sort,500,50,0.00090010
+Heap Sort,500,51,0.00099770
+Heap Sort,500,52,0.00146540
+Heap Sort,500,53,0.00143380
+Heap Sort,500,54,0.00123520
+Heap Sort,500,55,0.00119940
+Heap Sort,500,56,0.00133310
+Heap Sort,500,57,0.00146220
+Heap Sort,500,58,0.00126460
+Heap Sort,500,59,0.00144000
+Heap Sort,500,60,0.00122480
+Heap Sort,500,61,0.00151360
+Heap Sort,500,62,0.00134340
+Heap Sort,500,63,0.00151120
+Heap Sort,500,64,0.00129250
+Heap Sort,500,65,0.00095230
+Heap Sort,500,66,0.00144390
+Heap Sort,500,67,0.00132720
+Heap Sort,500,68,0.00132540
+Heap Sort,500,69,0.00087250
+Heap Sort,500,70,0.00146800
+Heap Sort,500,71,0.00149070
+Heap Sort,500,72,0.00152700
+Heap Sort,500,73,0.00133620
+Heap Sort,500,74,0.00122770
+Heap Sort,500,75,0.00094010
+Heap Sort,500,76,0.00086680
+Heap Sort,500,77,0.00141890
+Heap Sort,500,78,0.00118770
+Heap Sort,500,79,0.00148470
+Heap Sort,500,80,0.00116100
+Heap Sort,500,81,0.00140080
+Heap Sort,500,82,0.00146680
+Heap Sort,500,83,0.00136560
+Heap Sort,500,84,0.00098870
+Heap Sort,500,85,0.00103060
+Heap Sort,500,86,0.00150510
+Heap Sort,500,87,0.00120020
+Heap Sort,500,88,0.00137440
+Heap Sort,500,89,0.00145850
+Heap Sort,500,90,0.00107160
+Heap Sort,500,91,0.00152850
+Heap Sort,500,92,0.00115380
+Heap Sort,500,93,0.00150430
+Heap Sort,500,94,0.00096600
+Heap Sort,500,95,0.00107070
+Heap Sort,500,96,0.00151460
+Heap Sort,500,97,0.00147520
+Heap Sort,500,98,0.00121010
+Heap Sort,500,99,0.00133630
+Heap Sort,500,100,0.00145650
+Heap Sort,500,101,0.00145660
+Heap Sort,500,102,0.00192040
+Heap Sort,500,103,0.00148190
+Heap Sort,500,104,0.00142180
+Heap Sort,500,105,0.00140000
+Heap Sort,500,106,0.00162530
+Heap Sort,500,107,0.00165290
+Heap Sort,500,108,0.00145910
+Heap Sort,500,109,0.00136240
+Heap Sort,500,110,0.00182530
+Heap Sort,500,111,0.00193100
+Heap Sort,500,112,0.00152300
+Heap Sort,500,113,0.00163650
+Heap Sort,500,114,0.00144680
+Heap Sort,500,115,0.00154700
+Heap Sort,500,116,0.00129600
+Heap Sort,500,117,0.00148810
+Heap Sort,500,118,0.00200770
+Heap Sort,500,119,0.00115010
+Heap Sort,500,120,0.00140110
+Heap Sort,500,121,0.00132590
+Heap Sort,500,122,0.00115320
+Heap Sort,500,123,0.00137490
+Heap Sort,500,124,0.00150530
+Heap Sort,500,125,0.00095410
+Heap Sort,500,126,0.00138480
+Heap Sort,500,127,0.00144270
+Heap Sort,500,128,0.00144180
+Heap Sort,500,129,0.00141730
+Heap Sort,500,130,0.00128410
+Heap Sort,500,131,0.00110020
+Heap Sort,500,132,0.00143210
+Heap Sort,500,133,0.00151300
+Heap Sort,500,134,0.00107330
+Heap Sort,500,135,0.00142830
+Heap Sort,500,136,0.00129320
+Heap Sort,500,137,0.00106170
+Heap Sort,500,138,0.00116010
+Heap Sort,500,139,0.00143100
+Heap Sort,500,140,0.00111700
+Heap Sort,500,141,0.00106310
+Heap Sort,500,142,0.00146850
+Heap Sort,500,143,0.00096480
+Heap Sort,500,144,0.00109290
+Heap Sort,500,145,0.00130910
+Heap Sort,500,146,0.00143930
+Heap Sort,500,147,0.00094050
+Heap Sort,500,148,0.00131920
+Heap Sort,500,149,0.00127600
+Heap Sort,500,150,0.00103530
+Heap Sort,500,151,0.00120700
+Heap Sort,500,152,0.00145840
+Heap Sort,500,153,0.00148800
+Heap Sort,500,154,0.00142600
+Heap Sort,500,155,0.00086710
+Heap Sort,500,156,0.00146430
+Heap Sort,500,157,0.00088910
+Heap Sort,500,158,0.00136060
+Heap Sort,500,159,0.00143050
+Heap Sort,500,160,0.00131380
+Heap Sort,500,161,0.00134980
+Heap Sort,500,162,0.00124230
+Heap Sort,500,163,0.00090060
+Heap Sort,500,164,0.00100450
+Heap Sort,500,165,0.00107070
+Heap Sort,500,166,0.00150820
+Heap Sort,500,167,0.00096150
+Heap Sort,500,168,0.00130840
+Heap Sort,500,169,0.00142090
+Heap Sort,500,170,0.00147920
+Heap Sort,500,171,0.00147250
+Heap Sort,500,172,0.00138050
+Heap Sort,500,173,0.00141200
+Heap Sort,500,174,0.00143480
+Heap Sort,500,175,0.00141860
+Heap Sort,500,176,0.00159730
+Heap Sort,500,177,0.00142660
+Heap Sort,500,178,0.00125590
+Heap Sort,500,179,0.00141550
+Heap Sort,500,180,0.00124890
+Heap Sort,500,181,0.00153290
+Heap Sort,500,182,0.00116650
+Heap Sort,500,183,0.00144470
+Heap Sort,500,184,0.00144700
+Heap Sort,500,185,0.00123290
+Heap Sort,500,186,0.00121990
+Heap Sort,500,187,0.00143470
+Heap Sort,500,188,0.00145540
+Heap Sort,500,189,0.00106350
+Heap Sort,500,190,0.00102180
+Heap Sort,500,191,0.00135450
+Heap Sort,500,192,0.00146020
+Heap Sort,500,193,0.00144660
+Heap Sort,500,194,0.00104770
+Heap Sort,500,195,0.00146170
+Heap Sort,500,196,0.00143650
+Heap Sort,500,197,0.00096720
+Heap Sort,500,198,0.00145770
+Heap Sort,500,199,0.00088230
+Heap Sort,500,200,0.00146350
+Heap Sort,500,201,0.00124460
+Heap Sort,500,202,0.00177540
+Heap Sort,500,203,0.00171410
+Heap Sort,500,204,0.00134670
+Heap Sort,500,205,0.00142050
+Heap Sort,500,206,0.00146020
+Heap Sort,500,207,0.00115790
+Heap Sort,500,208,0.00150910
+Heap Sort,500,209,0.00146940
+Heap Sort,500,210,0.00146290
+Heap Sort,500,211,0.00118220
+Heap Sort,500,212,0.00142550
+Heap Sort,500,213,0.00145920
+Heap Sort,500,214,0.00141990
+Heap Sort,500,215,0.00146580
+Heap Sort,500,216,0.00144510
+Heap Sort,500,217,0.00137510
+Heap Sort,500,218,0.00098220
+Heap Sort,500,219,0.00145140
+Heap Sort,500,220,0.00148480
+Heap Sort,500,221,0.00134820
+Heap Sort,500,222,0.00113160
+Heap Sort,500,223,0.00150540
+Heap Sort,500,224,0.00126380
+Heap Sort,500,225,0.00143610
+Heap Sort,500,226,0.00148070
+Heap Sort,500,227,0.00144760
+Heap Sort,500,228,0.00096010
+Heap Sort,500,229,0.00142730
+Heap Sort,500,230,0.00147270
+Heap Sort,500,231,0.00089140
+Heap Sort,500,232,0.00133220
+Heap Sort,500,233,0.00152670
+Heap Sort,500,234,0.00095450
+Heap Sort,500,235,0.00143880
+Heap Sort,500,236,0.00147870
+Heap Sort,500,237,0.00089230
+Heap Sort,500,238,0.00143260
+Heap Sort,500,239,0.00106920
+Heap Sort,500,240,0.00130940
+Heap Sort,500,241,0.00148820
+Heap Sort,500,242,0.00145320
+Heap Sort,500,243,0.00115740
+Heap Sort,500,244,0.00131110
+Heap Sort,500,245,0.00096600
+Heap Sort,500,246,0.00132390
+Heap Sort,500,247,0.00143050
+Heap Sort,500,248,0.00101100
+Heap Sort,500,249,0.00118100
+Heap Sort,500,250,0.00137880
+Heap Sort,500,251,0.00110300
+Heap Sort,500,252,0.00145750
+Heap Sort,500,253,0.00106410
+Heap Sort,500,254,0.00092290
+Heap Sort,500,255,0.00120170
+Heap Sort,500,256,0.00092910
+Heap Sort,500,257,0.00145240
+Heap Sort,500,258,0.00084100
+Heap Sort,500,259,0.00110310
+Heap Sort,500,260,0.00135050
+Heap Sort,500,261,0.00148440
+Heap Sort,500,262,0.00142900
+Heap Sort,500,263,0.00126930
+Heap Sort,500,264,0.00140790
+Heap Sort,500,265,0.00083810
+Heap Sort,500,266,0.00145770
+Heap Sort,500,267,0.00119600
+Heap Sort,500,268,0.00108740
+Heap Sort,500,269,0.00158250
+Heap Sort,500,270,0.00143310
+Heap Sort,500,271,0.00145460
+Heap Sort,500,272,0.00139920
+Heap Sort,500,273,0.00149410
+Heap Sort,500,274,0.00115910
+Heap Sort,500,275,0.00096040
+Heap Sort,500,276,0.00122510
+Heap Sort,500,277,0.00123240
+Heap Sort,500,278,0.00107050
+Heap Sort,500,279,0.00148880
+Heap Sort,500,280,0.00142980
+Heap Sort,500,281,0.00092540
+Heap Sort,500,282,0.00148290
+Heap Sort,500,283,0.00127040
+Heap Sort,500,284,0.00124300
+Heap Sort,500,285,0.00123940
+Heap Sort,500,286,0.00142520
+Heap Sort,500,287,0.00117010
+Heap Sort,500,288,0.00104940
+Heap Sort,500,289,0.00142810
+Heap Sort,500,290,0.00099810
+Heap Sort,500,291,0.00126070
+Heap Sort,500,292,0.00144240
+Heap Sort,500,293,0.00146460
+Heap Sort,500,294,0.00125230
+Heap Sort,500,295,0.00138370
+Heap Sort,500,296,0.00139660
+Heap Sort,500,297,0.00137300
+Heap Sort,500,298,0.00091130
+Heap Sort,500,299,0.00093340
+Heap Sort,500,300,0.00144350
+Heap Sort,500,301,0.00135520
+Heap Sort,500,302,0.00101500
+Heap Sort,500,303,0.00126750
+Heap Sort,500,304,0.00105030
+Heap Sort,500,305,0.00093000
+Heap Sort,500,306,0.00142630
+Heap Sort,500,307,0.00148980
+Heap Sort,500,308,0.00100010
+Heap Sort,500,309,0.00144550
+Heap Sort,500,310,0.00148360
+Heap Sort,500,311,0.00136010
+Heap Sort,500,312,0.00148520
+Heap Sort,500,313,0.00142050
+Heap Sort,500,314,0.00142940
+Heap Sort,500,315,0.00149880
+Heap Sort,500,316,0.00119330
+Heap Sort,500,317,0.00152570
+Heap Sort,500,318,0.00144610
+Heap Sort,500,319,0.00127050
+Heap Sort,500,320,0.00111100
+Heap Sort,500,321,0.00154560
+Heap Sort,500,322,0.00136530
+Heap Sort,500,323,0.00145850
+Heap Sort,500,324,0.00130570
+Heap Sort,500,325,0.00160770
+Heap Sort,500,326,0.00147770
+Heap Sort,500,327,0.00139110
+Heap Sort,500,328,0.00117300
+Heap Sort,500,329,0.00142140
+Heap Sort,500,330,0.00129090
+Heap Sort,500,331,0.00144860
+Heap Sort,500,332,0.00102220
+Heap Sort,500,333,0.00128090
+Heap Sort,500,334,0.00114560
+Heap Sort,500,335,0.00141570
+Heap Sort,500,336,0.00111740
+Heap Sort,500,337,0.00116920
+Heap Sort,500,338,0.00087120
+Heap Sort,500,339,0.00127070
+Heap Sort,500,340,0.00140500
+Heap Sort,500,341,0.00114650
+Heap Sort,500,342,0.00137200
+Heap Sort,500,343,0.00143020
+Heap Sort,500,344,0.00165820
+Heap Sort,500,345,0.00145970
+Heap Sort,500,346,0.00155320
+Heap Sort,500,347,0.00143200
+Heap Sort,500,348,0.00156340
+Heap Sort,500,349,0.00144580
+Heap Sort,500,350,0.00149190
+Heap Sort,500,351,0.00165550
+Heap Sort,500,352,0.00164350
+Heap Sort,500,353,0.00135540
+Heap Sort,500,354,0.00146970
+Heap Sort,500,355,0.00131190
+Heap Sort,500,356,0.00133990
+Heap Sort,500,357,0.00163550
+Heap Sort,500,358,0.00150490
+Heap Sort,500,359,0.00166560
+Heap Sort,500,360,0.00136110
+Heap Sort,500,361,0.00152550
+Heap Sort,500,362,0.00147050
+Heap Sort,500,363,0.00140850
+Heap Sort,500,364,0.00150550
+Heap Sort,500,365,0.00168110
+Heap Sort,500,366,0.00144560
+Heap Sort,500,367,0.00134740
+Heap Sort,500,368,0.00096080
+Heap Sort,500,369,0.00124000
+Heap Sort,500,370,0.00144270
+Heap Sort,500,371,0.00143570
+Heap Sort,500,372,0.00093650
+Heap Sort,500,373,0.00141080
+Heap Sort,500,374,0.00135630
+Heap Sort,500,375,0.00137750
+Heap Sort,500,376,0.00134510
+Heap Sort,500,377,0.00152700
+Heap Sort,500,378,0.00149740
+Heap Sort,500,379,0.00196480
+Heap Sort,500,380,0.00161360
+Heap Sort,500,381,0.00148800
+Heap Sort,500,382,0.00155180
+Heap Sort,500,383,0.00148860
+Heap Sort,500,384,0.00141920
+Heap Sort,500,385,0.00109640
+Heap Sort,500,386,0.00138270
+Heap Sort,500,387,0.00153560
+Heap Sort,500,388,0.00154690
+Heap Sort,500,389,0.00139080
+Heap Sort,500,390,0.00168110
+Heap Sort,500,391,0.00122590
+Heap Sort,500,392,0.00109430
+Heap Sort,500,393,0.00142390
+Heap Sort,500,394,0.00132240
+Heap Sort,500,395,0.00152970
+Heap Sort,500,396,0.00087580
+Heap Sort,500,397,0.00154980
+Heap Sort,500,398,0.00154280
+Heap Sort,500,399,0.00145300
+Heap Sort,500,400,0.00092220
+Heap Sort,500,401,0.00151440
+Heap Sort,500,402,0.00135050
+Heap Sort,500,403,0.00147350
+Heap Sort,500,404,0.00151160
+Heap Sort,500,405,0.00137310
+Heap Sort,500,406,0.00142110
+Heap Sort,500,407,0.00102260
+Heap Sort,500,408,0.00137670
+Heap Sort,500,409,0.00145370
+Heap Sort,500,410,0.00155680
+Heap Sort,500,411,0.00154440
+Heap Sort,500,412,0.00153230
+Heap Sort,500,413,0.00104340
+Heap Sort,500,414,0.00122080
+Heap Sort,500,415,0.00142870
+Heap Sort,500,416,0.00104470
+Heap Sort,500,417,0.00093030
+Heap Sort,500,418,0.00142020
+Heap Sort,500,419,0.00115340
+Heap Sort,500,420,0.00142730
+Heap Sort,500,421,0.00106900
+Heap Sort,500,422,0.00120400
+Heap Sort,500,423,0.00125420
+Heap Sort,500,424,0.00093170
+Heap Sort,500,425,0.00109610
+Heap Sort,500,426,0.00147440
+Heap Sort,500,427,0.00115100
+Heap Sort,500,428,0.00169090
+Heap Sort,500,429,0.00094690
+Heap Sort,500,430,0.00145910
+Heap Sort,500,431,0.00143750
+Heap Sort,500,432,0.00142370
+Heap Sort,500,433,0.00144060
+Heap Sort,500,434,0.00118340
+Heap Sort,500,435,0.00144170
+Heap Sort,500,436,0.00146050
+Heap Sort,500,437,0.00152930
+Heap Sort,500,438,0.00145260
+Heap Sort,500,439,0.00088030
+Heap Sort,500,440,0.00108840
+Heap Sort,500,441,0.00127890
+Heap Sort,500,442,0.00102320
+Heap Sort,500,443,0.00111730
+Heap Sort,500,444,0.00129330
+Heap Sort,500,445,0.00091050
+Heap Sort,500,446,0.00141270
+Heap Sort,500,447,0.00123540
+Heap Sort,500,448,0.00141930
+Heap Sort,500,449,0.00102480
+Heap Sort,500,450,0.00149940
+Heap Sort,500,451,0.00119530
+Heap Sort,500,452,0.00091610
+Heap Sort,500,453,0.00111650
+Heap Sort,500,454,0.00086770
+Heap Sort,500,455,0.00144770
+Heap Sort,500,456,0.00147380
+Heap Sort,500,457,0.00128320
+Heap Sort,500,458,0.00133640
+Heap Sort,500,459,0.00095080
+Heap Sort,500,460,0.00144450
+Heap Sort,500,461,0.00146020
+Heap Sort,500,462,0.00145520
+Heap Sort,500,463,0.00150980
+Heap Sort,500,464,0.00145750
+Heap Sort,500,465,0.00146180
+Heap Sort,500,466,0.00140930
+Heap Sort,500,467,0.00120340
+Heap Sort,500,468,0.00140330
+Heap Sort,500,469,0.00141330
+Heap Sort,500,470,0.00113820
+Heap Sort,500,471,0.00107050
+Heap Sort,500,472,0.00144700
+Heap Sort,500,473,0.00109340
+Heap Sort,500,474,0.00149500
+Heap Sort,500,475,0.00144390
+Heap Sort,500,476,0.00106560
+Heap Sort,500,477,0.00145180
+Heap Sort,500,478,0.00144680
+Heap Sort,500,479,0.00163050
+Heap Sort,500,480,0.00148130
+Heap Sort,500,481,0.00140440
+Heap Sort,500,482,0.00136080
+Heap Sort,500,483,0.00145840
+Heap Sort,500,484,0.00140590
+Heap Sort,500,485,0.00151030
+Heap Sort,500,486,0.00152810
+Heap Sort,500,487,0.00192160
+Heap Sort,500,488,0.00142840
+Heap Sort,500,489,0.00148430
+Heap Sort,500,490,0.00180390
+Heap Sort,500,491,0.00144640
+Heap Sort,500,492,0.00162120
+Heap Sort,500,493,0.00150620
+Heap Sort,500,494,0.00139680
+Heap Sort,500,495,0.00176740
+Heap Sort,500,496,0.00142460
+Heap Sort,500,497,0.00148110
+Heap Sort,500,498,0.00140760
+Heap Sort,500,499,0.00153920
+Heap Sort,500,500,0.00142260
+Hyper Quick,500,1,0.00113750
+Hyper Quick,500,2,0.00119330
+Hyper Quick,500,3,0.00100950
+Hyper Quick,500,4,0.00102800
+Hyper Quick,500,5,0.00094090
+Hyper Quick,500,6,0.00104510
+Hyper Quick,500,7,0.00107320
+Hyper Quick,500,8,0.00097850
+Hyper Quick,500,9,0.00097630
+Hyper Quick,500,10,0.00126620
+Hyper Quick,500,11,0.00097300
+Hyper Quick,500,12,0.00098850
+Hyper Quick,500,13,0.00091570
+Hyper Quick,500,14,0.00117340
+Hyper Quick,500,15,0.00103650
+Hyper Quick,500,16,0.00080090
+Hyper Quick,500,17,0.00091940
+Hyper Quick,500,18,0.00105140
+Hyper Quick,500,19,0.00097190
+Hyper Quick,500,20,0.00099050
+Hyper Quick,500,21,0.00094580
+Hyper Quick,500,22,0.00092490
+Hyper Quick,500,23,0.00104670
+Hyper Quick,500,24,0.00104330
+Hyper Quick,500,25,0.00093920
+Hyper Quick,500,26,0.00083980
+Hyper Quick,500,27,0.00098570
+Hyper Quick,500,28,0.00109320
+Hyper Quick,500,29,0.00099230
+Hyper Quick,500,30,0.00091450
+Hyper Quick,500,31,0.00092310
+Hyper Quick,500,32,0.00104310
+Hyper Quick,500,33,0.00107360
+Hyper Quick,500,34,0.00090540
+Hyper Quick,500,35,0.00084100
+Hyper Quick,500,36,0.00093050
+Hyper Quick,500,37,0.00073460
+Hyper Quick,500,38,0.00081380
+Hyper Quick,500,39,0.00105970
+Hyper Quick,500,40,0.00086230
+Hyper Quick,500,41,0.00095810
+Hyper Quick,500,42,0.00080750
+Hyper Quick,500,43,0.00111890
+Hyper Quick,500,44,0.00091500
+Hyper Quick,500,45,0.00101170
+Hyper Quick,500,46,0.00109850
+Hyper Quick,500,47,0.00092290
+Hyper Quick,500,48,0.00095690
+Hyper Quick,500,49,0.00102190
+Hyper Quick,500,50,0.00094910
+Hyper Quick,500,51,0.00123650
+Hyper Quick,500,52,0.00100290
+Hyper Quick,500,53,0.00100180
+Hyper Quick,500,54,0.00089190
+Hyper Quick,500,55,0.00104900
+Hyper Quick,500,56,0.00091250
+Hyper Quick,500,57,0.00090180
+Hyper Quick,500,58,0.00080740
+Hyper Quick,500,59,0.00070870
+Hyper Quick,500,60,0.00119660
+Hyper Quick,500,61,0.00092420
+Hyper Quick,500,62,0.00100500
+Hyper Quick,500,63,0.00123100
+Hyper Quick,500,64,0.00106130
+Hyper Quick,500,65,0.00096640
+Hyper Quick,500,66,0.00104270
+Hyper Quick,500,67,0.00128300
+Hyper Quick,500,68,0.00107550
+Hyper Quick,500,69,0.00113100
+Hyper Quick,500,70,0.00110150
+Hyper Quick,500,71,0.00108930
+Hyper Quick,500,72,0.00092090
+Hyper Quick,500,73,0.00103820
+Hyper Quick,500,74,0.00117040
+Hyper Quick,500,75,0.00096040
+Hyper Quick,500,76,0.00066700
+Hyper Quick,500,77,0.00095810
+Hyper Quick,500,78,0.00112440
+Hyper Quick,500,79,0.00098060
+Hyper Quick,500,80,0.00094890
+Hyper Quick,500,81,0.00094720
+Hyper Quick,500,82,0.00111210
+Hyper Quick,500,83,0.00104350
+Hyper Quick,500,84,0.00097400
+Hyper Quick,500,85,0.00098590
+Hyper Quick,500,86,0.00097340
+Hyper Quick,500,87,0.00096590
+Hyper Quick,500,88,0.00099530
+Hyper Quick,500,89,0.00091560
+Hyper Quick,500,90,0.00095020
+Hyper Quick,500,91,0.00107400
+Hyper Quick,500,92,0.00110440
+Hyper Quick,500,93,0.00095010
+Hyper Quick,500,94,0.00068990
+Hyper Quick,500,95,0.00096900
+Hyper Quick,500,96,0.00098610
+Hyper Quick,500,97,0.00093370
+Hyper Quick,500,98,0.00064190
+Hyper Quick,500,99,0.00099440
+Hyper Quick,500,100,0.00097260
+Hyper Quick,500,101,0.00102190
+Hyper Quick,500,102,0.00085140
+Hyper Quick,500,103,0.00072320
+Hyper Quick,500,104,0.00107080
+Hyper Quick,500,105,0.00093050
+Hyper Quick,500,106,0.00065710
+Hyper Quick,500,107,0.00092660
+Hyper Quick,500,108,0.00066760
+Hyper Quick,500,109,0.00106540
+Hyper Quick,500,110,0.00103640
+Hyper Quick,500,111,0.00082190
+Hyper Quick,500,112,0.00099610
+Hyper Quick,500,113,0.00095330
+Hyper Quick,500,114,0.00097220
+Hyper Quick,500,115,0.00079510
+Hyper Quick,500,116,0.00103190
+Hyper Quick,500,117,0.00083240
+Hyper Quick,500,118,0.00082440
+Hyper Quick,500,119,0.00076890
+Hyper Quick,500,120,0.00091900
+Hyper Quick,500,121,0.00069370
+Hyper Quick,500,122,0.00062600
+Hyper Quick,500,123,0.00094740
+Hyper Quick,500,124,0.00093090
+Hyper Quick,500,125,0.00096950
+Hyper Quick,500,126,0.00098290
+Hyper Quick,500,127,0.00098940
+Hyper Quick,500,128,0.00094230
+Hyper Quick,500,129,0.00074110
+Hyper Quick,500,130,0.00094400
+Hyper Quick,500,131,0.00060600
+Hyper Quick,500,132,0.00073680
+Hyper Quick,500,133,0.00095310
+Hyper Quick,500,134,0.00101230
+Hyper Quick,500,135,0.00077380
+Hyper Quick,500,136,0.00109780
+Hyper Quick,500,137,0.00094340
+Hyper Quick,500,138,0.00084120
+Hyper Quick,500,139,0.00084720
+Hyper Quick,500,140,0.00090860
+Hyper Quick,500,141,0.00093770
+Hyper Quick,500,142,0.00095760
+Hyper Quick,500,143,0.00086220
+Hyper Quick,500,144,0.00090080
+Hyper Quick,500,145,0.00090640
+Hyper Quick,500,146,0.00098570
+Hyper Quick,500,147,0.00105740
+Hyper Quick,500,148,0.00061240
+Hyper Quick,500,149,0.00069420
+Hyper Quick,500,150,0.00093810
+Hyper Quick,500,151,0.00075680
+Hyper Quick,500,152,0.00100200
+Hyper Quick,500,153,0.00073590
+Hyper Quick,500,154,0.00092120
+Hyper Quick,500,155,0.00059530
+Hyper Quick,500,156,0.00066910
+Hyper Quick,500,157,0.00110700
+Hyper Quick,500,158,0.00097760
+Hyper Quick,500,159,0.00091940
+Hyper Quick,500,160,0.00098760
+Hyper Quick,500,161,0.00095070
+Hyper Quick,500,162,0.00097510
+Hyper Quick,500,163,0.00096910
+Hyper Quick,500,164,0.00094350
+Hyper Quick,500,165,0.00067040
+Hyper Quick,500,166,0.00115170
+Hyper Quick,500,167,0.00089260
+Hyper Quick,500,168,0.00099130
+Hyper Quick,500,169,0.00094760
+Hyper Quick,500,170,0.00078660
+Hyper Quick,500,171,0.00101850
+Hyper Quick,500,172,0.00097900
+Hyper Quick,500,173,0.00100070
+Hyper Quick,500,174,0.00081230
+Hyper Quick,500,175,0.00087630
+Hyper Quick,500,176,0.00091860
+Hyper Quick,500,177,0.00116170
+Hyper Quick,500,178,0.00089850
+Hyper Quick,500,179,0.00097840
+Hyper Quick,500,180,0.00061010
+Hyper Quick,500,181,0.00094970
+Hyper Quick,500,182,0.00092300
+Hyper Quick,500,183,0.00057960
+Hyper Quick,500,184,0.00098910
+Hyper Quick,500,185,0.00060060
+Hyper Quick,500,186,0.00100090
+Hyper Quick,500,187,0.00091400
+Hyper Quick,500,188,0.00066840
+Hyper Quick,500,189,0.00095790
+Hyper Quick,500,190,0.00072940
+Hyper Quick,500,191,0.00084090
+Hyper Quick,500,192,0.00090300
+Hyper Quick,500,193,0.00094190
+Hyper Quick,500,194,0.00067200
+Hyper Quick,500,195,0.00088680
+Hyper Quick,500,196,0.00088860
+Hyper Quick,500,197,0.00065000
+Hyper Quick,500,198,0.00093340
+Hyper Quick,500,199,0.00108020
+Hyper Quick,500,200,0.00060820
+Hyper Quick,500,201,0.00058770
+Hyper Quick,500,202,0.00107400
+Hyper Quick,500,203,0.00088030
+Hyper Quick,500,204,0.00066130
+Hyper Quick,500,205,0.00094440
+Hyper Quick,500,206,0.00094200
+Hyper Quick,500,207,0.00106320
+Hyper Quick,500,208,0.00106620
+Hyper Quick,500,209,0.00091680
+Hyper Quick,500,210,0.00104550
+Hyper Quick,500,211,0.00112930
+Hyper Quick,500,212,0.00107920
+Hyper Quick,500,213,0.00079390
+Hyper Quick,500,214,0.00092680
+Hyper Quick,500,215,0.00103500
+Hyper Quick,500,216,0.00079000
+Hyper Quick,500,217,0.00085020
+Hyper Quick,500,218,0.00087820
+Hyper Quick,500,219,0.00100030
+Hyper Quick,500,220,0.00070300
+Hyper Quick,500,221,0.00094950
+Hyper Quick,500,222,0.00079570
+Hyper Quick,500,223,0.00081480
+Hyper Quick,500,224,0.00104860
+Hyper Quick,500,225,0.00098150
+Hyper Quick,500,226,0.00100770
+Hyper Quick,500,227,0.00064190
+Hyper Quick,500,228,0.00073620
+Hyper Quick,500,229,0.00096840
+Hyper Quick,500,230,0.00066470
+Hyper Quick,500,231,0.00071550
+Hyper Quick,500,232,0.00085020
+Hyper Quick,500,233,0.00095750
+Hyper Quick,500,234,0.00100650
+Hyper Quick,500,235,0.00088250
+Hyper Quick,500,236,0.00103930
+Hyper Quick,500,237,0.00097720
+Hyper Quick,500,238,0.00106170
+Hyper Quick,500,239,0.00129240
+Hyper Quick,500,240,0.00091950
+Hyper Quick,500,241,0.00098970
+Hyper Quick,500,242,0.00095560
+Hyper Quick,500,243,0.00122540
+Hyper Quick,500,244,0.00092190
+Hyper Quick,500,245,0.00094270
+Hyper Quick,500,246,0.00097320
+Hyper Quick,500,247,0.00094380
+Hyper Quick,500,248,0.00097760
+Hyper Quick,500,249,0.00098450
+Hyper Quick,500,250,0.00098930
+Hyper Quick,500,251,0.00097580
+Hyper Quick,500,252,0.00097950
+Hyper Quick,500,253,0.00083890
+Hyper Quick,500,254,0.00102380
+Hyper Quick,500,255,0.00097590
+Hyper Quick,500,256,0.00105450
+Hyper Quick,500,257,0.00097100
+Hyper Quick,500,258,0.00097460
+Hyper Quick,500,259,0.00094480
+Hyper Quick,500,260,0.00109210
+Hyper Quick,500,261,0.00106430
+Hyper Quick,500,262,0.00094590
+Hyper Quick,500,263,0.00111740
+Hyper Quick,500,264,0.00109660
+Hyper Quick,500,265,0.00112340
+Hyper Quick,500,266,0.00105410
+Hyper Quick,500,267,0.00097460
+Hyper Quick,500,268,0.00096720
+Hyper Quick,500,269,0.00100030
+Hyper Quick,500,270,0.00110650
+Hyper Quick,500,271,0.00096010
+Hyper Quick,500,272,0.00094940
+Hyper Quick,500,273,0.00098110
+Hyper Quick,500,274,0.00108250
+Hyper Quick,500,275,0.00102150
+Hyper Quick,500,276,0.00098460
+Hyper Quick,500,277,0.00103060
+Hyper Quick,500,278,0.00106620
+Hyper Quick,500,279,0.00102020
+Hyper Quick,500,280,0.00093830
+Hyper Quick,500,281,0.00100020
+Hyper Quick,500,282,0.00111480
+Hyper Quick,500,283,0.00108500
+Hyper Quick,500,284,0.00103700
+Hyper Quick,500,285,0.00127320
+Hyper Quick,500,286,0.00088370
+Hyper Quick,500,287,0.00096770
+Hyper Quick,500,288,0.00099570
+Hyper Quick,500,289,0.00100630
+Hyper Quick,500,290,0.00086720
+Hyper Quick,500,291,0.00095770
+Hyper Quick,500,292,0.00112640
+Hyper Quick,500,293,0.00097100
+Hyper Quick,500,294,0.00134490
+Hyper Quick,500,295,0.00108290
+Hyper Quick,500,296,0.00102060
+Hyper Quick,500,297,0.00108830
+Hyper Quick,500,298,0.00089720
+Hyper Quick,500,299,0.00097450
+Hyper Quick,500,300,0.00077720
+Hyper Quick,500,301,0.00093570
+Hyper Quick,500,302,0.00096190
+Hyper Quick,500,303,0.00101630
+Hyper Quick,500,304,0.00132920
+Hyper Quick,500,305,0.00105900
+Hyper Quick,500,306,0.00092110
+Hyper Quick,500,307,0.00097990
+Hyper Quick,500,308,0.00101510
+Hyper Quick,500,309,0.00099150
+Hyper Quick,500,310,0.00099080
+Hyper Quick,500,311,0.00093570
+Hyper Quick,500,312,0.00136940
+Hyper Quick,500,313,0.00094750
+Hyper Quick,500,314,0.00100710
+Hyper Quick,500,315,0.00116950
+Hyper Quick,500,316,0.00094760
+Hyper Quick,500,317,0.00094570
+Hyper Quick,500,318,0.00103850
+Hyper Quick,500,319,0.00080330
+Hyper Quick,500,320,0.00106070
+Hyper Quick,500,321,0.00092610
+Hyper Quick,500,322,0.00133210
+Hyper Quick,500,323,0.00099030
+Hyper Quick,500,324,0.00098520
+Hyper Quick,500,325,0.00105080
+Hyper Quick,500,326,0.00107860
+Hyper Quick,500,327,0.00106210
+Hyper Quick,500,328,0.00095330
+Hyper Quick,500,329,0.00093990
+Hyper Quick,500,330,0.00096200
+Hyper Quick,500,331,0.00101760
+Hyper Quick,500,332,0.00146310
+Hyper Quick,500,333,0.00097420
+Hyper Quick,500,334,0.00088670
+Hyper Quick,500,335,0.00142690
+Hyper Quick,500,336,0.00097630
+Hyper Quick,500,337,0.00095550
+Hyper Quick,500,338,0.00100520
+Hyper Quick,500,339,0.00109730
+Hyper Quick,500,340,0.00103150
+Hyper Quick,500,341,0.00103730
+Hyper Quick,500,342,0.00093270
+Hyper Quick,500,343,0.00094150
+Hyper Quick,500,344,0.00082730
+Hyper Quick,500,345,0.00060800
+Hyper Quick,500,346,0.00096730
+Hyper Quick,500,347,0.00084120
+Hyper Quick,500,348,0.00082380
+Hyper Quick,500,349,0.00092590
+Hyper Quick,500,350,0.00100060
+Hyper Quick,500,351,0.00104980
+Hyper Quick,500,352,0.00094470
+Hyper Quick,500,353,0.00072560
+Hyper Quick,500,354,0.00076820
+Hyper Quick,500,355,0.00099870
+Hyper Quick,500,356,0.00068310
+Hyper Quick,500,357,0.00092310
+Hyper Quick,500,358,0.00077810
+Hyper Quick,500,359,0.00090010
+Hyper Quick,500,360,0.00089500
+Hyper Quick,500,361,0.00071930
+Hyper Quick,500,362,0.00098850
+Hyper Quick,500,363,0.00104290
+Hyper Quick,500,364,0.00102390
+Hyper Quick,500,365,0.00099740
+Hyper Quick,500,366,0.00103420
+Hyper Quick,500,367,0.00095040
+Hyper Quick,500,368,0.00095650
+Hyper Quick,500,369,0.00099390
+Hyper Quick,500,370,0.00099380
+Hyper Quick,500,371,0.00096400
+Hyper Quick,500,372,0.00064570
+Hyper Quick,500,373,0.00103330
+Hyper Quick,500,374,0.00099530
+Hyper Quick,500,375,0.00096510
+Hyper Quick,500,376,0.00082680
+Hyper Quick,500,377,0.00090060
+Hyper Quick,500,378,0.00101270
+Hyper Quick,500,379,0.00087080
+Hyper Quick,500,380,0.00083580
+Hyper Quick,500,381,0.00071260
+Hyper Quick,500,382,0.00101880
+Hyper Quick,500,383,0.00098560
+Hyper Quick,500,384,0.00085150
+Hyper Quick,500,385,0.00102020
+Hyper Quick,500,386,0.00102550
+Hyper Quick,500,387,0.00104720
+Hyper Quick,500,388,0.00137670
+Hyper Quick,500,389,0.00104500
+Hyper Quick,500,390,0.00088770
+Hyper Quick,500,391,0.00104050
+Hyper Quick,500,392,0.00114120
+Hyper Quick,500,393,0.00100330
+Hyper Quick,500,394,0.00101800
+Hyper Quick,500,395,0.00098530
+Hyper Quick,500,396,0.00069820
+Hyper Quick,500,397,0.00077620
+Hyper Quick,500,398,0.00092830
+Hyper Quick,500,399,0.00102340
+Hyper Quick,500,400,0.00089600
+Hyper Quick,500,401,0.00076360
+Hyper Quick,500,402,0.00096530
+Hyper Quick,500,403,0.00117140
+Hyper Quick,500,404,0.00103100
+Hyper Quick,500,405,0.00109670
+Hyper Quick,500,406,0.00096260
+Hyper Quick,500,407,0.00105800
+Hyper Quick,500,408,0.00094900
+Hyper Quick,500,409,0.00091000
+Hyper Quick,500,410,0.00073110
+Hyper Quick,500,411,0.00100700
+Hyper Quick,500,412,0.00092970
+Hyper Quick,500,413,0.00088600
+Hyper Quick,500,414,0.00102910
+Hyper Quick,500,415,0.00087620
+Hyper Quick,500,416,0.00099970
+Hyper Quick,500,417,0.00106230
+Hyper Quick,500,418,0.00094850
+Hyper Quick,500,419,0.00091820
+Hyper Quick,500,420,0.00101830
+Hyper Quick,500,421,0.00091650
+Hyper Quick,500,422,0.00096040
+Hyper Quick,500,423,0.00095610
+Hyper Quick,500,424,0.00108890
+Hyper Quick,500,425,0.00134850
+Hyper Quick,500,426,0.00103410
+Hyper Quick,500,427,0.00098570
+Hyper Quick,500,428,0.00104890
+Hyper Quick,500,429,0.00098760
+Hyper Quick,500,430,0.00100030
+Hyper Quick,500,431,0.00097390
+Hyper Quick,500,432,0.00124130
+Hyper Quick,500,433,0.00103110
+Hyper Quick,500,434,0.00147360
+Hyper Quick,500,435,0.00115970
+Hyper Quick,500,436,0.00107190
+Hyper Quick,500,437,0.00096350
+Hyper Quick,500,438,0.00095980
+Hyper Quick,500,439,0.00112780
+Hyper Quick,500,440,0.00100360
+Hyper Quick,500,441,0.00115240
+Hyper Quick,500,442,0.00106850
+Hyper Quick,500,443,0.00100570
+Hyper Quick,500,444,0.00098730
+Hyper Quick,500,445,0.00094670
+Hyper Quick,500,446,0.00097920
+Hyper Quick,500,447,0.00099870
+Hyper Quick,500,448,0.00089880
+Hyper Quick,500,449,0.00093020
+Hyper Quick,500,450,0.00097170
+Hyper Quick,500,451,0.00097700
+Hyper Quick,500,452,0.00087540
+Hyper Quick,500,453,0.00099870
+Hyper Quick,500,454,0.00094760
+Hyper Quick,500,455,0.00071070
+Hyper Quick,500,456,0.00074620
+Hyper Quick,500,457,0.00102310
+Hyper Quick,500,458,0.00078920
+Hyper Quick,500,459,0.00061090
+Hyper Quick,500,460,0.00103970
+Hyper Quick,500,461,0.00105810
+Hyper Quick,500,462,0.00064030
+Hyper Quick,500,463,0.00081340
+Hyper Quick,500,464,0.00100090
+Hyper Quick,500,465,0.00130740
+Hyper Quick,500,466,0.00118780
+Hyper Quick,500,467,0.00195260
+Hyper Quick,500,468,0.00120460
+Hyper Quick,500,469,0.00110680
+Hyper Quick,500,470,0.00085850
+Hyper Quick,500,471,0.00102740
+Hyper Quick,500,472,0.00095820
+Hyper Quick,500,473,0.00096140
+Hyper Quick,500,474,0.00098810
+Hyper Quick,500,475,0.00101450
+Hyper Quick,500,476,0.00095320
+Hyper Quick,500,477,0.00096380
+Hyper Quick,500,478,0.00102310
+Hyper Quick,500,479,0.00095700
+Hyper Quick,500,480,0.00106250
+Hyper Quick,500,481,0.00107940
+Hyper Quick,500,482,0.00119090
+Hyper Quick,500,483,0.00103900
+Hyper Quick,500,484,0.00103440
+Hyper Quick,500,485,0.00097540
+Hyper Quick,500,486,0.00102740
+Hyper Quick,500,487,0.00096320
+Hyper Quick,500,488,0.00098050
+Hyper Quick,500,489,0.00109790
+Hyper Quick,500,490,0.00118880
+Hyper Quick,500,491,0.00107750
+Hyper Quick,500,492,0.00097580
+Hyper Quick,500,493,0.00085570
+Hyper Quick,500,494,0.00112840
+Hyper Quick,500,495,0.00096960
+Hyper Quick,500,496,0.00098920
+Hyper Quick,500,497,0.00106160
+Hyper Quick,500,498,0.00115260
+Hyper Quick,500,499,0.00115910
+Hyper Quick,500,500,0.00139520
+I Can't Believe It Can Sort,500,1,0.00129940
+I Can't Believe It Can Sort,500,2,0.00161550
+I Can't Believe It Can Sort,500,3,0.00121180
+I Can't Believe It Can Sort,500,4,0.00133990
+I Can't Believe It Can Sort,500,5,0.00138310
+I Can't Believe It Can Sort,500,6,0.00149700
+I Can't Believe It Can Sort,500,7,0.00151930
+I Can't Believe It Can Sort,500,8,0.00145210
+I Can't Believe It Can Sort,500,9,0.00134710
+I Can't Believe It Can Sort,500,10,0.00133370
+I Can't Believe It Can Sort,500,11,0.00090540
+I Can't Believe It Can Sort,500,12,0.00136600
+I Can't Believe It Can Sort,500,13,0.00108820
+I Can't Believe It Can Sort,500,14,0.00143200
+I Can't Believe It Can Sort,500,15,0.00095910
+I Can't Believe It Can Sort,500,16,0.00114300
+I Can't Believe It Can Sort,500,17,0.00134250
+I Can't Believe It Can Sort,500,18,0.00122800
+I Can't Believe It Can Sort,500,19,0.00127920
+I Can't Believe It Can Sort,500,20,0.00104540
+I Can't Believe It Can Sort,500,21,0.00135390
+I Can't Believe It Can Sort,500,22,0.00118290
+I Can't Believe It Can Sort,500,23,0.00106300
+I Can't Believe It Can Sort,500,24,0.00138740
+I Can't Believe It Can Sort,500,25,0.00165810
+I Can't Believe It Can Sort,500,26,0.00144680
+I Can't Believe It Can Sort,500,27,0.00134280
+I Can't Believe It Can Sort,500,28,0.00125630
+I Can't Believe It Can Sort,500,29,0.00137210
+I Can't Believe It Can Sort,500,30,0.00126960
+I Can't Believe It Can Sort,500,31,0.00119850
+I Can't Believe It Can Sort,500,32,0.00118150
+I Can't Believe It Can Sort,500,33,0.00137900
+I Can't Believe It Can Sort,500,34,0.00120140
+I Can't Believe It Can Sort,500,35,0.00134310
+I Can't Believe It Can Sort,500,36,0.00124350
+I Can't Believe It Can Sort,500,37,0.00136890
+I Can't Believe It Can Sort,500,38,0.00156650
+I Can't Believe It Can Sort,500,39,0.00129060
+I Can't Believe It Can Sort,500,40,0.00145990
+I Can't Believe It Can Sort,500,41,0.00137550
+I Can't Believe It Can Sort,500,42,0.00123210
+I Can't Believe It Can Sort,500,43,0.00150590
+I Can't Believe It Can Sort,500,44,0.00138670
+I Can't Believe It Can Sort,500,45,0.00141880
+I Can't Believe It Can Sort,500,46,0.00103320
+I Can't Believe It Can Sort,500,47,0.00126440
+I Can't Believe It Can Sort,500,48,0.00159180
+I Can't Believe It Can Sort,500,49,0.00129710
+I Can't Believe It Can Sort,500,50,0.00186120
+I Can't Believe It Can Sort,500,51,0.00124600
+I Can't Believe It Can Sort,500,52,0.00127330
+I Can't Believe It Can Sort,500,53,0.00120700
+I Can't Believe It Can Sort,500,54,0.00128130
+I Can't Believe It Can Sort,500,55,0.00135850
+I Can't Believe It Can Sort,500,56,0.00124160
+I Can't Believe It Can Sort,500,57,0.00110600
+I Can't Believe It Can Sort,500,58,0.00103770
+I Can't Believe It Can Sort,500,59,0.00113110
+I Can't Believe It Can Sort,500,60,0.00136040
+I Can't Believe It Can Sort,500,61,0.00090450
+I Can't Believe It Can Sort,500,62,0.00128210
+I Can't Believe It Can Sort,500,63,0.00121600
+I Can't Believe It Can Sort,500,64,0.00101420
+I Can't Believe It Can Sort,500,65,0.00146210
+I Can't Believe It Can Sort,500,66,0.00093260
+I Can't Believe It Can Sort,500,67,0.00118820
+I Can't Believe It Can Sort,500,68,0.00128990
+I Can't Believe It Can Sort,500,69,0.00119570
+I Can't Believe It Can Sort,500,70,0.00117160
+I Can't Believe It Can Sort,500,71,0.00118690
+I Can't Believe It Can Sort,500,72,0.00134280
+I Can't Believe It Can Sort,500,73,0.00134180
+I Can't Believe It Can Sort,500,74,0.00097650
+I Can't Believe It Can Sort,500,75,0.00118700
+I Can't Believe It Can Sort,500,76,0.00131910
+I Can't Believe It Can Sort,500,77,0.00130040
+I Can't Believe It Can Sort,500,78,0.00144930
+I Can't Believe It Can Sort,500,79,0.00127490
+I Can't Believe It Can Sort,500,80,0.00121250
+I Can't Believe It Can Sort,500,81,0.00149910
+I Can't Believe It Can Sort,500,82,0.00124750
+I Can't Believe It Can Sort,500,83,0.00137330
+I Can't Believe It Can Sort,500,84,0.00128780
+I Can't Believe It Can Sort,500,85,0.00130610
+I Can't Believe It Can Sort,500,86,0.00123280
+I Can't Believe It Can Sort,500,87,0.00120560
+I Can't Believe It Can Sort,500,88,0.00112170
+I Can't Believe It Can Sort,500,89,0.00132300
+I Can't Believe It Can Sort,500,90,0.00124560
+I Can't Believe It Can Sort,500,91,0.00097040
+I Can't Believe It Can Sort,500,92,0.00127010
+I Can't Believe It Can Sort,500,93,0.00124760
+I Can't Believe It Can Sort,500,94,0.00133840
+I Can't Believe It Can Sort,500,95,0.00083230
+I Can't Believe It Can Sort,500,96,0.00124100
+I Can't Believe It Can Sort,500,97,0.00073390
+I Can't Believe It Can Sort,500,98,0.00124940
+I Can't Believe It Can Sort,500,99,0.00132060
+I Can't Believe It Can Sort,500,100,0.00097560
+I Can't Believe It Can Sort,500,101,0.00132100
+I Can't Believe It Can Sort,500,102,0.00121140
+I Can't Believe It Can Sort,500,103,0.00111920
+I Can't Believe It Can Sort,500,104,0.00114070
+I Can't Believe It Can Sort,500,105,0.00108610
+I Can't Believe It Can Sort,500,106,0.00120420
+I Can't Believe It Can Sort,500,107,0.00121130
+I Can't Believe It Can Sort,500,108,0.00104390
+I Can't Believe It Can Sort,500,109,0.00104490
+I Can't Believe It Can Sort,500,110,0.00113870
+I Can't Believe It Can Sort,500,111,0.00121820
+I Can't Believe It Can Sort,500,112,0.00159320
+I Can't Believe It Can Sort,500,113,0.00130770
+I Can't Believe It Can Sort,500,114,0.00122820
+I Can't Believe It Can Sort,500,115,0.00126810
+I Can't Believe It Can Sort,500,116,0.00118590
+I Can't Believe It Can Sort,500,117,0.00147540
+I Can't Believe It Can Sort,500,118,0.00124600
+I Can't Believe It Can Sort,500,119,0.00103360
+I Can't Believe It Can Sort,500,120,0.00129560
+I Can't Believe It Can Sort,500,121,0.00150320
+I Can't Believe It Can Sort,500,122,0.00120360
+I Can't Believe It Can Sort,500,123,0.00099910
+I Can't Believe It Can Sort,500,124,0.00109050
+I Can't Believe It Can Sort,500,125,0.00147690
+I Can't Believe It Can Sort,500,126,0.00114300
+I Can't Believe It Can Sort,500,127,0.00111520
+I Can't Believe It Can Sort,500,128,0.00109780
+I Can't Believe It Can Sort,500,129,0.00125810
+I Can't Believe It Can Sort,500,130,0.00118940
+I Can't Believe It Can Sort,500,131,0.00125110
+I Can't Believe It Can Sort,500,132,0.00110890
+I Can't Believe It Can Sort,500,133,0.00119640
+I Can't Believe It Can Sort,500,134,0.00124440
+I Can't Believe It Can Sort,500,135,0.00127950
+I Can't Believe It Can Sort,500,136,0.00133260
+I Can't Believe It Can Sort,500,137,0.00108340
+I Can't Believe It Can Sort,500,138,0.00124400
+I Can't Believe It Can Sort,500,139,0.00119430
+I Can't Believe It Can Sort,500,140,0.00122970
+I Can't Believe It Can Sort,500,141,0.00104220
+I Can't Believe It Can Sort,500,142,0.00125980
+I Can't Believe It Can Sort,500,143,0.00123960
+I Can't Believe It Can Sort,500,144,0.00127410
+I Can't Believe It Can Sort,500,145,0.00111460
+I Can't Believe It Can Sort,500,146,0.00138390
+I Can't Believe It Can Sort,500,147,0.00120030
+I Can't Believe It Can Sort,500,148,0.00126520
+I Can't Believe It Can Sort,500,149,0.00112770
+I Can't Believe It Can Sort,500,150,0.00125880
+I Can't Believe It Can Sort,500,151,0.00143490
+I Can't Believe It Can Sort,500,152,0.00125970
+I Can't Believe It Can Sort,500,153,0.00125590
+I Can't Believe It Can Sort,500,154,0.00124520
+I Can't Believe It Can Sort,500,155,0.00138150
+I Can't Believe It Can Sort,500,156,0.00121050
+I Can't Believe It Can Sort,500,157,0.00124770
+I Can't Believe It Can Sort,500,158,0.00131430
+I Can't Believe It Can Sort,500,159,0.00142570
+I Can't Believe It Can Sort,500,160,0.00082750
+I Can't Believe It Can Sort,500,161,0.00119670
+I Can't Believe It Can Sort,500,162,0.00093490
+I Can't Believe It Can Sort,500,163,0.00110880
+I Can't Believe It Can Sort,500,164,0.00108690
+I Can't Believe It Can Sort,500,165,0.00096150
+I Can't Believe It Can Sort,500,166,0.00109640
+I Can't Believe It Can Sort,500,167,0.00074810
+I Can't Believe It Can Sort,500,168,0.00101480
+I Can't Believe It Can Sort,500,169,0.00081840
+I Can't Believe It Can Sort,500,170,0.00127140
+I Can't Believe It Can Sort,500,171,0.00099760
+I Can't Believe It Can Sort,500,172,0.00133680
+I Can't Believe It Can Sort,500,173,0.00130240
+I Can't Believe It Can Sort,500,174,0.00132730
+I Can't Believe It Can Sort,500,175,0.00119430
+I Can't Believe It Can Sort,500,176,0.00074020
+I Can't Believe It Can Sort,500,177,0.00113980
+I Can't Believe It Can Sort,500,178,0.00103170
+I Can't Believe It Can Sort,500,179,0.00097970
+I Can't Believe It Can Sort,500,180,0.00117800
+I Can't Believe It Can Sort,500,181,0.00138940
+I Can't Believe It Can Sort,500,182,0.00077310
+I Can't Believe It Can Sort,500,183,0.00120590
+I Can't Believe It Can Sort,500,184,0.00107230
+I Can't Believe It Can Sort,500,185,0.00071240
+I Can't Believe It Can Sort,500,186,0.00119090
+I Can't Believe It Can Sort,500,187,0.00124130
+I Can't Believe It Can Sort,500,188,0.00110420
+I Can't Believe It Can Sort,500,189,0.00074050
+I Can't Believe It Can Sort,500,190,0.00143460
+I Can't Believe It Can Sort,500,191,0.00129380
+I Can't Believe It Can Sort,500,192,0.00127040
+I Can't Believe It Can Sort,500,193,0.00137700
+I Can't Believe It Can Sort,500,194,0.00144600
+I Can't Believe It Can Sort,500,195,0.00092200
+I Can't Believe It Can Sort,500,196,0.00094480
+I Can't Believe It Can Sort,500,197,0.00093570
+I Can't Believe It Can Sort,500,198,0.00099720
+I Can't Believe It Can Sort,500,199,0.00144710
+I Can't Believe It Can Sort,500,200,0.00120050
+I Can't Believe It Can Sort,500,201,0.00072460
+I Can't Believe It Can Sort,500,202,0.00121220
+I Can't Believe It Can Sort,500,203,0.00119960
+I Can't Believe It Can Sort,500,204,0.00118800
+I Can't Believe It Can Sort,500,205,0.00123170
+I Can't Believe It Can Sort,500,206,0.00097190
+I Can't Believe It Can Sort,500,207,0.00089800
+I Can't Believe It Can Sort,500,208,0.00122270
+I Can't Believe It Can Sort,500,209,0.00130830
+I Can't Believe It Can Sort,500,210,0.00117320
+I Can't Believe It Can Sort,500,211,0.00124170
+I Can't Believe It Can Sort,500,212,0.00094120
+I Can't Believe It Can Sort,500,213,0.00137710
+I Can't Believe It Can Sort,500,214,0.00099560
+I Can't Believe It Can Sort,500,215,0.00128700
+I Can't Believe It Can Sort,500,216,0.00121000
+I Can't Believe It Can Sort,500,217,0.00137620
+I Can't Believe It Can Sort,500,218,0.00120540
+I Can't Believe It Can Sort,500,219,0.00122620
+I Can't Believe It Can Sort,500,220,0.00081370
+I Can't Believe It Can Sort,500,221,0.00071530
+I Can't Believe It Can Sort,500,222,0.00136870
+I Can't Believe It Can Sort,500,223,0.00108030
+I Can't Believe It Can Sort,500,224,0.00071040
+I Can't Believe It Can Sort,500,225,0.00071530
+I Can't Believe It Can Sort,500,226,0.00098460
+I Can't Believe It Can Sort,500,227,0.00103740
+I Can't Believe It Can Sort,500,228,0.00122920
+I Can't Believe It Can Sort,500,229,0.00136080
+I Can't Believe It Can Sort,500,230,0.00074050
+I Can't Believe It Can Sort,500,231,0.00120380
+I Can't Believe It Can Sort,500,232,0.00125580
+I Can't Believe It Can Sort,500,233,0.00138810
+I Can't Believe It Can Sort,500,234,0.00077460
+I Can't Believe It Can Sort,500,235,0.00137240
+I Can't Believe It Can Sort,500,236,0.00108120
+I Can't Believe It Can Sort,500,237,0.00128540
+I Can't Believe It Can Sort,500,238,0.00116770
+I Can't Believe It Can Sort,500,239,0.00128310
+I Can't Believe It Can Sort,500,240,0.00073820
+I Can't Believe It Can Sort,500,241,0.00115140
+I Can't Believe It Can Sort,500,242,0.00114960
+I Can't Believe It Can Sort,500,243,0.00111060
+I Can't Believe It Can Sort,500,244,0.00111090
+I Can't Believe It Can Sort,500,245,0.00107790
+I Can't Believe It Can Sort,500,246,0.00136310
+I Can't Believe It Can Sort,500,247,0.00119710
+I Can't Believe It Can Sort,500,248,0.00077920
+I Can't Believe It Can Sort,500,249,0.00085220
+I Can't Believe It Can Sort,500,250,0.00142130
+I Can't Believe It Can Sort,500,251,0.00070740
+I Can't Believe It Can Sort,500,252,0.00103640
+I Can't Believe It Can Sort,500,253,0.00096580
+I Can't Believe It Can Sort,500,254,0.00091530
+I Can't Believe It Can Sort,500,255,0.00123960
+I Can't Believe It Can Sort,500,256,0.00097820
+I Can't Believe It Can Sort,500,257,0.00120800
+I Can't Believe It Can Sort,500,258,0.00119230
+I Can't Believe It Can Sort,500,259,0.00099170
+I Can't Believe It Can Sort,500,260,0.00140480
+I Can't Believe It Can Sort,500,261,0.00129810
+I Can't Believe It Can Sort,500,262,0.00119570
+I Can't Believe It Can Sort,500,263,0.00094520
+I Can't Believe It Can Sort,500,264,0.00126740
+I Can't Believe It Can Sort,500,265,0.00148280
+I Can't Believe It Can Sort,500,266,0.00116170
+I Can't Believe It Can Sort,500,267,0.00115400
+I Can't Believe It Can Sort,500,268,0.00097530
+I Can't Believe It Can Sort,500,269,0.00161380
+I Can't Believe It Can Sort,500,270,0.00118250
+I Can't Believe It Can Sort,500,271,0.00107010
+I Can't Believe It Can Sort,500,272,0.00122100
+I Can't Believe It Can Sort,500,273,0.00125760
+I Can't Believe It Can Sort,500,274,0.00119390
+I Can't Believe It Can Sort,500,275,0.00152990
+I Can't Believe It Can Sort,500,276,0.00123170
+I Can't Believe It Can Sort,500,277,0.00116700
+I Can't Believe It Can Sort,500,278,0.00127630
+I Can't Believe It Can Sort,500,279,0.00127230
+I Can't Believe It Can Sort,500,280,0.00135790
+I Can't Believe It Can Sort,500,281,0.00123120
+I Can't Believe It Can Sort,500,282,0.00132550
+I Can't Believe It Can Sort,500,283,0.00139900
+I Can't Believe It Can Sort,500,284,0.00121120
+I Can't Believe It Can Sort,500,285,0.00119440
+I Can't Believe It Can Sort,500,286,0.00090830
+I Can't Believe It Can Sort,500,287,0.00124030
+I Can't Believe It Can Sort,500,288,0.00136510
+I Can't Believe It Can Sort,500,289,0.00095880
+I Can't Believe It Can Sort,500,290,0.00120750
+I Can't Believe It Can Sort,500,291,0.00113750
+I Can't Believe It Can Sort,500,292,0.00115430
+I Can't Believe It Can Sort,500,293,0.00119230
+I Can't Believe It Can Sort,500,294,0.00139470
+I Can't Believe It Can Sort,500,295,0.00112340
+I Can't Believe It Can Sort,500,296,0.00112400
+I Can't Believe It Can Sort,500,297,0.00120830
+I Can't Believe It Can Sort,500,298,0.00140950
+I Can't Believe It Can Sort,500,299,0.00117300
+I Can't Believe It Can Sort,500,300,0.00117270
+I Can't Believe It Can Sort,500,301,0.00099620
+I Can't Believe It Can Sort,500,302,0.00119530
+I Can't Believe It Can Sort,500,303,0.00095810
+I Can't Believe It Can Sort,500,304,0.00087240
+I Can't Believe It Can Sort,500,305,0.00104090
+I Can't Believe It Can Sort,500,306,0.00118890
+I Can't Believe It Can Sort,500,307,0.00077650
+I Can't Believe It Can Sort,500,308,0.00089390
+I Can't Believe It Can Sort,500,309,0.00125100
+I Can't Believe It Can Sort,500,310,0.00104200
+I Can't Believe It Can Sort,500,311,0.00131910
+I Can't Believe It Can Sort,500,312,0.00119660
+I Can't Believe It Can Sort,500,313,0.00103730
+I Can't Believe It Can Sort,500,314,0.00123760
+I Can't Believe It Can Sort,500,315,0.00135950
+I Can't Believe It Can Sort,500,316,0.00126060
+I Can't Believe It Can Sort,500,317,0.00120530
+I Can't Believe It Can Sort,500,318,0.00109180
+I Can't Believe It Can Sort,500,319,0.00143430
+I Can't Believe It Can Sort,500,320,0.00075410
+I Can't Believe It Can Sort,500,321,0.00080140
+I Can't Believe It Can Sort,500,322,0.00118590
+I Can't Believe It Can Sort,500,323,0.00099470
+I Can't Believe It Can Sort,500,324,0.00119820
+I Can't Believe It Can Sort,500,325,0.00136730
+I Can't Believe It Can Sort,500,326,0.00110180
+I Can't Believe It Can Sort,500,327,0.00096820
+I Can't Believe It Can Sort,500,328,0.00093900
+I Can't Believe It Can Sort,500,329,0.00136820
+I Can't Believe It Can Sort,500,330,0.00128500
+I Can't Believe It Can Sort,500,331,0.00124340
+I Can't Believe It Can Sort,500,332,0.00079750
+I Can't Believe It Can Sort,500,333,0.00134800
+I Can't Believe It Can Sort,500,334,0.00072890
+I Can't Believe It Can Sort,500,335,0.00128590
+I Can't Believe It Can Sort,500,336,0.00072570
+I Can't Believe It Can Sort,500,337,0.00098880
+I Can't Believe It Can Sort,500,338,0.00107900
+I Can't Believe It Can Sort,500,339,0.00122700
+I Can't Believe It Can Sort,500,340,0.00079520
+I Can't Believe It Can Sort,500,341,0.00089030
+I Can't Believe It Can Sort,500,342,0.00098280
+I Can't Believe It Can Sort,500,343,0.00114350
+I Can't Believe It Can Sort,500,344,0.00109860
+I Can't Believe It Can Sort,500,345,0.00086090
+I Can't Believe It Can Sort,500,346,0.00081890
+I Can't Believe It Can Sort,500,347,0.00080410
+I Can't Believe It Can Sort,500,348,0.00138360
+I Can't Believe It Can Sort,500,349,0.00083670
+I Can't Believe It Can Sort,500,350,0.00125290
+I Can't Believe It Can Sort,500,351,0.00122820
+I Can't Believe It Can Sort,500,352,0.00128100
+I Can't Believe It Can Sort,500,353,0.00136190
+I Can't Believe It Can Sort,500,354,0.00104420
+I Can't Believe It Can Sort,500,355,0.00081510
+I Can't Believe It Can Sort,500,356,0.00114620
+I Can't Believe It Can Sort,500,357,0.00128740
+I Can't Believe It Can Sort,500,358,0.00121940
+I Can't Believe It Can Sort,500,359,0.00118870
+I Can't Believe It Can Sort,500,360,0.00094600
+I Can't Believe It Can Sort,500,361,0.00121120
+I Can't Believe It Can Sort,500,362,0.00085710
+I Can't Believe It Can Sort,500,363,0.00084790
+I Can't Believe It Can Sort,500,364,0.00121130
+I Can't Believe It Can Sort,500,365,0.00073500
+I Can't Believe It Can Sort,500,366,0.00078640
+I Can't Believe It Can Sort,500,367,0.00117550
+I Can't Believe It Can Sort,500,368,0.00074590
+I Can't Believe It Can Sort,500,369,0.00118670
+I Can't Believe It Can Sort,500,370,0.00074640
+I Can't Believe It Can Sort,500,371,0.00107250
+I Can't Believe It Can Sort,500,372,0.00074520
+I Can't Believe It Can Sort,500,373,0.00079990
+I Can't Believe It Can Sort,500,374,0.00081520
+I Can't Believe It Can Sort,500,375,0.00119920
+I Can't Believe It Can Sort,500,376,0.00138040
+I Can't Believe It Can Sort,500,377,0.00123800
+I Can't Believe It Can Sort,500,378,0.00098650
+I Can't Believe It Can Sort,500,379,0.00119610
+I Can't Believe It Can Sort,500,380,0.00115330
+I Can't Believe It Can Sort,500,381,0.00102970
+I Can't Believe It Can Sort,500,382,0.00139000
+I Can't Believe It Can Sort,500,383,0.00124800
+I Can't Believe It Can Sort,500,384,0.00120100
+I Can't Believe It Can Sort,500,385,0.00139260
+I Can't Believe It Can Sort,500,386,0.00119190
+I Can't Believe It Can Sort,500,387,0.00105000
+I Can't Believe It Can Sort,500,388,0.00115580
+I Can't Believe It Can Sort,500,389,0.00119940
+I Can't Believe It Can Sort,500,390,0.00073840
+I Can't Believe It Can Sort,500,391,0.00103270
+I Can't Believe It Can Sort,500,392,0.00109090
+I Can't Believe It Can Sort,500,393,0.00105640
+I Can't Believe It Can Sort,500,394,0.00119720
+I Can't Believe It Can Sort,500,395,0.00128610
+I Can't Believe It Can Sort,500,396,0.00147320
+I Can't Believe It Can Sort,500,397,0.00132530
+I Can't Believe It Can Sort,500,398,0.00113930
+I Can't Believe It Can Sort,500,399,0.00116000
+I Can't Believe It Can Sort,500,400,0.00135860
+I Can't Believe It Can Sort,500,401,0.00123440
+I Can't Believe It Can Sort,500,402,0.00077990
+I Can't Believe It Can Sort,500,403,0.00124200
+I Can't Believe It Can Sort,500,404,0.00101290
+I Can't Believe It Can Sort,500,405,0.00125650
+I Can't Believe It Can Sort,500,406,0.00139930
+I Can't Believe It Can Sort,500,407,0.00123310
+I Can't Believe It Can Sort,500,408,0.00107740
+I Can't Believe It Can Sort,500,409,0.00124930
+I Can't Believe It Can Sort,500,410,0.00135660
+I Can't Believe It Can Sort,500,411,0.00120970
+I Can't Believe It Can Sort,500,412,0.00118650
+I Can't Believe It Can Sort,500,413,0.00129410
+I Can't Believe It Can Sort,500,414,0.00161270
+I Can't Believe It Can Sort,500,415,0.00102250
+I Can't Believe It Can Sort,500,416,0.00077870
+I Can't Believe It Can Sort,500,417,0.00114200
+I Can't Believe It Can Sort,500,418,0.00072790
+I Can't Believe It Can Sort,500,419,0.00102350
+I Can't Believe It Can Sort,500,420,0.00130030
+I Can't Believe It Can Sort,500,421,0.00084980
+I Can't Believe It Can Sort,500,422,0.00119410
+I Can't Believe It Can Sort,500,423,0.00131830
+I Can't Believe It Can Sort,500,424,0.00135940
+I Can't Believe It Can Sort,500,425,0.00095300
+I Can't Believe It Can Sort,500,426,0.00109490
+I Can't Believe It Can Sort,500,427,0.00077360
+I Can't Believe It Can Sort,500,428,0.00117580
+I Can't Believe It Can Sort,500,429,0.00136510
+I Can't Believe It Can Sort,500,430,0.00120980
+I Can't Believe It Can Sort,500,431,0.00075770
+I Can't Believe It Can Sort,500,432,0.00081810
+I Can't Believe It Can Sort,500,433,0.00124100
+I Can't Believe It Can Sort,500,434,0.00136770
+I Can't Believe It Can Sort,500,435,0.00110850
+I Can't Believe It Can Sort,500,436,0.00123960
+I Can't Believe It Can Sort,500,437,0.00123500
+I Can't Believe It Can Sort,500,438,0.00123590
+I Can't Believe It Can Sort,500,439,0.00141670
+I Can't Believe It Can Sort,500,440,0.00126040
+I Can't Believe It Can Sort,500,441,0.00142160
+I Can't Believe It Can Sort,500,442,0.00129210
+I Can't Believe It Can Sort,500,443,0.00153100
+I Can't Believe It Can Sort,500,444,0.00125850
+I Can't Believe It Can Sort,500,445,0.00123630
+I Can't Believe It Can Sort,500,446,0.00111980
+I Can't Believe It Can Sort,500,447,0.00121310
+I Can't Believe It Can Sort,500,448,0.00143110
+I Can't Believe It Can Sort,500,449,0.00122290
+I Can't Believe It Can Sort,500,450,0.00127900
+I Can't Believe It Can Sort,500,451,0.00123920
+I Can't Believe It Can Sort,500,452,0.00131970
+I Can't Believe It Can Sort,500,453,0.00112760
+I Can't Believe It Can Sort,500,454,0.00124350
+I Can't Believe It Can Sort,500,455,0.00123880
+I Can't Believe It Can Sort,500,456,0.00110010
+I Can't Believe It Can Sort,500,457,0.00107220
+I Can't Believe It Can Sort,500,458,0.00124080
+I Can't Believe It Can Sort,500,459,0.00124430
+I Can't Believe It Can Sort,500,460,0.00116590
+I Can't Believe It Can Sort,500,461,0.00128180
+I Can't Believe It Can Sort,500,462,0.00124230
+I Can't Believe It Can Sort,500,463,0.00123220
+I Can't Believe It Can Sort,500,464,0.00132440
+I Can't Believe It Can Sort,500,465,0.00134480
+I Can't Believe It Can Sort,500,466,0.00126340
+I Can't Believe It Can Sort,500,467,0.00097260
+I Can't Believe It Can Sort,500,468,0.00113970
+I Can't Believe It Can Sort,500,469,0.00123180
+I Can't Believe It Can Sort,500,470,0.00113860
+I Can't Believe It Can Sort,500,471,0.00122260
+I Can't Believe It Can Sort,500,472,0.00112980
+I Can't Believe It Can Sort,500,473,0.00143600
+I Can't Believe It Can Sort,500,474,0.00105240
+I Can't Believe It Can Sort,500,475,0.00138050
+I Can't Believe It Can Sort,500,476,0.00139440
+I Can't Believe It Can Sort,500,477,0.00100320
+I Can't Believe It Can Sort,500,478,0.00078210
+I Can't Believe It Can Sort,500,479,0.00123690
+I Can't Believe It Can Sort,500,480,0.00134980
+I Can't Believe It Can Sort,500,481,0.00074780
+I Can't Believe It Can Sort,500,482,0.00101290
+I Can't Believe It Can Sort,500,483,0.00117060
+I Can't Believe It Can Sort,500,484,0.00119850
+I Can't Believe It Can Sort,500,485,0.00128540
+I Can't Believe It Can Sort,500,486,0.00120090
+I Can't Believe It Can Sort,500,487,0.00116510
+I Can't Believe It Can Sort,500,488,0.00100760
+I Can't Believe It Can Sort,500,489,0.00132040
+I Can't Believe It Can Sort,500,490,0.00107940
+I Can't Believe It Can Sort,500,491,0.00116230
+I Can't Believe It Can Sort,500,492,0.00128760
+I Can't Believe It Can Sort,500,493,0.00134610
+I Can't Believe It Can Sort,500,494,0.00098980
+I Can't Believe It Can Sort,500,495,0.00099500
+I Can't Believe It Can Sort,500,496,0.00110950
+I Can't Believe It Can Sort,500,497,0.00127560
+I Can't Believe It Can Sort,500,498,0.00139460
+I Can't Believe It Can Sort,500,499,0.00071650
+I Can't Believe It Can Sort,500,500,0.00122570
+Insertion Sort,500,1,0.00644800
+Insertion Sort,500,2,0.00543330
+Insertion Sort,500,3,0.00587860
+Insertion Sort,500,4,0.00612480
+Insertion Sort,500,5,0.00524340
+Insertion Sort,500,6,0.00626520
+Insertion Sort,500,7,0.00759980
+Insertion Sort,500,8,0.00633710
+Insertion Sort,500,9,0.00564860
+Insertion Sort,500,10,0.00475650
+Insertion Sort,500,11,0.00495130
+Insertion Sort,500,12,0.00677330
+Insertion Sort,500,13,0.00473230
+Insertion Sort,500,14,0.00695280
+Insertion Sort,500,15,0.00666530
+Insertion Sort,500,16,0.00600410
+Insertion Sort,500,17,0.00479860
+Insertion Sort,500,18,0.00750480
+Insertion Sort,500,19,0.00479880
+Insertion Sort,500,20,0.00526140
+Insertion Sort,500,21,0.00653130
+Insertion Sort,500,22,0.00627040
+Insertion Sort,500,23,0.00635830
+Insertion Sort,500,24,0.00584850
+Insertion Sort,500,25,0.00737960
+Insertion Sort,500,26,0.00538140
+Insertion Sort,500,27,0.00630970
+Insertion Sort,500,28,0.00763140
+Insertion Sort,500,29,0.00493990
+Insertion Sort,500,30,0.00765660
+Insertion Sort,500,31,0.00651410
+Insertion Sort,500,32,0.00736470
+Insertion Sort,500,33,0.00518480
+Insertion Sort,500,34,0.00647070
+Insertion Sort,500,35,0.00472970
+Insertion Sort,500,36,0.00692570
+Insertion Sort,500,37,0.00570080
+Insertion Sort,500,38,0.00474810
+Insertion Sort,500,39,0.00694190
+Insertion Sort,500,40,0.00672200
+Insertion Sort,500,41,0.00487080
+Insertion Sort,500,42,0.00627990
+Insertion Sort,500,43,0.00619400
+Insertion Sort,500,44,0.00647980
+Insertion Sort,500,45,0.00574430
+Insertion Sort,500,46,0.00568020
+Insertion Sort,500,47,0.00457580
+Insertion Sort,500,48,0.00493530
+Insertion Sort,500,49,0.00564650
+Insertion Sort,500,50,0.00752740
+Insertion Sort,500,51,0.00496430
+Insertion Sort,500,52,0.00499690
+Insertion Sort,500,53,0.00639250
+Insertion Sort,500,54,0.00630860
+Insertion Sort,500,55,0.00567000
+Insertion Sort,500,56,0.00747660
+Insertion Sort,500,57,0.00676950
+Insertion Sort,500,58,0.00599890
+Insertion Sort,500,59,0.00697160
+Insertion Sort,500,60,0.00672250
+Insertion Sort,500,61,0.00612960
+Insertion Sort,500,62,0.00633590
+Insertion Sort,500,63,0.00699750
+Insertion Sort,500,64,0.00702490
+Insertion Sort,500,65,0.00584120
+Insertion Sort,500,66,0.00719770
+Insertion Sort,500,67,0.00697440
+Insertion Sort,500,68,0.00664300
+Insertion Sort,500,69,0.00649850
+Insertion Sort,500,70,0.00736590
+Insertion Sort,500,71,0.00706340
+Insertion Sort,500,72,0.00768070
+Insertion Sort,500,73,0.00778430
+Insertion Sort,500,74,0.00664130
+Insertion Sort,500,75,0.00592920
+Insertion Sort,500,76,0.00579640
+Insertion Sort,500,77,0.00593230
+Insertion Sort,500,78,0.00556720
+Insertion Sort,500,79,0.00517500
+Insertion Sort,500,80,0.00696500
+Insertion Sort,500,81,0.00665480
+Insertion Sort,500,82,0.00730200
+Insertion Sort,500,83,0.00631250
+Insertion Sort,500,84,0.00640210
+Insertion Sort,500,85,0.00703890
+Insertion Sort,500,86,0.00463980
+Insertion Sort,500,87,0.00538260
+Insertion Sort,500,88,0.00667820
+Insertion Sort,500,89,0.00582380
+Insertion Sort,500,90,0.00718470
+Insertion Sort,500,91,0.00654350
+Insertion Sort,500,92,0.00562130
+Insertion Sort,500,93,0.00638690
+Insertion Sort,500,94,0.00637970
+Insertion Sort,500,95,0.00698910
+Insertion Sort,500,96,0.00667960
+Insertion Sort,500,97,0.00737500
+Insertion Sort,500,98,0.00683120
+Insertion Sort,500,99,0.00658560
+Insertion Sort,500,100,0.00727740
+Insertion Sort,500,101,0.00524840
+Insertion Sort,500,102,0.00712750
+Insertion Sort,500,103,0.00560700
+Insertion Sort,500,104,0.00661160
+Insertion Sort,500,105,0.00574800
+Insertion Sort,500,106,0.00582250
+Insertion Sort,500,107,0.00736010
+Insertion Sort,500,108,0.00591750
+Insertion Sort,500,109,0.00630700
+Insertion Sort,500,110,0.00710180
+Insertion Sort,500,111,0.00539810
+Insertion Sort,500,112,0.00663010
+Insertion Sort,500,113,0.00542780
+Insertion Sort,500,114,0.00689330
+Insertion Sort,500,115,0.00658780
+Insertion Sort,500,116,0.00565700
+Insertion Sort,500,117,0.00739950
+Insertion Sort,500,118,0.00645920
+Insertion Sort,500,119,0.00764620
+Insertion Sort,500,120,0.00614830
+Insertion Sort,500,121,0.00591930
+Insertion Sort,500,122,0.00597450
+Insertion Sort,500,123,0.00553610
+Insertion Sort,500,124,0.00500890
+Insertion Sort,500,125,0.00475930
+Insertion Sort,500,126,0.00688290
+Insertion Sort,500,127,0.00550230
+Insertion Sort,500,128,0.00590140
+Insertion Sort,500,129,0.00557620
+Insertion Sort,500,130,0.00703000
+Insertion Sort,500,131,0.00684780
+Insertion Sort,500,132,0.00608200
+Insertion Sort,500,133,0.00725230
+Insertion Sort,500,134,0.00681590
+Insertion Sort,500,135,0.00695960
+Insertion Sort,500,136,0.00705690
+Insertion Sort,500,137,0.00506980
+Insertion Sort,500,138,0.00565380
+Insertion Sort,500,139,0.00736280
+Insertion Sort,500,140,0.00612080
+Insertion Sort,500,141,0.00627760
+Insertion Sort,500,142,0.00552140
+Insertion Sort,500,143,0.00471280
+Insertion Sort,500,144,0.00529490
+Insertion Sort,500,145,0.00434960
+Insertion Sort,500,146,0.00704790
+Insertion Sort,500,147,0.00472090
+Insertion Sort,500,148,0.00482510
+Insertion Sort,500,149,0.00792690
+Insertion Sort,500,150,0.00625640
+Insertion Sort,500,151,0.00467800
+Insertion Sort,500,152,0.00671550
+Insertion Sort,500,153,0.00644610
+Insertion Sort,500,154,0.00581670
+Insertion Sort,500,155,0.00668340
+Insertion Sort,500,156,0.00533590
+Insertion Sort,500,157,0.00638540
+Insertion Sort,500,158,0.00606540
+Insertion Sort,500,159,0.00565100
+Insertion Sort,500,160,0.00600870
+Insertion Sort,500,161,0.00516730
+Insertion Sort,500,162,0.00685700
+Insertion Sort,500,163,0.00421230
+Insertion Sort,500,164,0.00465140
+Insertion Sort,500,165,0.00471590
+Insertion Sort,500,166,0.00474970
+Insertion Sort,500,167,0.00611600
+Insertion Sort,500,168,0.00574600
+Insertion Sort,500,169,0.00585700
+Insertion Sort,500,170,0.00656660
+Insertion Sort,500,171,0.00539250
+Insertion Sort,500,172,0.00566050
+Insertion Sort,500,173,0.00756300
+Insertion Sort,500,174,0.00783860
+Insertion Sort,500,175,0.00708010
+Insertion Sort,500,176,0.00557610
+Insertion Sort,500,177,0.00723140
+Insertion Sort,500,178,0.00545080
+Insertion Sort,500,179,0.00761720
+Insertion Sort,500,180,0.00634850
+Insertion Sort,500,181,0.00565810
+Insertion Sort,500,182,0.00481110
+Insertion Sort,500,183,0.00481970
+Insertion Sort,500,184,0.00679630
+Insertion Sort,500,185,0.00438880
+Insertion Sort,500,186,0.00561510
+Insertion Sort,500,187,0.00525940
+Insertion Sort,500,188,0.00663820
+Insertion Sort,500,189,0.00717560
+Insertion Sort,500,190,0.00706830
+Insertion Sort,500,191,0.00829160
+Insertion Sort,500,192,0.00737480
+Insertion Sort,500,193,0.00763710
+Insertion Sort,500,194,0.00801940
+Insertion Sort,500,195,0.00910830
+Insertion Sort,500,196,0.00857730
+Insertion Sort,500,197,0.00729180
+Insertion Sort,500,198,0.00779610
+Insertion Sort,500,199,0.00836220
+Insertion Sort,500,200,0.00833920
+Insertion Sort,500,201,0.00712050
+Insertion Sort,500,202,0.00824450
+Insertion Sort,500,203,0.00799100
+Insertion Sort,500,204,0.00835950
+Insertion Sort,500,205,0.00745460
+Insertion Sort,500,206,0.00772120
+Insertion Sort,500,207,0.01013440
+Insertion Sort,500,208,0.00758600
+Insertion Sort,500,209,0.00777550
+Insertion Sort,500,210,0.00828760
+Insertion Sort,500,211,0.00856510
+Insertion Sort,500,212,0.00767010
+Insertion Sort,500,213,0.00768640
+Insertion Sort,500,214,0.00790530
+Insertion Sort,500,215,0.00757120
+Insertion Sort,500,216,0.00827700
+Insertion Sort,500,217,0.00755080
+Insertion Sort,500,218,0.00809800
+Insertion Sort,500,219,0.00898980
+Insertion Sort,500,220,0.00813910
+Insertion Sort,500,221,0.00772650
+Insertion Sort,500,222,0.00871540
+Insertion Sort,500,223,0.00866830
+Insertion Sort,500,224,0.00908860
+Insertion Sort,500,225,0.00901430
+Insertion Sort,500,226,0.00952200
+Insertion Sort,500,227,0.00772530
+Insertion Sort,500,228,0.00742660
+Insertion Sort,500,229,0.00767790
+Insertion Sort,500,230,0.00756700
+Insertion Sort,500,231,0.00880050
+Insertion Sort,500,232,0.00841980
+Insertion Sort,500,233,0.00816390
+Insertion Sort,500,234,0.00715050
+Insertion Sort,500,235,0.00761260
+Insertion Sort,500,236,0.00796360
+Insertion Sort,500,237,0.00808750
+Insertion Sort,500,238,0.00744320
+Insertion Sort,500,239,0.00814540
+Insertion Sort,500,240,0.00781560
+Insertion Sort,500,241,0.00713340
+Insertion Sort,500,242,0.00580770
+Insertion Sort,500,243,0.00734070
+Insertion Sort,500,244,0.00727050
+Insertion Sort,500,245,0.00747950
+Insertion Sort,500,246,0.00719320
+Insertion Sort,500,247,0.00763670
+Insertion Sort,500,248,0.00770420
+Insertion Sort,500,249,0.00716800
+Insertion Sort,500,250,0.00746730
+Insertion Sort,500,251,0.00718460
+Insertion Sort,500,252,0.00691240
+Insertion Sort,500,253,0.00793280
+Insertion Sort,500,254,0.00756270
+Insertion Sort,500,255,0.00855940
+Insertion Sort,500,256,0.00782530
+Insertion Sort,500,257,0.00821260
+Insertion Sort,500,258,0.00876440
+Insertion Sort,500,259,0.00747470
+Insertion Sort,500,260,0.01053000
+Insertion Sort,500,261,0.00853820
+Insertion Sort,500,262,0.00860330
+Insertion Sort,500,263,0.01073310
+Insertion Sort,500,264,0.00907860
+Insertion Sort,500,265,0.00782070
+Insertion Sort,500,266,0.01141320
+Insertion Sort,500,267,0.01007450
+Insertion Sort,500,268,0.00817500
+Insertion Sort,500,269,0.00941970
+Insertion Sort,500,270,0.00983300
+Insertion Sort,500,271,0.00820160
+Insertion Sort,500,272,0.00792080
+Insertion Sort,500,273,0.00838060
+Insertion Sort,500,274,0.00879290
+Insertion Sort,500,275,0.00797240
+Insertion Sort,500,276,0.00911700
+Insertion Sort,500,277,0.00974020
+Insertion Sort,500,278,0.00970360
+Insertion Sort,500,279,0.00884510
+Insertion Sort,500,280,0.00736330
+Insertion Sort,500,281,0.01005320
+Insertion Sort,500,282,0.01052850
+Insertion Sort,500,283,0.00869510
+Insertion Sort,500,284,0.01039440
+Insertion Sort,500,285,0.00816710
+Insertion Sort,500,286,0.00957630
+Insertion Sort,500,287,0.00819680
+Insertion Sort,500,288,0.00818970
+Insertion Sort,500,289,0.00834490
+Insertion Sort,500,290,0.00907230
+Insertion Sort,500,291,0.00795340
+Insertion Sort,500,292,0.00832820
+Insertion Sort,500,293,0.00740020
+Insertion Sort,500,294,0.00977940
+Insertion Sort,500,295,0.01119020
+Insertion Sort,500,296,0.00771230
+Insertion Sort,500,297,0.00772230
+Insertion Sort,500,298,0.01030520
+Insertion Sort,500,299,0.00812670
+Insertion Sort,500,300,0.00886130
+Insertion Sort,500,301,0.00766560
+Insertion Sort,500,302,0.00769590
+Insertion Sort,500,303,0.00960000
+Insertion Sort,500,304,0.00760520
+Insertion Sort,500,305,0.00828260
+Insertion Sort,500,306,0.00758410
+Insertion Sort,500,307,0.00729100
+Insertion Sort,500,308,0.00802080
+Insertion Sort,500,309,0.00818890
+Insertion Sort,500,310,0.00742880
+Insertion Sort,500,311,0.00739120
+Insertion Sort,500,312,0.00602180
+Insertion Sort,500,313,0.00584280
+Insertion Sort,500,314,0.00772430
+Insertion Sort,500,315,0.00636400
+Insertion Sort,500,316,0.00787780
+Insertion Sort,500,317,0.00697260
+Insertion Sort,500,318,0.00611530
+Insertion Sort,500,319,0.00581850
+Insertion Sort,500,320,0.00639280
+Insertion Sort,500,321,0.00746030
+Insertion Sort,500,322,0.00505600
+Insertion Sort,500,323,0.00599760
+Insertion Sort,500,324,0.00635670
+Insertion Sort,500,325,0.00551100
+Insertion Sort,500,326,0.00704280
+Insertion Sort,500,327,0.00707010
+Insertion Sort,500,328,0.00699770
+Insertion Sort,500,329,0.00571330
+Insertion Sort,500,330,0.00671080
+Insertion Sort,500,331,0.00669070
+Insertion Sort,500,332,0.00547900
+Insertion Sort,500,333,0.00772880
+Insertion Sort,500,334,0.00648760
+Insertion Sort,500,335,0.00550430
+Insertion Sort,500,336,0.00657390
+Insertion Sort,500,337,0.00627010
+Insertion Sort,500,338,0.00680340
+Insertion Sort,500,339,0.00615800
+Insertion Sort,500,340,0.00685390
+Insertion Sort,500,341,0.00698760
+Insertion Sort,500,342,0.00765120
+Insertion Sort,500,343,0.00744740
+Insertion Sort,500,344,0.00550700
+Insertion Sort,500,345,0.00740640
+Insertion Sort,500,346,0.00696430
+Insertion Sort,500,347,0.00570730
+Insertion Sort,500,348,0.00582830
+Insertion Sort,500,349,0.00718340
+Insertion Sort,500,350,0.00476420
+Insertion Sort,500,351,0.00675260
+Insertion Sort,500,352,0.00550970
+Insertion Sort,500,353,0.00695810
+Insertion Sort,500,354,0.00702660
+Insertion Sort,500,355,0.00565150
+Insertion Sort,500,356,0.00575620
+Insertion Sort,500,357,0.00464800
+Insertion Sort,500,358,0.00650450
+Insertion Sort,500,359,0.00694560
+Insertion Sort,500,360,0.00638230
+Insertion Sort,500,361,0.00493040
+Insertion Sort,500,362,0.00644540
+Insertion Sort,500,363,0.00620770
+Insertion Sort,500,364,0.00592990
+Insertion Sort,500,365,0.00533640
+Insertion Sort,500,366,0.00587920
+Insertion Sort,500,367,0.00455680
+Insertion Sort,500,368,0.00646230
+Insertion Sort,500,369,0.00506560
+Insertion Sort,500,370,0.00599420
+Insertion Sort,500,371,0.00585910
+Insertion Sort,500,372,0.00565860
+Insertion Sort,500,373,0.00652230
+Insertion Sort,500,374,0.00632880
+Insertion Sort,500,375,0.00653970
+Insertion Sort,500,376,0.00590510
+Insertion Sort,500,377,0.00642410
+Insertion Sort,500,378,0.00708920
+Insertion Sort,500,379,0.00474370
+Insertion Sort,500,380,0.00543920
+Insertion Sort,500,381,0.00649910
+Insertion Sort,500,382,0.00568860
+Insertion Sort,500,383,0.00723980
+Insertion Sort,500,384,0.00464790
+Insertion Sort,500,385,0.00613420
+Insertion Sort,500,386,0.00460360
+Insertion Sort,500,387,0.00545480
+Insertion Sort,500,388,0.00740390
+Insertion Sort,500,389,0.00533000
+Insertion Sort,500,390,0.00653890
+Insertion Sort,500,391,0.00576890
+Insertion Sort,500,392,0.00508920
+Insertion Sort,500,393,0.00706750
+Insertion Sort,500,394,0.00618560
+Insertion Sort,500,395,0.00629780
+Insertion Sort,500,396,0.00614750
+Insertion Sort,500,397,0.00608960
+Insertion Sort,500,398,0.00760560
+Insertion Sort,500,399,0.00692990
+Insertion Sort,500,400,0.00619680
+Insertion Sort,500,401,0.00663100
+Insertion Sort,500,402,0.00751230
+Insertion Sort,500,403,0.00747410
+Insertion Sort,500,404,0.00735320
+Insertion Sort,500,405,0.00739700
+Insertion Sort,500,406,0.00743170
+Insertion Sort,500,407,0.00704330
+Insertion Sort,500,408,0.00606410
+Insertion Sort,500,409,0.00704070
+Insertion Sort,500,410,0.00614110
+Insertion Sort,500,411,0.00679470
+Insertion Sort,500,412,0.00741490
+Insertion Sort,500,413,0.00519440
+Insertion Sort,500,414,0.00754330
+Insertion Sort,500,415,0.00742440
+Insertion Sort,500,416,0.00700540
+Insertion Sort,500,417,0.00662050
+Insertion Sort,500,418,0.00579370
+Insertion Sort,500,419,0.00556190
+Insertion Sort,500,420,0.00658920
+Insertion Sort,500,421,0.00659770
+Insertion Sort,500,422,0.00609210
+Insertion Sort,500,423,0.00710420
+Insertion Sort,500,424,0.00578190
+Insertion Sort,500,425,0.00714490
+Insertion Sort,500,426,0.00524420
+Insertion Sort,500,427,0.00695430
+Insertion Sort,500,428,0.00679380
+Insertion Sort,500,429,0.00526930
+Insertion Sort,500,430,0.00456060
+Insertion Sort,500,431,0.00501760
+Insertion Sort,500,432,0.00580080
+Insertion Sort,500,433,0.00649420
+Insertion Sort,500,434,0.00504960
+Insertion Sort,500,435,0.00630220
+Insertion Sort,500,436,0.00759990
+Insertion Sort,500,437,0.00788430
+Insertion Sort,500,438,0.00683690
+Insertion Sort,500,439,0.00653610
+Insertion Sort,500,440,0.00760740
+Insertion Sort,500,441,0.00553340
+Insertion Sort,500,442,0.00676290
+Insertion Sort,500,443,0.00923700
+Insertion Sort,500,444,0.00809450
+Insertion Sort,500,445,0.00796240
+Insertion Sort,500,446,0.00756090
+Insertion Sort,500,447,0.00788480
+Insertion Sort,500,448,0.00661000
+Insertion Sort,500,449,0.00810530
+Insertion Sort,500,450,0.00731910
+Insertion Sort,500,451,0.00805050
+Insertion Sort,500,452,0.00764160
+Insertion Sort,500,453,0.00741920
+Insertion Sort,500,454,0.00640340
+Insertion Sort,500,455,0.00674440
+Insertion Sort,500,456,0.00788620
+Insertion Sort,500,457,0.00633930
+Insertion Sort,500,458,0.00720440
+Insertion Sort,500,459,0.00597430
+Insertion Sort,500,460,0.00592030
+Insertion Sort,500,461,0.00616040
+Insertion Sort,500,462,0.00559160
+Insertion Sort,500,463,0.00729160
+Insertion Sort,500,464,0.00614060
+Insertion Sort,500,465,0.00497050
+Insertion Sort,500,466,0.00691980
+Insertion Sort,500,467,0.00752950
+Insertion Sort,500,468,0.00802120
+Insertion Sort,500,469,0.00765030
+Insertion Sort,500,470,0.00787280
+Insertion Sort,500,471,0.00747010
+Insertion Sort,500,472,0.00791720
+Insertion Sort,500,473,0.00697160
+Insertion Sort,500,474,0.00780570
+Insertion Sort,500,475,0.00806950
+Insertion Sort,500,476,0.00584950
+Insertion Sort,500,477,0.00509570
+Insertion Sort,500,478,0.00762890
+Insertion Sort,500,479,0.00738510
+Insertion Sort,500,480,0.00713170
+Insertion Sort,500,481,0.00798340
+Insertion Sort,500,482,0.00665150
+Insertion Sort,500,483,0.00638610
+Insertion Sort,500,484,0.00697000
+Insertion Sort,500,485,0.00747980
+Insertion Sort,500,486,0.00714480
+Insertion Sort,500,487,0.00664260
+Insertion Sort,500,488,0.00749170
+Insertion Sort,500,489,0.00661630
+Insertion Sort,500,490,0.00619030
+Insertion Sort,500,491,0.00726290
+Insertion Sort,500,492,0.00640740
+Insertion Sort,500,493,0.00710210
+Insertion Sort,500,494,0.00729090
+Insertion Sort,500,495,0.00722430
+Insertion Sort,500,496,0.00674350
+Insertion Sort,500,497,0.00783050
+Insertion Sort,500,498,0.00714230
+Insertion Sort,500,499,0.00556060
+Insertion Sort,500,500,0.00721420
+Intro Sort,500,1,0.00065410
+Intro Sort,500,2,0.00064070
+Intro Sort,500,3,0.00070050
+Intro Sort,500,4,0.00046720
+Intro Sort,500,5,0.00065060
+Intro Sort,500,6,0.00045480
+Intro Sort,500,7,0.00051130
+Intro Sort,500,8,0.00042160
+Intro Sort,500,9,0.00066410
+Intro Sort,500,10,0.00049250
+Intro Sort,500,11,0.00041870
+Intro Sort,500,12,0.00059360
+Intro Sort,500,13,0.00079090
+Intro Sort,500,14,0.00084200
+Intro Sort,500,15,0.00074250
+Intro Sort,500,16,0.00112580
+Intro Sort,500,17,0.00080120
+Intro Sort,500,18,0.00081280
+Intro Sort,500,19,0.00065100
+Intro Sort,500,20,0.00046540
+Intro Sort,500,21,0.00063370
+Intro Sort,500,22,0.00065420
+Intro Sort,500,23,0.00070380
+Intro Sort,500,24,0.00086480
+Intro Sort,500,25,0.00041010
+Intro Sort,500,26,0.00065600
+Intro Sort,500,27,0.00113990
+Intro Sort,500,28,0.00085520
+Intro Sort,500,29,0.00082410
+Intro Sort,500,30,0.00068380
+Intro Sort,500,31,0.00064080
+Intro Sort,500,32,0.00045170
+Intro Sort,500,33,0.00077900
+Intro Sort,500,34,0.00068340
+Intro Sort,500,35,0.00070650
+Intro Sort,500,36,0.00073620
+Intro Sort,500,37,0.00073550
+Intro Sort,500,38,0.00073690
+Intro Sort,500,39,0.00095610
+Intro Sort,500,40,0.00053990
+Intro Sort,500,41,0.00084920
+Intro Sort,500,42,0.00067220
+Intro Sort,500,43,0.00043880
+Intro Sort,500,44,0.00073160
+Intro Sort,500,45,0.00077100
+Intro Sort,500,46,0.00065180
+Intro Sort,500,47,0.00052480
+Intro Sort,500,48,0.00069510
+Intro Sort,500,49,0.00073420
+Intro Sort,500,50,0.00081630
+Intro Sort,500,51,0.00072080
+Intro Sort,500,52,0.00065200
+Intro Sort,500,53,0.00069340
+Intro Sort,500,54,0.00092240
+Intro Sort,500,55,0.00084710
+Intro Sort,500,56,0.00069820
+Intro Sort,500,57,0.00071460
+Intro Sort,500,58,0.00062470
+Intro Sort,500,59,0.00082440
+Intro Sort,500,60,0.00047390
+Intro Sort,500,61,0.00051310
+Intro Sort,500,62,0.00076180
+Intro Sort,500,63,0.00090220
+Intro Sort,500,64,0.00059070
+Intro Sort,500,65,0.00076700
+Intro Sort,500,66,0.00065350
+Intro Sort,500,67,0.00082060
+Intro Sort,500,68,0.00074540
+Intro Sort,500,69,0.00069990
+Intro Sort,500,70,0.00043030
+Intro Sort,500,71,0.00067970
+Intro Sort,500,72,0.00066020
+Intro Sort,500,73,0.00071240
+Intro Sort,500,74,0.00051040
+Intro Sort,500,75,0.00071020
+Intro Sort,500,76,0.00066720
+Intro Sort,500,77,0.00059250
+Intro Sort,500,78,0.00074560
+Intro Sort,500,79,0.00054990
+Intro Sort,500,80,0.00071950
+Intro Sort,500,81,0.00073710
+Intro Sort,500,82,0.00069000
+Intro Sort,500,83,0.00045940
+Intro Sort,500,84,0.00049660
+Intro Sort,500,85,0.00069960
+Intro Sort,500,86,0.00069530
+Intro Sort,500,87,0.00065060
+Intro Sort,500,88,0.00053130
+Intro Sort,500,89,0.00057190
+Intro Sort,500,90,0.00073390
+Intro Sort,500,91,0.00076010
+Intro Sort,500,92,0.00061570
+Intro Sort,500,93,0.00075430
+Intro Sort,500,94,0.00068590
+Intro Sort,500,95,0.00073580
+Intro Sort,500,96,0.00085710
+Intro Sort,500,97,0.00069310
+Intro Sort,500,98,0.00044320
+Intro Sort,500,99,0.00063870
+Intro Sort,500,100,0.00068880
+Intro Sort,500,101,0.00077320
+Intro Sort,500,102,0.00039700
+Intro Sort,500,103,0.00064780
+Intro Sort,500,104,0.00073950
+Intro Sort,500,105,0.00068850
+Intro Sort,500,106,0.00066690
+Intro Sort,500,107,0.00073800
+Intro Sort,500,108,0.00068740
+Intro Sort,500,109,0.00057480
+Intro Sort,500,110,0.00067100
+Intro Sort,500,111,0.00061730
+Intro Sort,500,112,0.00046610
+Intro Sort,500,113,0.00058310
+Intro Sort,500,114,0.00068320
+Intro Sort,500,115,0.00048600
+Intro Sort,500,116,0.00048610
+Intro Sort,500,117,0.00059670
+Intro Sort,500,118,0.00063900
+Intro Sort,500,119,0.00074950
+Intro Sort,500,120,0.00062700
+Intro Sort,500,121,0.00066490
+Intro Sort,500,122,0.00075300
+Intro Sort,500,123,0.00073540
+Intro Sort,500,124,0.00054050
+Intro Sort,500,125,0.00068160
+Intro Sort,500,126,0.00071530
+Intro Sort,500,127,0.00071750
+Intro Sort,500,128,0.00080090
+Intro Sort,500,129,0.00067040
+Intro Sort,500,130,0.00086310
+Intro Sort,500,131,0.00063070
+Intro Sort,500,132,0.00067050
+Intro Sort,500,133,0.00068210
+Intro Sort,500,134,0.00070130
+Intro Sort,500,135,0.00066410
+Intro Sort,500,136,0.00065100
+Intro Sort,500,137,0.00049860
+Intro Sort,500,138,0.00080910
+Intro Sort,500,139,0.00044850
+Intro Sort,500,140,0.00079180
+Intro Sort,500,141,0.00045690
+Intro Sort,500,142,0.00048240
+Intro Sort,500,143,0.00039970
+Intro Sort,500,144,0.00075020
+Intro Sort,500,145,0.00078920
+Intro Sort,500,146,0.00066510
+Intro Sort,500,147,0.00050140
+Intro Sort,500,148,0.00073850
+Intro Sort,500,149,0.00044250
+Intro Sort,500,150,0.00040740
+Intro Sort,500,151,0.00067650
+Intro Sort,500,152,0.00043110
+Intro Sort,500,153,0.00057690
+Intro Sort,500,154,0.00074560
+Intro Sort,500,155,0.00045340
+Intro Sort,500,156,0.00074710
+Intro Sort,500,157,0.00044900
+Intro Sort,500,158,0.00087190
+Intro Sort,500,159,0.00052050
+Intro Sort,500,160,0.00055640
+Intro Sort,500,161,0.00070520
+Intro Sort,500,162,0.00074870
+Intro Sort,500,163,0.00071370
+Intro Sort,500,164,0.00077360
+Intro Sort,500,165,0.00073980
+Intro Sort,500,166,0.00067020
+Intro Sort,500,167,0.00055380
+Intro Sort,500,168,0.00061710
+Intro Sort,500,169,0.00063540
+Intro Sort,500,170,0.00042460
+Intro Sort,500,171,0.00045090
+Intro Sort,500,172,0.00067540
+Intro Sort,500,173,0.00070950
+Intro Sort,500,174,0.00049970
+Intro Sort,500,175,0.00066430
+Intro Sort,500,176,0.00067540
+Intro Sort,500,177,0.00043290
+Intro Sort,500,178,0.00066360
+Intro Sort,500,179,0.00073920
+Intro Sort,500,180,0.00043700
+Intro Sort,500,181,0.00073920
+Intro Sort,500,182,0.00069610
+Intro Sort,500,183,0.00043040
+Intro Sort,500,184,0.00039510
+Intro Sort,500,185,0.00056050
+Intro Sort,500,186,0.00107550
+Intro Sort,500,187,0.00061280
+Intro Sort,500,188,0.00048360
+Intro Sort,500,189,0.00069000
+Intro Sort,500,190,0.00077390
+Intro Sort,500,191,0.00070420
+Intro Sort,500,192,0.00048180
+Intro Sort,500,193,0.00062740
+Intro Sort,500,194,0.00051010
+Intro Sort,500,195,0.00042280
+Intro Sort,500,196,0.00072930
+Intro Sort,500,197,0.00042840
+Intro Sort,500,198,0.00068710
+Intro Sort,500,199,0.00071240
+Intro Sort,500,200,0.00077010
+Intro Sort,500,201,0.00047440
+Intro Sort,500,202,0.00060800
+Intro Sort,500,203,0.00072150
+Intro Sort,500,204,0.00067680
+Intro Sort,500,205,0.00062760
+Intro Sort,500,206,0.00050790
+Intro Sort,500,207,0.00053620
+Intro Sort,500,208,0.00040650
+Intro Sort,500,209,0.00050790
+Intro Sort,500,210,0.00095020
+Intro Sort,500,211,0.00066420
+Intro Sort,500,212,0.00072370
+Intro Sort,500,213,0.00042840
+Intro Sort,500,214,0.00063280
+Intro Sort,500,215,0.00084250
+Intro Sort,500,216,0.00068960
+Intro Sort,500,217,0.00043030
+Intro Sort,500,218,0.00073350
+Intro Sort,500,219,0.00051270
+Intro Sort,500,220,0.00049880
+Intro Sort,500,221,0.00041370
+Intro Sort,500,222,0.00055780
+Intro Sort,500,223,0.00052200
+Intro Sort,500,224,0.00046810
+Intro Sort,500,225,0.00066420
+Intro Sort,500,226,0.00082020
+Intro Sort,500,227,0.00042350
+Intro Sort,500,228,0.00057530
+Intro Sort,500,229,0.00073560
+Intro Sort,500,230,0.00048900
+Intro Sort,500,231,0.00078620
+Intro Sort,500,232,0.00063620
+Intro Sort,500,233,0.00070340
+Intro Sort,500,234,0.00076460
+Intro Sort,500,235,0.00063870
+Intro Sort,500,236,0.00070190
+Intro Sort,500,237,0.00069830
+Intro Sort,500,238,0.00076190
+Intro Sort,500,239,0.00295650
+Intro Sort,500,240,0.00269830
+Intro Sort,500,241,0.00059430
+Intro Sort,500,242,0.00066920
+Intro Sort,500,243,0.00119670
+Intro Sort,500,244,0.00071650
+Intro Sort,500,245,0.00067070
+Intro Sort,500,246,0.00125310
+Intro Sort,500,247,0.00076010
+Intro Sort,500,248,0.00113970
+Intro Sort,500,249,0.00069610
+Intro Sort,500,250,0.00067750
+Intro Sort,500,251,0.00074160
+Intro Sort,500,252,0.00116430
+Intro Sort,500,253,0.00066720
+Intro Sort,500,254,0.00094930
+Intro Sort,500,255,0.00062370
+Intro Sort,500,256,0.00068320
+Intro Sort,500,257,0.00083380
+Intro Sort,500,258,0.00069530
+Intro Sort,500,259,0.00074290
+Intro Sort,500,260,0.00073260
+Intro Sort,500,261,0.00065940
+Intro Sort,500,262,0.00073200
+Intro Sort,500,263,0.00078070
+Intro Sort,500,264,0.00068230
+Intro Sort,500,265,0.00080410
+Intro Sort,500,266,0.00068820
+Intro Sort,500,267,0.00074480
+Intro Sort,500,268,0.00068010
+Intro Sort,500,269,0.00069680
+Intro Sort,500,270,0.00074180
+Intro Sort,500,271,0.00058900
+Intro Sort,500,272,0.00060090
+Intro Sort,500,273,0.00071350
+Intro Sort,500,274,0.00069430
+Intro Sort,500,275,0.00076430
+Intro Sort,500,276,0.00087470
+Intro Sort,500,277,0.00063480
+Intro Sort,500,278,0.00070380
+Intro Sort,500,279,0.00103030
+Intro Sort,500,280,0.00075010
+Intro Sort,500,281,0.00093020
+Intro Sort,500,282,0.00069010
+Intro Sort,500,283,0.00075630
+Intro Sort,500,284,0.00075290
+Intro Sort,500,285,0.00064940
+Intro Sort,500,286,0.00079650
+Intro Sort,500,287,0.00110860
+Intro Sort,500,288,0.00088140
+Intro Sort,500,289,0.00081420
+Intro Sort,500,290,0.00068090
+Intro Sort,500,291,0.00079280
+Intro Sort,500,292,0.00071410
+Intro Sort,500,293,0.00067850
+Intro Sort,500,294,0.00072360
+Intro Sort,500,295,0.00250390
+Intro Sort,500,296,0.00066230
+Intro Sort,500,297,0.00068310
+Intro Sort,500,298,0.00085060
+Intro Sort,500,299,0.00064290
+Intro Sort,500,300,0.00080600
+Intro Sort,500,301,0.00074840
+Intro Sort,500,302,0.00071010
+Intro Sort,500,303,0.00073220
+Intro Sort,500,304,0.00065610
+Intro Sort,500,305,0.00073370
+Intro Sort,500,306,0.00067130
+Intro Sort,500,307,0.00069830
+Intro Sort,500,308,0.00067800
+Intro Sort,500,309,0.00063040
+Intro Sort,500,310,0.00078720
+Intro Sort,500,311,0.00078490
+Intro Sort,500,312,0.00070360
+Intro Sort,500,313,0.00067670
+Intro Sort,500,314,0.00066280
+Intro Sort,500,315,0.00065200
+Intro Sort,500,316,0.00070430
+Intro Sort,500,317,0.00092150
+Intro Sort,500,318,0.00069960
+Intro Sort,500,319,0.00065650
+Intro Sort,500,320,0.00073300
+Intro Sort,500,321,0.00100100
+Intro Sort,500,322,0.00926600
+Intro Sort,500,323,0.00071360
+Intro Sort,500,324,0.00079360
+Intro Sort,500,325,0.00122840
+Intro Sort,500,326,0.00076850
+Intro Sort,500,327,0.00065060
+Intro Sort,500,328,0.00065260
+Intro Sort,500,329,0.00090820
+Intro Sort,500,330,0.00093950
+Intro Sort,500,331,0.00063920
+Intro Sort,500,332,0.00078250
+Intro Sort,500,333,0.00069110
+Intro Sort,500,334,0.00068220
+Intro Sort,500,335,0.00070030
+Intro Sort,500,336,0.00072030
+Intro Sort,500,337,0.00064800
+Intro Sort,500,338,0.00069610
+Intro Sort,500,339,0.00081600
+Intro Sort,500,340,0.00071570
+Intro Sort,500,341,0.00063710
+Intro Sort,500,342,0.00077060
+Intro Sort,500,343,0.00083110
+Intro Sort,500,344,0.00075250
+Intro Sort,500,345,0.00069030
+Intro Sort,500,346,0.00049560
+Intro Sort,500,347,0.00057990
+Intro Sort,500,348,0.00067770
+Intro Sort,500,349,0.00075740
+Intro Sort,500,350,0.00061340
+Intro Sort,500,351,0.00054960
+Intro Sort,500,352,0.00066510
+Intro Sort,500,353,0.00047740
+Intro Sort,500,354,0.00065160
+Intro Sort,500,355,0.00042480
+Intro Sort,500,356,0.00072050
+Intro Sort,500,357,0.00049390
+Intro Sort,500,358,0.00048080
+Intro Sort,500,359,0.00065810
+Intro Sort,500,360,0.00051960
+Intro Sort,500,361,0.00066730
+Intro Sort,500,362,0.00055780
+Intro Sort,500,363,0.00054190
+Intro Sort,500,364,0.00054000
+Intro Sort,500,365,0.00069700
+Intro Sort,500,366,0.00079570
+Intro Sort,500,367,0.00052140
+Intro Sort,500,368,0.00046580
+Intro Sort,500,369,0.00063580
+Intro Sort,500,370,0.00071970
+Intro Sort,500,371,0.00081860
+Intro Sort,500,372,0.00068920
+Intro Sort,500,373,0.00048710
+Intro Sort,500,374,0.00086080
+Intro Sort,500,375,0.00085540
+Intro Sort,500,376,0.00069710
+Intro Sort,500,377,0.00088980
+Intro Sort,500,378,0.00110790
+Intro Sort,500,379,0.00074070
+Intro Sort,500,380,0.00068750
+Intro Sort,500,381,0.00071790
+Intro Sort,500,382,0.00071190
+Intro Sort,500,383,0.00073720
+Intro Sort,500,384,0.00073350
+Intro Sort,500,385,0.00077280
+Intro Sort,500,386,0.00118630
+Intro Sort,500,387,0.00089800
+Intro Sort,500,388,0.00078920
+Intro Sort,500,389,0.00070660
+Intro Sort,500,390,0.00078700
+Intro Sort,500,391,0.00076110
+Intro Sort,500,392,0.00074220
+Intro Sort,500,393,0.00068070
+Intro Sort,500,394,0.00063170
+Intro Sort,500,395,0.00084230
+Intro Sort,500,396,0.00065080
+Intro Sort,500,397,0.00073270
+Intro Sort,500,398,0.00071120
+Intro Sort,500,399,0.00052170
+Intro Sort,500,400,0.00064530
+Intro Sort,500,401,0.00064130
+Intro Sort,500,402,0.00049720
+Intro Sort,500,403,0.00069760
+Intro Sort,500,404,0.00042180
+Intro Sort,500,405,0.00077470
+Intro Sort,500,406,0.00059590
+Intro Sort,500,407,0.00068510
+Intro Sort,500,408,0.00044310
+Intro Sort,500,409,0.00064980
+Intro Sort,500,410,0.00072510
+Intro Sort,500,411,0.00055700
+Intro Sort,500,412,0.00067390
+Intro Sort,500,413,0.00053100
+Intro Sort,500,414,0.00081010
+Intro Sort,500,415,0.00065820
+Intro Sort,500,416,0.00045610
+Intro Sort,500,417,0.00040000
+Intro Sort,500,418,0.00070740
+Intro Sort,500,419,0.00062230
+Intro Sort,500,420,0.00082330
+Intro Sort,500,421,0.00042310
+Intro Sort,500,422,0.00045890
+Intro Sort,500,423,0.00045590
+Intro Sort,500,424,0.00069200
+Intro Sort,500,425,0.00081790
+Intro Sort,500,426,0.00045660
+Intro Sort,500,427,0.00044430
+Intro Sort,500,428,0.00070250
+Intro Sort,500,429,0.00045600
+Intro Sort,500,430,0.00047310
+Intro Sort,500,431,0.00071420
+Intro Sort,500,432,0.00043740
+Intro Sort,500,433,0.00073850
+Intro Sort,500,434,0.00069720
+Intro Sort,500,435,0.00057940
+Intro Sort,500,436,0.00048230
+Intro Sort,500,437,0.00082680
+Intro Sort,500,438,0.00042150
+Intro Sort,500,439,0.00044870
+Intro Sort,500,440,0.00066030
+Intro Sort,500,441,0.00044900
+Intro Sort,500,442,0.00050400
+Intro Sort,500,443,0.00069260
+Intro Sort,500,444,0.00074520
+Intro Sort,500,445,0.00058140
+Intro Sort,500,446,0.00074580
+Intro Sort,500,447,0.00082050
+Intro Sort,500,448,0.00072050
+Intro Sort,500,449,0.00045140
+Intro Sort,500,450,0.00058360
+Intro Sort,500,451,0.00049590
+Intro Sort,500,452,0.00055040
+Intro Sort,500,453,0.00065260
+Intro Sort,500,454,0.00053960
+Intro Sort,500,455,0.00052810
+Intro Sort,500,456,0.00057000
+Intro Sort,500,457,0.00075360
+Intro Sort,500,458,0.00069730
+Intro Sort,500,459,0.00065240
+Intro Sort,500,460,0.00063220
+Intro Sort,500,461,0.00073930
+Intro Sort,500,462,0.00063140
+Intro Sort,500,463,0.00068810
+Intro Sort,500,464,0.00052390
+Intro Sort,500,465,0.00065720
+Intro Sort,500,466,0.00067600
+Intro Sort,500,467,0.00073370
+Intro Sort,500,468,0.00057810
+Intro Sort,500,469,0.00072470
+Intro Sort,500,470,0.00074440
+Intro Sort,500,471,0.00072580
+Intro Sort,500,472,0.00067860
+Intro Sort,500,473,0.00070910
+Intro Sort,500,474,0.00073230
+Intro Sort,500,475,0.00072470
+Intro Sort,500,476,0.00057110
+Intro Sort,500,477,0.00070820
+Intro Sort,500,478,0.00072460
+Intro Sort,500,479,0.00067230
+Intro Sort,500,480,0.00077710
+Intro Sort,500,481,0.00070210
+Intro Sort,500,482,0.00075800
+Intro Sort,500,483,0.00070940
+Intro Sort,500,484,0.00069800
+Intro Sort,500,485,0.00046590
+Intro Sort,500,486,0.00077270
+Intro Sort,500,487,0.00068120
+Intro Sort,500,488,0.00045860
+Intro Sort,500,489,0.00040400
+Intro Sort,500,490,0.00063040
+Intro Sort,500,491,0.00075090
+Intro Sort,500,492,0.00048610
+Intro Sort,500,493,0.00041940
+Intro Sort,500,494,0.00043510
+Intro Sort,500,495,0.00048410
+Intro Sort,500,496,0.00076070
+Intro Sort,500,497,0.00067770
+Intro Sort,500,498,0.00051020
+Intro Sort,500,499,0.00065390
+Intro Sort,500,500,0.00070250
+LSD Radix Sort,500,1,0.00111330
+LSD Radix Sort,500,2,0.00111130
+LSD Radix Sort,500,3,0.00115140
+LSD Radix Sort,500,4,0.00086010
+LSD Radix Sort,500,5,0.00108330
+LSD Radix Sort,500,6,0.00107990
+LSD Radix Sort,500,7,0.00076020
+LSD Radix Sort,500,8,0.00079550
+LSD Radix Sort,500,9,0.00111880
+LSD Radix Sort,500,10,0.00109590
+LSD Radix Sort,500,11,0.00112280
+LSD Radix Sort,500,12,0.00099790
+LSD Radix Sort,500,13,0.00111740
+LSD Radix Sort,500,14,0.00108360
+LSD Radix Sort,500,15,0.00107140
+LSD Radix Sort,500,16,0.00111700
+LSD Radix Sort,500,17,0.00111810
+LSD Radix Sort,500,18,0.00108600
+LSD Radix Sort,500,19,0.00107140
+LSD Radix Sort,500,20,0.00086100
+LSD Radix Sort,500,21,0.00108620
+LSD Radix Sort,500,22,0.00109240
+LSD Radix Sort,500,23,0.00070020
+LSD Radix Sort,500,24,0.00109430
+LSD Radix Sort,500,25,0.00088880
+LSD Radix Sort,500,26,0.00130620
+LSD Radix Sort,500,27,0.00120880
+LSD Radix Sort,500,28,0.00110690
+LSD Radix Sort,500,29,0.00102780
+LSD Radix Sort,500,30,0.00106500
+LSD Radix Sort,500,31,0.00112150
+LSD Radix Sort,500,32,0.00119160
+LSD Radix Sort,500,33,0.00107590
+LSD Radix Sort,500,34,0.00090940
+LSD Radix Sort,500,35,0.00116880
+LSD Radix Sort,500,36,0.00109370
+LSD Radix Sort,500,37,0.00112900
+LSD Radix Sort,500,38,0.00097030
+LSD Radix Sort,500,39,0.00113880
+LSD Radix Sort,500,40,0.00087320
+LSD Radix Sort,500,41,0.00090360
+LSD Radix Sort,500,42,0.00111580
+LSD Radix Sort,500,43,0.00103620
+LSD Radix Sort,500,44,0.00113510
+LSD Radix Sort,500,45,0.00109740
+LSD Radix Sort,500,46,0.00124520
+LSD Radix Sort,500,47,0.00108820
+LSD Radix Sort,500,48,0.00097750
+LSD Radix Sort,500,49,0.00109720
+LSD Radix Sort,500,50,0.00116910
+LSD Radix Sort,500,51,0.00118160
+LSD Radix Sort,500,52,0.00110300
+LSD Radix Sort,500,53,0.00110960
+LSD Radix Sort,500,54,0.00099940
+LSD Radix Sort,500,55,0.00115220
+LSD Radix Sort,500,56,0.00098630
+LSD Radix Sort,500,57,0.00113820
+LSD Radix Sort,500,58,0.00110900
+LSD Radix Sort,500,59,0.00111210
+LSD Radix Sort,500,60,0.00106430
+LSD Radix Sort,500,61,0.00112710
+LSD Radix Sort,500,62,0.00120540
+LSD Radix Sort,500,63,0.00112580
+LSD Radix Sort,500,64,0.00080060
+LSD Radix Sort,500,65,0.00113340
+LSD Radix Sort,500,66,0.00108590
+LSD Radix Sort,500,67,0.00074420
+LSD Radix Sort,500,68,0.00068800
+LSD Radix Sort,500,69,0.00108940
+LSD Radix Sort,500,70,0.00071580
+LSD Radix Sort,500,71,0.00099680
+LSD Radix Sort,500,72,0.00072740
+LSD Radix Sort,500,73,0.00108450
+LSD Radix Sort,500,74,0.00064250
+LSD Radix Sort,500,75,0.00096110
+LSD Radix Sort,500,76,0.00108750
+LSD Radix Sort,500,77,0.00076470
+LSD Radix Sort,500,78,0.00110480
+LSD Radix Sort,500,79,0.00069540
+LSD Radix Sort,500,80,0.00108630
+LSD Radix Sort,500,81,0.00106720
+LSD Radix Sort,500,82,0.00086900
+LSD Radix Sort,500,83,0.00112030
+LSD Radix Sort,500,84,0.00116990
+LSD Radix Sort,500,85,0.00114760
+LSD Radix Sort,500,86,0.00093570
+LSD Radix Sort,500,87,0.00110780
+LSD Radix Sort,500,88,0.00113010
+LSD Radix Sort,500,89,0.00087260
+LSD Radix Sort,500,90,0.00110750
+LSD Radix Sort,500,91,0.00110230
+LSD Radix Sort,500,92,0.00108160
+LSD Radix Sort,500,93,0.00098880
+LSD Radix Sort,500,94,0.00069410
+LSD Radix Sort,500,95,0.00116250
+LSD Radix Sort,500,96,0.00086420
+LSD Radix Sort,500,97,0.00093310
+LSD Radix Sort,500,98,0.00112040
+LSD Radix Sort,500,99,0.00110590
+LSD Radix Sort,500,100,0.00110620
+LSD Radix Sort,500,101,0.00069510
+LSD Radix Sort,500,102,0.00109300
+LSD Radix Sort,500,103,0.00075040
+LSD Radix Sort,500,104,0.00110150
+LSD Radix Sort,500,105,0.00110340
+LSD Radix Sort,500,106,0.00111270
+LSD Radix Sort,500,107,0.00079690
+LSD Radix Sort,500,108,0.00110630
+LSD Radix Sort,500,109,0.00115250
+LSD Radix Sort,500,110,0.00078580
+LSD Radix Sort,500,111,0.00110320
+LSD Radix Sort,500,112,0.00071570
+LSD Radix Sort,500,113,0.00111060
+LSD Radix Sort,500,114,0.00116100
+LSD Radix Sort,500,115,0.00114200
+LSD Radix Sort,500,116,0.00110350
+LSD Radix Sort,500,117,0.00095540
+LSD Radix Sort,500,118,0.00115870
+LSD Radix Sort,500,119,0.00109890
+LSD Radix Sort,500,120,0.00095660
+LSD Radix Sort,500,121,0.00077060
+LSD Radix Sort,500,122,0.00081480
+LSD Radix Sort,500,123,0.00109670
+LSD Radix Sort,500,124,0.00109020
+LSD Radix Sort,500,125,0.00067900
+LSD Radix Sort,500,126,0.00120770
+LSD Radix Sort,500,127,0.00122960
+LSD Radix Sort,500,128,0.00134480
+LSD Radix Sort,500,129,0.00109800
+LSD Radix Sort,500,130,0.00110200
+LSD Radix Sort,500,131,0.00097470
+LSD Radix Sort,500,132,0.00111450
+LSD Radix Sort,500,133,0.00107900
+LSD Radix Sort,500,134,0.00136630
+LSD Radix Sort,500,135,0.00116400
+LSD Radix Sort,500,136,0.00112820
+LSD Radix Sort,500,137,0.00125480
+LSD Radix Sort,500,138,0.00117610
+LSD Radix Sort,500,139,0.00092280
+LSD Radix Sort,500,140,0.00108580
+LSD Radix Sort,500,141,0.00112380
+LSD Radix Sort,500,142,0.00095110
+LSD Radix Sort,500,143,0.00126440
+LSD Radix Sort,500,144,0.00106250
+LSD Radix Sort,500,145,0.00112670
+LSD Radix Sort,500,146,0.00109940
+LSD Radix Sort,500,147,0.00113020
+LSD Radix Sort,500,148,0.00078990
+LSD Radix Sort,500,149,0.00098550
+LSD Radix Sort,500,150,0.00069550
+LSD Radix Sort,500,151,0.00070330
+LSD Radix Sort,500,152,0.00104160
+LSD Radix Sort,500,153,0.00069530
+LSD Radix Sort,500,154,0.00075330
+LSD Radix Sort,500,155,0.00082250
+LSD Radix Sort,500,156,0.00140790
+LSD Radix Sort,500,157,0.00120960
+LSD Radix Sort,500,158,0.00112190
+LSD Radix Sort,500,159,0.00102240
+LSD Radix Sort,500,160,0.00107090
+LSD Radix Sort,500,161,0.00091030
+LSD Radix Sort,500,162,0.00116550
+LSD Radix Sort,500,163,0.00091580
+LSD Radix Sort,500,164,0.00119610
+LSD Radix Sort,500,165,0.00096910
+LSD Radix Sort,500,166,0.00089940
+LSD Radix Sort,500,167,0.00113510
+LSD Radix Sort,500,168,0.00110560
+LSD Radix Sort,500,169,0.00105590
+LSD Radix Sort,500,170,0.00111230
+LSD Radix Sort,500,171,0.00102270
+LSD Radix Sort,500,172,0.00073480
+LSD Radix Sort,500,173,0.00120750
+LSD Radix Sort,500,174,0.00111090
+LSD Radix Sort,500,175,0.00108640
+LSD Radix Sort,500,176,0.00112190
+LSD Radix Sort,500,177,0.00079690
+LSD Radix Sort,500,178,0.00088900
+LSD Radix Sort,500,179,0.00082920
+LSD Radix Sort,500,180,0.00080610
+LSD Radix Sort,500,181,0.00074360
+LSD Radix Sort,500,182,0.00088260
+LSD Radix Sort,500,183,0.00066800
+LSD Radix Sort,500,184,0.00064170
+LSD Radix Sort,500,185,0.00074240
+LSD Radix Sort,500,186,0.00095770
+LSD Radix Sort,500,187,0.00074460
+LSD Radix Sort,500,188,0.00112110
+LSD Radix Sort,500,189,0.00110210
+LSD Radix Sort,500,190,0.00065790
+LSD Radix Sort,500,191,0.00103470
+LSD Radix Sort,500,192,0.00077080
+LSD Radix Sort,500,193,0.00065970
+LSD Radix Sort,500,194,0.00065780
+LSD Radix Sort,500,195,0.00090190
+LSD Radix Sort,500,196,0.00064670
+LSD Radix Sort,500,197,0.00065060
+LSD Radix Sort,500,198,0.00078440
+LSD Radix Sort,500,199,0.00097130
+LSD Radix Sort,500,200,0.00108050
+LSD Radix Sort,500,201,0.00079630
+LSD Radix Sort,500,202,0.00109930
+LSD Radix Sort,500,203,0.00069750
+LSD Radix Sort,500,204,0.00073950
+LSD Radix Sort,500,205,0.00107490
+LSD Radix Sort,500,206,0.00111650
+LSD Radix Sort,500,207,0.00105760
+LSD Radix Sort,500,208,0.00095380
+LSD Radix Sort,500,209,0.00129470
+LSD Radix Sort,500,210,0.00110830
+LSD Radix Sort,500,211,0.00066410
+LSD Radix Sort,500,212,0.00108230
+LSD Radix Sort,500,213,0.00114290
+LSD Radix Sort,500,214,0.00081980
+LSD Radix Sort,500,215,0.00111350
+LSD Radix Sort,500,216,0.00108140
+LSD Radix Sort,500,217,0.00073820
+LSD Radix Sort,500,218,0.00112410
+LSD Radix Sort,500,219,0.00112840
+LSD Radix Sort,500,220,0.00115020
+LSD Radix Sort,500,221,0.00109340
+LSD Radix Sort,500,222,0.00107520
+LSD Radix Sort,500,223,0.00120390
+LSD Radix Sort,500,224,0.00142520
+LSD Radix Sort,500,225,0.00091370
+LSD Radix Sort,500,226,0.00075480
+LSD Radix Sort,500,227,0.00111200
+LSD Radix Sort,500,228,0.00104470
+LSD Radix Sort,500,229,0.00116880
+LSD Radix Sort,500,230,0.00113280
+LSD Radix Sort,500,231,0.00113770
+LSD Radix Sort,500,232,0.00065190
+LSD Radix Sort,500,233,0.00112100
+LSD Radix Sort,500,234,0.00076970
+LSD Radix Sort,500,235,0.00064950
+LSD Radix Sort,500,236,0.00113760
+LSD Radix Sort,500,237,0.00066040
+LSD Radix Sort,500,238,0.00088890
+LSD Radix Sort,500,239,0.00116540
+LSD Radix Sort,500,240,0.00115770
+LSD Radix Sort,500,241,0.00109370
+LSD Radix Sort,500,242,0.00098660
+LSD Radix Sort,500,243,0.00102500
+LSD Radix Sort,500,244,0.00064970
+LSD Radix Sort,500,245,0.00095780
+LSD Radix Sort,500,246,0.00111370
+LSD Radix Sort,500,247,0.00068320
+LSD Radix Sort,500,248,0.00069820
+LSD Radix Sort,500,249,0.00088040
+LSD Radix Sort,500,250,0.00089000
+LSD Radix Sort,500,251,0.00112310
+LSD Radix Sort,500,252,0.00105830
+LSD Radix Sort,500,253,0.00110470
+LSD Radix Sort,500,254,0.00109680
+LSD Radix Sort,500,255,0.00065970
+LSD Radix Sort,500,256,0.00110080
+LSD Radix Sort,500,257,0.00113680
+LSD Radix Sort,500,258,0.00068510
+LSD Radix Sort,500,259,0.00115330
+LSD Radix Sort,500,260,0.00112480
+LSD Radix Sort,500,261,0.00078220
+LSD Radix Sort,500,262,0.00088070
+LSD Radix Sort,500,263,0.00076290
+LSD Radix Sort,500,264,0.00073270
+LSD Radix Sort,500,265,0.00108520
+LSD Radix Sort,500,266,0.00067230
+LSD Radix Sort,500,267,0.00066900
+LSD Radix Sort,500,268,0.00095730
+LSD Radix Sort,500,269,0.00110280
+LSD Radix Sort,500,270,0.00079940
+LSD Radix Sort,500,271,0.00072690
+LSD Radix Sort,500,272,0.00111870
+LSD Radix Sort,500,273,0.00108260
+LSD Radix Sort,500,274,0.00115770
+LSD Radix Sort,500,275,0.00112020
+LSD Radix Sort,500,276,0.00109940
+LSD Radix Sort,500,277,0.00065850
+LSD Radix Sort,500,278,0.00079270
+LSD Radix Sort,500,279,0.00109200
+LSD Radix Sort,500,280,0.00107390
+LSD Radix Sort,500,281,0.00062490
+LSD Radix Sort,500,282,0.00081840
+LSD Radix Sort,500,283,0.00075700
+LSD Radix Sort,500,284,0.00108380
+LSD Radix Sort,500,285,0.00109740
+LSD Radix Sort,500,286,0.00089020
+LSD Radix Sort,500,287,0.00067500
+LSD Radix Sort,500,288,0.00110140
+LSD Radix Sort,500,289,0.00108370
+LSD Radix Sort,500,290,0.00087460
+LSD Radix Sort,500,291,0.00116320
+LSD Radix Sort,500,292,0.00113030
+LSD Radix Sort,500,293,0.00106450
+LSD Radix Sort,500,294,0.00107180
+LSD Radix Sort,500,295,0.00098890
+LSD Radix Sort,500,296,0.00107950
+LSD Radix Sort,500,297,0.00108240
+LSD Radix Sort,500,298,0.00108340
+LSD Radix Sort,500,299,0.00073600
+LSD Radix Sort,500,300,0.00063480
+LSD Radix Sort,500,301,0.00106590
+LSD Radix Sort,500,302,0.00092730
+LSD Radix Sort,500,303,0.00101570
+LSD Radix Sort,500,304,0.00073670
+LSD Radix Sort,500,305,0.00064920
+LSD Radix Sort,500,306,0.00081480
+LSD Radix Sort,500,307,0.00103580
+LSD Radix Sort,500,308,0.00065670
+LSD Radix Sort,500,309,0.00064140
+LSD Radix Sort,500,310,0.00071440
+LSD Radix Sort,500,311,0.00063680
+LSD Radix Sort,500,312,0.00094820
+LSD Radix Sort,500,313,0.00064700
+LSD Radix Sort,500,314,0.00065580
+LSD Radix Sort,500,315,0.00082390
+LSD Radix Sort,500,316,0.00073710
+LSD Radix Sort,500,317,0.00073900
+LSD Radix Sort,500,318,0.00114750
+LSD Radix Sort,500,319,0.00111930
+LSD Radix Sort,500,320,0.00081350
+LSD Radix Sort,500,321,0.00091820
+LSD Radix Sort,500,322,0.00115910
+LSD Radix Sort,500,323,0.00119650
+LSD Radix Sort,500,324,0.00111770
+LSD Radix Sort,500,325,0.00118140
+LSD Radix Sort,500,326,0.00103620
+LSD Radix Sort,500,327,0.00093170
+LSD Radix Sort,500,328,0.00099370
+LSD Radix Sort,500,329,0.00100200
+LSD Radix Sort,500,330,0.00083900
+LSD Radix Sort,500,331,0.00064070
+LSD Radix Sort,500,332,0.00120010
+LSD Radix Sort,500,333,0.00064630
+LSD Radix Sort,500,334,0.00080190
+LSD Radix Sort,500,335,0.00110090
+LSD Radix Sort,500,336,0.00066260
+LSD Radix Sort,500,337,0.00133350
+LSD Radix Sort,500,338,0.00113170
+LSD Radix Sort,500,339,0.00115860
+LSD Radix Sort,500,340,0.00072680
+LSD Radix Sort,500,341,0.00112450
+LSD Radix Sort,500,342,0.00069010
+LSD Radix Sort,500,343,0.00112100
+LSD Radix Sort,500,344,0.00110240
+LSD Radix Sort,500,345,0.00088130
+LSD Radix Sort,500,346,0.00112960
+LSD Radix Sort,500,347,0.00123030
+LSD Radix Sort,500,348,0.00121630
+LSD Radix Sort,500,349,0.00131000
+LSD Radix Sort,500,350,0.00111290
+LSD Radix Sort,500,351,0.00078530
+LSD Radix Sort,500,352,0.00111280
+LSD Radix Sort,500,353,0.00092340
+LSD Radix Sort,500,354,0.00091060
+LSD Radix Sort,500,355,0.00110360
+LSD Radix Sort,500,356,0.00106990
+LSD Radix Sort,500,357,0.00124970
+LSD Radix Sort,500,358,0.00098450
+LSD Radix Sort,500,359,0.00115620
+LSD Radix Sort,500,360,0.00103690
+LSD Radix Sort,500,361,0.00111370
+LSD Radix Sort,500,362,0.00082690
+LSD Radix Sort,500,363,0.00110820
+LSD Radix Sort,500,364,0.00087350
+LSD Radix Sort,500,365,0.00106430
+LSD Radix Sort,500,366,0.00111460
+LSD Radix Sort,500,367,0.00111450
+LSD Radix Sort,500,368,0.00119910
+LSD Radix Sort,500,369,0.00110910
+LSD Radix Sort,500,370,0.00101740
+LSD Radix Sort,500,371,0.00112110
+LSD Radix Sort,500,372,0.00075450
+LSD Radix Sort,500,373,0.00079670
+LSD Radix Sort,500,374,0.00111360
+LSD Radix Sort,500,375,0.00080210
+LSD Radix Sort,500,376,0.00087840
+LSD Radix Sort,500,377,0.00097670
+LSD Radix Sort,500,378,0.00093200
+LSD Radix Sort,500,379,0.00073010
+LSD Radix Sort,500,380,0.00110540
+LSD Radix Sort,500,381,0.00079530
+LSD Radix Sort,500,382,0.00070040
+LSD Radix Sort,500,383,0.00121680
+LSD Radix Sort,500,384,0.00117980
+LSD Radix Sort,500,385,0.00117270
+LSD Radix Sort,500,386,0.00094780
+LSD Radix Sort,500,387,0.00105370
+LSD Radix Sort,500,388,0.00116400
+LSD Radix Sort,500,389,0.00070160
+LSD Radix Sort,500,390,0.00116510
+LSD Radix Sort,500,391,0.00108660
+LSD Radix Sort,500,392,0.00097780
+LSD Radix Sort,500,393,0.00115570
+LSD Radix Sort,500,394,0.00109270
+LSD Radix Sort,500,395,0.00115170
+LSD Radix Sort,500,396,0.00103740
+LSD Radix Sort,500,397,0.00112090
+LSD Radix Sort,500,398,0.00111860
+LSD Radix Sort,500,399,0.00101200
+LSD Radix Sort,500,400,0.00100230
+LSD Radix Sort,500,401,0.00105560
+LSD Radix Sort,500,402,0.00085130
+LSD Radix Sort,500,403,0.00066930
+LSD Radix Sort,500,404,0.00075690
+LSD Radix Sort,500,405,0.00087360
+LSD Radix Sort,500,406,0.00080950
+LSD Radix Sort,500,407,0.00084890
+LSD Radix Sort,500,408,0.00146550
+LSD Radix Sort,500,409,0.00108480
+LSD Radix Sort,500,410,0.00110140
+LSD Radix Sort,500,411,0.00117660
+LSD Radix Sort,500,412,0.00094370
+LSD Radix Sort,500,413,0.00087420
+LSD Radix Sort,500,414,0.00089510
+LSD Radix Sort,500,415,0.00126030
+LSD Radix Sort,500,416,0.00115090
+LSD Radix Sort,500,417,0.00122040
+LSD Radix Sort,500,418,0.00114590
+LSD Radix Sort,500,419,0.00104010
+LSD Radix Sort,500,420,0.00111400
+LSD Radix Sort,500,421,0.00109020
+LSD Radix Sort,500,422,0.00101640
+LSD Radix Sort,500,423,0.00064880
+LSD Radix Sort,500,424,0.00073470
+LSD Radix Sort,500,425,0.00083270
+LSD Radix Sort,500,426,0.00094320
+LSD Radix Sort,500,427,0.00120250
+LSD Radix Sort,500,428,0.00094130
+LSD Radix Sort,500,429,0.00109340
+LSD Radix Sort,500,430,0.00112310
+LSD Radix Sort,500,431,0.00109760
+LSD Radix Sort,500,432,0.00112200
+LSD Radix Sort,500,433,0.00109480
+LSD Radix Sort,500,434,0.00111430
+LSD Radix Sort,500,435,0.00113820
+LSD Radix Sort,500,436,0.00111820
+LSD Radix Sort,500,437,0.00111930
+LSD Radix Sort,500,438,0.00107090
+LSD Radix Sort,500,439,0.00114040
+LSD Radix Sort,500,440,0.00112020
+LSD Radix Sort,500,441,0.00111870
+LSD Radix Sort,500,442,0.00068040
+LSD Radix Sort,500,443,0.00109230
+LSD Radix Sort,500,444,0.00109200
+LSD Radix Sort,500,445,0.00081800
+LSD Radix Sort,500,446,0.00114150
+LSD Radix Sort,500,447,0.00114510
+LSD Radix Sort,500,448,0.00111100
+LSD Radix Sort,500,449,0.00082160
+LSD Radix Sort,500,450,0.00092540
+LSD Radix Sort,500,451,0.00110220
+LSD Radix Sort,500,452,0.00114720
+LSD Radix Sort,500,453,0.00080300
+LSD Radix Sort,500,454,0.00083050
+LSD Radix Sort,500,455,0.00111000
+LSD Radix Sort,500,456,0.00108080
+LSD Radix Sort,500,457,0.00076990
+LSD Radix Sort,500,458,0.00112420
+LSD Radix Sort,500,459,0.00112910
+LSD Radix Sort,500,460,0.00093060
+LSD Radix Sort,500,461,0.00066420
+LSD Radix Sort,500,462,0.00115080
+LSD Radix Sort,500,463,0.00063950
+LSD Radix Sort,500,464,0.00114910
+LSD Radix Sort,500,465,0.00073890
+LSD Radix Sort,500,466,0.00121200
+LSD Radix Sort,500,467,0.00083630
+LSD Radix Sort,500,468,0.00113240
+LSD Radix Sort,500,469,0.00111710
+LSD Radix Sort,500,470,0.00084540
+LSD Radix Sort,500,471,0.00092990
+LSD Radix Sort,500,472,0.00110930
+LSD Radix Sort,500,473,0.00094090
+LSD Radix Sort,500,474,0.00115430
+LSD Radix Sort,500,475,0.00098280
+LSD Radix Sort,500,476,0.00110600
+LSD Radix Sort,500,477,0.00096180
+LSD Radix Sort,500,478,0.00113110
+LSD Radix Sort,500,479,0.00100130
+LSD Radix Sort,500,480,0.00112080
+LSD Radix Sort,500,481,0.00109040
+LSD Radix Sort,500,482,0.00112390
+LSD Radix Sort,500,483,0.00092680
+LSD Radix Sort,500,484,0.00075360
+LSD Radix Sort,500,485,0.00111840
+LSD Radix Sort,500,486,0.00074460
+LSD Radix Sort,500,487,0.00100860
+LSD Radix Sort,500,488,0.00112250
+LSD Radix Sort,500,489,0.00096610
+LSD Radix Sort,500,490,0.00067620
+LSD Radix Sort,500,491,0.00109850
+LSD Radix Sort,500,492,0.00063830
+LSD Radix Sort,500,493,0.00078060
+LSD Radix Sort,500,494,0.00067170
+LSD Radix Sort,500,495,0.00110820
+LSD Radix Sort,500,496,0.00078840
+LSD Radix Sort,500,497,0.00090510
+LSD Radix Sort,500,498,0.00093700
+LSD Radix Sort,500,499,0.00098970
+LSD Radix Sort,500,500,0.00107220
+Library Sort,500,1,0.00446070
+Library Sort,500,2,0.00529880
+Library Sort,500,3,0.00425300
+Library Sort,500,4,0.00371350
+Library Sort,500,5,0.00356000
+Library Sort,500,6,0.00429390
+Library Sort,500,7,0.00489850
+Library Sort,500,8,0.00575950
+Library Sort,500,9,0.00588480
+Library Sort,500,10,0.00337930
+Library Sort,500,11,0.00385270
+Library Sort,500,12,0.00602410
+Library Sort,500,13,0.00312600
+Library Sort,500,14,0.00293450
+Library Sort,500,15,0.00402420
+Library Sort,500,16,0.00336660
+Library Sort,500,17,0.00368980
+Library Sort,500,18,0.00420590
+Library Sort,500,19,0.00247990
+Library Sort,500,20,0.00414750
+Library Sort,500,21,0.00169990
+Library Sort,500,22,0.00740100
+Library Sort,500,23,0.00439440
+Library Sort,500,24,0.00351330
+Library Sort,500,25,0.00301530
+Library Sort,500,26,0.00339130
+Library Sort,500,27,0.00382430
+Library Sort,500,28,0.00187520
+Library Sort,500,29,0.00283590
+Library Sort,500,30,0.00397460
+Library Sort,500,31,0.00527790
+Library Sort,500,32,0.00164550
+Library Sort,500,33,0.00439290
+Library Sort,500,34,0.00365600
+Library Sort,500,35,0.00384810
+Library Sort,500,36,0.00419830
+Library Sort,500,37,0.00326560
+Library Sort,500,38,0.00528010
+Library Sort,500,39,0.00219890
+Library Sort,500,40,0.00499470
+Library Sort,500,41,0.00327490
+Library Sort,500,42,0.00474720
+Library Sort,500,43,0.00313650
+Library Sort,500,44,0.00220880
+Library Sort,500,45,0.00252620
+Library Sort,500,46,0.00305930
+Library Sort,500,47,0.00363170
+Library Sort,500,48,0.00703540
+Library Sort,500,49,0.00512630
+Library Sort,500,50,0.00370590
+Library Sort,500,51,0.00302280
+Library Sort,500,52,0.00196350
+Library Sort,500,53,0.00324640
+Library Sort,500,54,0.00273350
+Library Sort,500,55,0.00215420
+Library Sort,500,56,0.00245710
+Library Sort,500,57,0.00437170
+Library Sort,500,58,0.00307130
+Library Sort,500,59,0.00534000
+Library Sort,500,60,0.00526800
+Library Sort,500,61,0.00397280
+Library Sort,500,62,0.00249790
+Library Sort,500,63,0.00444370
+Library Sort,500,64,0.00316460
+Library Sort,500,65,0.00306020
+Library Sort,500,66,0.00569590
+Library Sort,500,67,0.00330080
+Library Sort,500,68,0.00518270
+Library Sort,500,69,0.00393720
+Library Sort,500,70,0.00370090
+Library Sort,500,71,0.00272590
+Library Sort,500,72,0.00362640
+Library Sort,500,73,0.00662860
+Library Sort,500,74,0.00316260
+Library Sort,500,75,0.00545690
+Library Sort,500,76,0.00229510
+Library Sort,500,77,0.00365110
+Library Sort,500,78,0.00336130
+Library Sort,500,79,0.00277170
+Library Sort,500,80,0.00209630
+Library Sort,500,81,0.00279370
+Library Sort,500,82,0.00419570
+Library Sort,500,83,0.00278210
+Library Sort,500,84,0.00310950
+Library Sort,500,85,0.00427830
+Library Sort,500,86,0.00396520
+Library Sort,500,87,0.00586410
+Library Sort,500,88,0.00285740
+Library Sort,500,89,0.00278540
+Library Sort,500,90,0.00383250
+Library Sort,500,91,0.00583650
+Library Sort,500,92,0.00391270
+Library Sort,500,93,0.00247260
+Library Sort,500,94,0.00334110
+Library Sort,500,95,0.00370350
+Library Sort,500,96,0.00767830
+Library Sort,500,97,0.00422740
+Library Sort,500,98,0.00513500
+Library Sort,500,99,0.00376660
+Library Sort,500,100,0.00214900
+Library Sort,500,101,0.00294730
+Library Sort,500,102,0.00841380
+Library Sort,500,103,0.00365540
+Library Sort,500,104,0.00221370
+Library Sort,500,105,0.00403500
+Library Sort,500,106,0.00344620
+Library Sort,500,107,0.00202410
+Library Sort,500,108,0.00287180
+Library Sort,500,109,0.00392570
+Library Sort,500,110,0.00390620
+Library Sort,500,111,0.00501650
+Library Sort,500,112,0.00261870
+Library Sort,500,113,0.00241040
+Library Sort,500,114,0.00303200
+Library Sort,500,115,0.00529580
+Library Sort,500,116,0.00231560
+Library Sort,500,117,0.00183150
+Library Sort,500,118,0.00228790
+Library Sort,500,119,0.00283250
+Library Sort,500,120,0.00288010
+Library Sort,500,121,0.00524560
+Library Sort,500,122,0.00300920
+Library Sort,500,123,0.00287840
+Library Sort,500,124,0.00291370
+Library Sort,500,125,0.00426540
+Library Sort,500,126,0.00814110
+Library Sort,500,127,0.00224510
+Library Sort,500,128,0.00319310
+Library Sort,500,129,0.00442730
+Library Sort,500,130,0.00478520
+Library Sort,500,131,0.00339280
+Library Sort,500,132,0.00775940
+Library Sort,500,133,0.00256850
+Library Sort,500,134,0.00259340
+Library Sort,500,135,0.00313430
+Library Sort,500,136,0.00273250
+Library Sort,500,137,0.00310390
+Library Sort,500,138,0.00326050
+Library Sort,500,139,0.00389600
+Library Sort,500,140,0.00474560
+Library Sort,500,141,0.00308630
+Library Sort,500,142,0.00474020
+Library Sort,500,143,0.00283830
+Library Sort,500,144,0.00293800
+Library Sort,500,145,0.00730140
+Library Sort,500,146,0.00484340
+Library Sort,500,147,0.00258600
+Library Sort,500,148,0.00254560
+Library Sort,500,149,0.00286920
+Library Sort,500,150,0.00491450
+Library Sort,500,151,0.00663400
+Library Sort,500,152,0.00229440
+Library Sort,500,153,0.00516920
+Library Sort,500,154,0.00348410
+Library Sort,500,155,0.00240160
+Library Sort,500,156,0.00489160
+Library Sort,500,157,0.00229490
+Library Sort,500,158,0.00379430
+Library Sort,500,159,0.00347990
+Library Sort,500,160,0.00578270
+Library Sort,500,161,0.00417630
+Library Sort,500,162,0.00231370
+Library Sort,500,163,0.00403560
+Library Sort,500,164,0.00250770
+Library Sort,500,165,0.00302350
+Library Sort,500,166,0.00364310
+Library Sort,500,167,0.00360510
+Library Sort,500,168,0.00494340
+Library Sort,500,169,0.00711970
+Library Sort,500,170,0.00555300
+Library Sort,500,171,0.00379470
+Library Sort,500,172,0.00217980
+Library Sort,500,173,0.00308290
+Library Sort,500,174,0.00256400
+Library Sort,500,175,0.00382650
+Library Sort,500,176,0.00587460
+Library Sort,500,177,0.00278550
+Library Sort,500,178,0.00416020
+Library Sort,500,179,0.00414190
+Library Sort,500,180,0.00324910
+Library Sort,500,181,0.00479240
+Library Sort,500,182,0.00414730
+Library Sort,500,183,0.00363440
+Library Sort,500,184,0.00302680
+Library Sort,500,185,0.00382920
+Library Sort,500,186,0.00328020
+Library Sort,500,187,0.00313320
+Library Sort,500,188,0.00316040
+Library Sort,500,189,0.00663990
+Library Sort,500,190,0.00326950
+Library Sort,500,191,0.00257790
+Library Sort,500,192,0.00866930
+Library Sort,500,193,0.00423910
+Library Sort,500,194,0.00363180
+Library Sort,500,195,0.00432490
+Library Sort,500,196,0.00598470
+Library Sort,500,197,0.00592180
+Library Sort,500,198,0.00493150
+Library Sort,500,199,0.00379990
+Library Sort,500,200,0.00307340
+Library Sort,500,201,0.00278140
+Library Sort,500,202,0.00415250
+Library Sort,500,203,0.00362550
+Library Sort,500,204,0.00327650
+Library Sort,500,205,0.00390220
+Library Sort,500,206,0.00446350
+Library Sort,500,207,0.00212300
+Library Sort,500,208,0.00622540
+Library Sort,500,209,0.00271320
+Library Sort,500,210,0.00662510
+Library Sort,500,211,0.00380470
+Library Sort,500,212,0.00356140
+Library Sort,500,213,0.00756860
+Library Sort,500,214,0.00359690
+Library Sort,500,215,0.00309720
+Library Sort,500,216,0.00354230
+Library Sort,500,217,0.00348710
+Library Sort,500,218,0.00349940
+Library Sort,500,219,0.00442270
+Library Sort,500,220,0.00581500
+Library Sort,500,221,0.00349780
+Library Sort,500,222,0.00319550
+Library Sort,500,223,0.00253790
+Library Sort,500,224,0.00513980
+Library Sort,500,225,0.00572730
+Library Sort,500,226,0.00223780
+Library Sort,500,227,0.00426650
+Library Sort,500,228,0.00306530
+Library Sort,500,229,0.00392510
+Library Sort,500,230,0.00513360
+Library Sort,500,231,0.00325620
+Library Sort,500,232,0.00228990
+Library Sort,500,233,0.00563550
+Library Sort,500,234,0.00288760
+Library Sort,500,235,0.00805590
+Library Sort,500,236,0.00386930
+Library Sort,500,237,0.00420930
+Library Sort,500,238,0.00202510
+Library Sort,500,239,0.00350100
+Library Sort,500,240,0.00825690
+Library Sort,500,241,0.00371920
+Library Sort,500,242,0.00250890
+Library Sort,500,243,0.00631250
+Library Sort,500,244,0.00710860
+Library Sort,500,245,0.00209240
+Library Sort,500,246,0.00231670
+Library Sort,500,247,0.00463980
+Library Sort,500,248,0.00489460
+Library Sort,500,249,0.00278820
+Library Sort,500,250,0.00465460
+Library Sort,500,251,0.00352880
+Library Sort,500,252,0.00344650
+Library Sort,500,253,0.00285330
+Library Sort,500,254,0.00352890
+Library Sort,500,255,0.00451190
+Library Sort,500,256,0.00724280
+Library Sort,500,257,0.00297960
+Library Sort,500,258,0.00181420
+Library Sort,500,259,0.00383840
+Library Sort,500,260,0.00550160
+Library Sort,500,261,0.00262660
+Library Sort,500,262,0.00259680
+Library Sort,500,263,0.00456600
+Library Sort,500,264,0.00338050
+Library Sort,500,265,0.00344760
+Library Sort,500,266,0.00626130
+Library Sort,500,267,0.00463730
+Library Sort,500,268,0.00220820
+Library Sort,500,269,0.00626230
+Library Sort,500,270,0.00357040
+Library Sort,500,271,0.00400480
+Library Sort,500,272,0.00580620
+Library Sort,500,273,0.00299480
+Library Sort,500,274,0.00416520
+Library Sort,500,275,0.00305770
+Library Sort,500,276,0.00332990
+Library Sort,500,277,0.00232110
+Library Sort,500,278,0.00448970
+Library Sort,500,279,0.00746870
+Library Sort,500,280,0.00210210
+Library Sort,500,281,0.00301010
+Library Sort,500,282,0.00252990
+Library Sort,500,283,0.00359070
+Library Sort,500,284,0.00407980
+Library Sort,500,285,0.00351990
+Library Sort,500,286,0.00434770
+Library Sort,500,287,0.00530720
+Library Sort,500,288,0.00406530
+Library Sort,500,289,0.00463580
+Library Sort,500,290,0.00367020
+Library Sort,500,291,0.00805450
+Library Sort,500,292,0.00479660
+Library Sort,500,293,0.00455400
+Library Sort,500,294,0.00403410
+Library Sort,500,295,0.00221090
+Library Sort,500,296,0.00380080
+Library Sort,500,297,0.00348720
+Library Sort,500,298,0.00389810
+Library Sort,500,299,0.00267000
+Library Sort,500,300,0.00342510
+Library Sort,500,301,0.00274250
+Library Sort,500,302,0.00231220
+Library Sort,500,303,0.00401400
+Library Sort,500,304,0.00207950
+Library Sort,500,305,0.00182150
+Library Sort,500,306,0.00275320
+Library Sort,500,307,0.00846650
+Library Sort,500,308,0.00508520
+Library Sort,500,309,0.00332410
+Library Sort,500,310,0.00452590
+Library Sort,500,311,0.00346380
+Library Sort,500,312,0.00546180
+Library Sort,500,313,0.00554290
+Library Sort,500,314,0.00628800
+Library Sort,500,315,0.00378510
+Library Sort,500,316,0.00711220
+Library Sort,500,317,0.00190020
+Library Sort,500,318,0.00371380
+Library Sort,500,319,0.00350340
+Library Sort,500,320,0.00443370
+Library Sort,500,321,0.00312150
+Library Sort,500,322,0.00487670
+Library Sort,500,323,0.00407280
+Library Sort,500,324,0.00305160
+Library Sort,500,325,0.00569570
+Library Sort,500,326,0.00414340
+Library Sort,500,327,0.00396390
+Library Sort,500,328,0.00486380
+Library Sort,500,329,0.00604770
+Library Sort,500,330,0.00511740
+Library Sort,500,331,0.00313920
+Library Sort,500,332,0.00400880
+Library Sort,500,333,0.00337230
+Library Sort,500,334,0.00750140
+Library Sort,500,335,0.00390120
+Library Sort,500,336,0.00243610
+Library Sort,500,337,0.00495240
+Library Sort,500,338,0.00172360
+Library Sort,500,339,0.00591040
+Library Sort,500,340,0.00413470
+Library Sort,500,341,0.00501900
+Library Sort,500,342,0.00532600
+Library Sort,500,343,0.00366210
+Library Sort,500,344,0.00459220
+Library Sort,500,345,0.00522780
+Library Sort,500,346,0.00284160
+Library Sort,500,347,0.00374030
+Library Sort,500,348,0.00451100
+Library Sort,500,349,0.00457810
+Library Sort,500,350,0.00622000
+Library Sort,500,351,0.00372240
+Library Sort,500,352,0.00470640
+Library Sort,500,353,0.00298090
+Library Sort,500,354,0.00264320
+Library Sort,500,355,0.00355250
+Library Sort,500,356,0.00796510
+Library Sort,500,357,0.00284240
+Library Sort,500,358,0.00753180
+Library Sort,500,359,0.00561880
+Library Sort,500,360,0.00370600
+Library Sort,500,361,0.00744160
+Library Sort,500,362,0.00217620
+Library Sort,500,363,0.00321250
+Library Sort,500,364,0.00266320
+Library Sort,500,365,0.00370380
+Library Sort,500,366,0.00714100
+Library Sort,500,367,0.00552450
+Library Sort,500,368,0.00281280
+Library Sort,500,369,0.00333400
+Library Sort,500,370,0.00390370
+Library Sort,500,371,0.00528060
+Library Sort,500,372,0.00349280
+Library Sort,500,373,0.00338290
+Library Sort,500,374,0.00426330
+Library Sort,500,375,0.00257830
+Library Sort,500,376,0.00678710
+Library Sort,500,377,0.00321200
+Library Sort,500,378,0.00462320
+Library Sort,500,379,0.00383970
+Library Sort,500,380,0.00317990
+Library Sort,500,381,0.00357660
+Library Sort,500,382,0.00335500
+Library Sort,500,383,0.00134340
+Library Sort,500,384,0.00470220
+Library Sort,500,385,0.00353510
+Library Sort,500,386,0.00495440
+Library Sort,500,387,0.00195700
+Library Sort,500,388,0.00245790
+Library Sort,500,389,0.00332460
+Library Sort,500,390,0.00469920
+Library Sort,500,391,0.00187880
+Library Sort,500,392,0.00370360
+Library Sort,500,393,0.00626180
+Library Sort,500,394,0.00237670
+Library Sort,500,395,0.00433420
+Library Sort,500,396,0.00184230
+Library Sort,500,397,0.00660530
+Library Sort,500,398,0.00272450
+Library Sort,500,399,0.00329840
+Library Sort,500,400,0.00310590
+Library Sort,500,401,0.00248400
+Library Sort,500,402,0.00194210
+Library Sort,500,403,0.00267490
+Library Sort,500,404,0.00280810
+Library Sort,500,405,0.00395950
+Library Sort,500,406,0.00348230
+Library Sort,500,407,0.00437030
+Library Sort,500,408,0.00449350
+Library Sort,500,409,0.00402910
+Library Sort,500,410,0.00444140
+Library Sort,500,411,0.00265440
+Library Sort,500,412,0.00244120
+Library Sort,500,413,0.00365150
+Library Sort,500,414,0.00489730
+Library Sort,500,415,0.00373010
+Library Sort,500,416,0.00366300
+Library Sort,500,417,0.00560140
+Library Sort,500,418,0.00345570
+Library Sort,500,419,0.00469630
+Library Sort,500,420,0.00559210
+Library Sort,500,421,0.00391550
+Library Sort,500,422,0.00377420
+Library Sort,500,423,0.00344850
+Library Sort,500,424,0.00288170
+Library Sort,500,425,0.00541710
+Library Sort,500,426,0.00302860
+Library Sort,500,427,0.00270390
+Library Sort,500,428,0.00520820
+Library Sort,500,429,0.00376000
+Library Sort,500,430,0.00505890
+Library Sort,500,431,0.00551380
+Library Sort,500,432,0.00499160
+Library Sort,500,433,0.00221440
+Library Sort,500,434,0.00310130
+Library Sort,500,435,0.00332150
+Library Sort,500,436,0.00336390
+Library Sort,500,437,0.00461540
+Library Sort,500,438,0.00532910
+Library Sort,500,439,0.00392050
+Library Sort,500,440,0.00377030
+Library Sort,500,441,0.00740860
+Library Sort,500,442,0.00188260
+Library Sort,500,443,0.00517360
+Library Sort,500,444,0.00272570
+Library Sort,500,445,0.00306020
+Library Sort,500,446,0.00357760
+Library Sort,500,447,0.00308040
+Library Sort,500,448,0.00415660
+Library Sort,500,449,0.00420510
+Library Sort,500,450,0.00288040
+Library Sort,500,451,0.00413680
+Library Sort,500,452,0.00754890
+Library Sort,500,453,0.00459210
+Library Sort,500,454,0.00237830
+Library Sort,500,455,0.00194200
+Library Sort,500,456,0.00342530
+Library Sort,500,457,0.00278850
+Library Sort,500,458,0.00480090
+Library Sort,500,459,0.00240190
+Library Sort,500,460,0.00393490
+Library Sort,500,461,0.00737690
+Library Sort,500,462,0.00154780
+Library Sort,500,463,0.00329220
+Library Sort,500,464,0.00273830
+Library Sort,500,465,0.00284310
+Library Sort,500,466,0.00289240
+Library Sort,500,467,0.00292050
+Library Sort,500,468,0.00621020
+Library Sort,500,469,0.00252650
+Library Sort,500,470,0.00270480
+Library Sort,500,471,0.00478450
+Library Sort,500,472,0.00178320
+Library Sort,500,473,0.00491380
+Library Sort,500,474,0.00440430
+Library Sort,500,475,0.00217220
+Library Sort,500,476,0.00283790
+Library Sort,500,477,0.00386050
+Library Sort,500,478,0.00560530
+Library Sort,500,479,0.00344740
+Library Sort,500,480,0.00245750
+Library Sort,500,481,0.00323580
+Library Sort,500,482,0.00583210
+Library Sort,500,483,0.00546910
+Library Sort,500,484,0.00566390
+Library Sort,500,485,0.00250170
+Library Sort,500,486,0.00272800
+Library Sort,500,487,0.00511710
+Library Sort,500,488,0.00448120
+Library Sort,500,489,0.00471780
+Library Sort,500,490,0.00347480
+Library Sort,500,491,0.00247770
+Library Sort,500,492,0.00264000
+Library Sort,500,493,0.00307120
+Library Sort,500,494,0.00288070
+Library Sort,500,495,0.00847260
+Library Sort,500,496,0.00231190
+Library Sort,500,497,0.00248110
+Library Sort,500,498,0.00721620
+Library Sort,500,499,0.00353010
+Library Sort,500,500,0.00447900
+MSD Radix Sort,500,1,0.00085420
+MSD Radix Sort,500,2,0.00064040
+MSD Radix Sort,500,3,0.00097650
+MSD Radix Sort,500,4,0.00060030
+MSD Radix Sort,500,5,0.00058410
+MSD Radix Sort,500,6,0.00087940
+MSD Radix Sort,500,7,0.00058110
+MSD Radix Sort,500,8,0.00072420
+MSD Radix Sort,500,9,0.00089310
+MSD Radix Sort,500,10,0.00070460
+MSD Radix Sort,500,11,0.00091960
+MSD Radix Sort,500,12,0.00086180
+MSD Radix Sort,500,13,0.00055510
+MSD Radix Sort,500,14,0.00072810
+MSD Radix Sort,500,15,0.00089610
+MSD Radix Sort,500,16,0.00064010
+MSD Radix Sort,500,17,0.00053270
+MSD Radix Sort,500,18,0.00071340
+MSD Radix Sort,500,19,0.00053840
+MSD Radix Sort,500,20,0.00098500
+MSD Radix Sort,500,21,0.00080100
+MSD Radix Sort,500,22,0.00055190
+MSD Radix Sort,500,23,0.00065820
+MSD Radix Sort,500,24,0.00088670
+MSD Radix Sort,500,25,0.00089220
+MSD Radix Sort,500,26,0.00086450
+MSD Radix Sort,500,27,0.00068370
+MSD Radix Sort,500,28,0.00085830
+MSD Radix Sort,500,29,0.00078320
+MSD Radix Sort,500,30,0.00054270
+MSD Radix Sort,500,31,0.00082890
+MSD Radix Sort,500,32,0.00051150
+MSD Radix Sort,500,33,0.00098990
+MSD Radix Sort,500,34,0.00093450
+MSD Radix Sort,500,35,0.00090490
+MSD Radix Sort,500,36,0.00091540
+MSD Radix Sort,500,37,0.00070700
+MSD Radix Sort,500,38,0.00086650
+MSD Radix Sort,500,39,0.00065610
+MSD Radix Sort,500,40,0.00091960
+MSD Radix Sort,500,41,0.00076020
+MSD Radix Sort,500,42,0.00052560
+MSD Radix Sort,500,43,0.00088680
+MSD Radix Sort,500,44,0.00085470
+MSD Radix Sort,500,45,0.00050320
+MSD Radix Sort,500,46,0.00088110
+MSD Radix Sort,500,47,0.00112460
+MSD Radix Sort,500,48,0.00085180
+MSD Radix Sort,500,49,0.00102490
+MSD Radix Sort,500,50,0.00092060
+MSD Radix Sort,500,51,0.00080620
+MSD Radix Sort,500,52,0.00102460
+MSD Radix Sort,500,53,0.00086780
+MSD Radix Sort,500,54,0.00096750
+MSD Radix Sort,500,55,0.00089780
+MSD Radix Sort,500,56,0.00106680
+MSD Radix Sort,500,57,0.00098090
+MSD Radix Sort,500,58,0.00095870
+MSD Radix Sort,500,59,0.00092800
+MSD Radix Sort,500,60,0.00090820
+MSD Radix Sort,500,61,0.00086010
+MSD Radix Sort,500,62,0.00087040
+MSD Radix Sort,500,63,0.00090510
+MSD Radix Sort,500,64,0.00067570
+MSD Radix Sort,500,65,0.00106510
+MSD Radix Sort,500,66,0.00087220
+MSD Radix Sort,500,67,0.00102390
+MSD Radix Sort,500,68,0.00100360
+MSD Radix Sort,500,69,0.00089840
+MSD Radix Sort,500,70,0.00096130
+MSD Radix Sort,500,71,0.00090890
+MSD Radix Sort,500,72,0.00095630
+MSD Radix Sort,500,73,0.00090020
+MSD Radix Sort,500,74,0.00096870
+MSD Radix Sort,500,75,0.00087940
+MSD Radix Sort,500,76,0.00101510
+MSD Radix Sort,500,77,0.00091420
+MSD Radix Sort,500,78,0.00100900
+MSD Radix Sort,500,79,0.00076070
+MSD Radix Sort,500,80,0.00080080
+MSD Radix Sort,500,81,0.00083200
+MSD Radix Sort,500,82,0.00085140
+MSD Radix Sort,500,83,0.00085970
+MSD Radix Sort,500,84,0.00067020
+MSD Radix Sort,500,85,0.00084600
+MSD Radix Sort,500,86,0.00084900
+MSD Radix Sort,500,87,0.00072730
+MSD Radix Sort,500,88,0.00093360
+MSD Radix Sort,500,89,0.00095200
+MSD Radix Sort,500,90,0.00085030
+MSD Radix Sort,500,91,0.00069960
+MSD Radix Sort,500,92,0.00088530
+MSD Radix Sort,500,93,0.00069420
+MSD Radix Sort,500,94,0.00085500
+MSD Radix Sort,500,95,0.00056640
+MSD Radix Sort,500,96,0.00088690
+MSD Radix Sort,500,97,0.00051300
+MSD Radix Sort,500,98,0.00076650
+MSD Radix Sort,500,99,0.00078750
+MSD Radix Sort,500,100,0.00099670
+MSD Radix Sort,500,101,0.00062870
+MSD Radix Sort,500,102,0.00094020
+MSD Radix Sort,500,103,0.00090730
+MSD Radix Sort,500,104,0.00093440
+MSD Radix Sort,500,105,0.00074780
+MSD Radix Sort,500,106,0.00091940
+MSD Radix Sort,500,107,0.00069950
+MSD Radix Sort,500,108,0.00090180
+MSD Radix Sort,500,109,0.00088000
+MSD Radix Sort,500,110,0.00097740
+MSD Radix Sort,500,111,0.00065400
+MSD Radix Sort,500,112,0.00087020
+MSD Radix Sort,500,113,0.00075940
+MSD Radix Sort,500,114,0.00076960
+MSD Radix Sort,500,115,0.00098740
+MSD Radix Sort,500,116,0.00068890
+MSD Radix Sort,500,117,0.00087780
+MSD Radix Sort,500,118,0.00070770
+MSD Radix Sort,500,119,0.00101140
+MSD Radix Sort,500,120,0.00077220
+MSD Radix Sort,500,121,0.00084230
+MSD Radix Sort,500,122,0.00051340
+MSD Radix Sort,500,123,0.00050890
+MSD Radix Sort,500,124,0.00084460
+MSD Radix Sort,500,125,0.00102570
+MSD Radix Sort,500,126,0.00064570
+MSD Radix Sort,500,127,0.00088460
+MSD Radix Sort,500,128,0.00079180
+MSD Radix Sort,500,129,0.00066840
+MSD Radix Sort,500,130,0.00099060
+MSD Radix Sort,500,131,0.00090990
+MSD Radix Sort,500,132,0.00083550
+MSD Radix Sort,500,133,0.00073310
+MSD Radix Sort,500,134,0.00082870
+MSD Radix Sort,500,135,0.00071120
+MSD Radix Sort,500,136,0.00080140
+MSD Radix Sort,500,137,0.00099510
+MSD Radix Sort,500,138,0.00070930
+MSD Radix Sort,500,139,0.00085170
+MSD Radix Sort,500,140,0.00068870
+MSD Radix Sort,500,141,0.00098440
+MSD Radix Sort,500,142,0.00059900
+MSD Radix Sort,500,143,0.00066730
+MSD Radix Sort,500,144,0.00082540
+MSD Radix Sort,500,145,0.00052080
+MSD Radix Sort,500,146,0.00064620
+MSD Radix Sort,500,147,0.00060350
+MSD Radix Sort,500,148,0.00099610
+MSD Radix Sort,500,149,0.00054420
+MSD Radix Sort,500,150,0.00090100
+MSD Radix Sort,500,151,0.00098130
+MSD Radix Sort,500,152,0.00090600
+MSD Radix Sort,500,153,0.00090930
+MSD Radix Sort,500,154,0.00094730
+MSD Radix Sort,500,155,0.00093630
+MSD Radix Sort,500,156,0.00091040
+MSD Radix Sort,500,157,0.00086680
+MSD Radix Sort,500,158,0.00094820
+MSD Radix Sort,500,159,0.00061240
+MSD Radix Sort,500,160,0.00090070
+MSD Radix Sort,500,161,0.00095000
+MSD Radix Sort,500,162,0.00054690
+MSD Radix Sort,500,163,0.00055260
+MSD Radix Sort,500,164,0.00078020
+MSD Radix Sort,500,165,0.00057110
+MSD Radix Sort,500,166,0.00068850
+MSD Radix Sort,500,167,0.00067020
+MSD Radix Sort,500,168,0.00067920
+MSD Radix Sort,500,169,0.00056470
+MSD Radix Sort,500,170,0.00051050
+MSD Radix Sort,500,171,0.00055570
+MSD Radix Sort,500,172,0.00056070
+MSD Radix Sort,500,173,0.00062800
+MSD Radix Sort,500,174,0.00059010
+MSD Radix Sort,500,175,0.00068120
+MSD Radix Sort,500,176,0.00072990
+MSD Radix Sort,500,177,0.00073640
+MSD Radix Sort,500,178,0.00073310
+MSD Radix Sort,500,179,0.00055300
+MSD Radix Sort,500,180,0.00083760
+MSD Radix Sort,500,181,0.00081540
+MSD Radix Sort,500,182,0.00050370
+MSD Radix Sort,500,183,0.00053160
+MSD Radix Sort,500,184,0.00059540
+MSD Radix Sort,500,185,0.00053840
+MSD Radix Sort,500,186,0.00098600
+MSD Radix Sort,500,187,0.00081820
+MSD Radix Sort,500,188,0.00082590
+MSD Radix Sort,500,189,0.00074050
+MSD Radix Sort,500,190,0.00089500
+MSD Radix Sort,500,191,0.00091170
+MSD Radix Sort,500,192,0.00066030
+MSD Radix Sort,500,193,0.00057810
+MSD Radix Sort,500,194,0.00087540
+MSD Radix Sort,500,195,0.00089760
+MSD Radix Sort,500,196,0.00052960
+MSD Radix Sort,500,197,0.00067710
+MSD Radix Sort,500,198,0.00053060
+MSD Radix Sort,500,199,0.00071110
+MSD Radix Sort,500,200,0.00081330
+MSD Radix Sort,500,201,0.00092940
+MSD Radix Sort,500,202,0.00069960
+MSD Radix Sort,500,203,0.00083020
+MSD Radix Sort,500,204,0.00061740
+MSD Radix Sort,500,205,0.00077660
+MSD Radix Sort,500,206,0.00086120
+MSD Radix Sort,500,207,0.00085500
+MSD Radix Sort,500,208,0.00069720
+MSD Radix Sort,500,209,0.00048950
+MSD Radix Sort,500,210,0.00089650
+MSD Radix Sort,500,211,0.00083820
+MSD Radix Sort,500,212,0.00050920
+MSD Radix Sort,500,213,0.00073870
+MSD Radix Sort,500,214,0.00086630
+MSD Radix Sort,500,215,0.00090370
+MSD Radix Sort,500,216,0.00084490
+MSD Radix Sort,500,217,0.00090860
+MSD Radix Sort,500,218,0.00051450
+MSD Radix Sort,500,219,0.00091660
+MSD Radix Sort,500,220,0.00070760
+MSD Radix Sort,500,221,0.00081730
+MSD Radix Sort,500,222,0.00053420
+MSD Radix Sort,500,223,0.00086470
+MSD Radix Sort,500,224,0.00073960
+MSD Radix Sort,500,225,0.00090730
+MSD Radix Sort,500,226,0.00051210
+MSD Radix Sort,500,227,0.00089990
+MSD Radix Sort,500,228,0.00076130
+MSD Radix Sort,500,229,0.00062370
+MSD Radix Sort,500,230,0.00089520
+MSD Radix Sort,500,231,0.00052670
+MSD Radix Sort,500,232,0.00062920
+MSD Radix Sort,500,233,0.00090520
+MSD Radix Sort,500,234,0.00088310
+MSD Radix Sort,500,235,0.00054740
+MSD Radix Sort,500,236,0.00060840
+MSD Radix Sort,500,237,0.00080280
+MSD Radix Sort,500,238,0.00049350
+MSD Radix Sort,500,239,0.00090950
+MSD Radix Sort,500,240,0.00067830
+MSD Radix Sort,500,241,0.00104890
+MSD Radix Sort,500,242,0.00067390
+MSD Radix Sort,500,243,0.00083370
+MSD Radix Sort,500,244,0.00095360
+MSD Radix Sort,500,245,0.00099640
+MSD Radix Sort,500,246,0.00054430
+MSD Radix Sort,500,247,0.00086600
+MSD Radix Sort,500,248,0.00050230
+MSD Radix Sort,500,249,0.00086520
+MSD Radix Sort,500,250,0.00103110
+MSD Radix Sort,500,251,0.00049660
+MSD Radix Sort,500,252,0.00072010
+MSD Radix Sort,500,253,0.00086120
+MSD Radix Sort,500,254,0.00088380
+MSD Radix Sort,500,255,0.00053050
+MSD Radix Sort,500,256,0.00091010
+MSD Radix Sort,500,257,0.00086990
+MSD Radix Sort,500,258,0.00049020
+MSD Radix Sort,500,259,0.00050890
+MSD Radix Sort,500,260,0.00081120
+MSD Radix Sort,500,261,0.00050950
+MSD Radix Sort,500,262,0.00051780
+MSD Radix Sort,500,263,0.00086480
+MSD Radix Sort,500,264,0.00090800
+MSD Radix Sort,500,265,0.00088850
+MSD Radix Sort,500,266,0.00083550
+MSD Radix Sort,500,267,0.00091680
+MSD Radix Sort,500,268,0.00091520
+MSD Radix Sort,500,269,0.00088140
+MSD Radix Sort,500,270,0.00084940
+MSD Radix Sort,500,271,0.00088770
+MSD Radix Sort,500,272,0.00092930
+MSD Radix Sort,500,273,0.00080710
+MSD Radix Sort,500,274,0.00088370
+MSD Radix Sort,500,275,0.00091790
+MSD Radix Sort,500,276,0.00104780
+MSD Radix Sort,500,277,0.00090440
+MSD Radix Sort,500,278,0.00082980
+MSD Radix Sort,500,279,0.00086480
+MSD Radix Sort,500,280,0.00084990
+MSD Radix Sort,500,281,0.00065910
+MSD Radix Sort,500,282,0.00088400
+MSD Radix Sort,500,283,0.00086530
+MSD Radix Sort,500,284,0.00060660
+MSD Radix Sort,500,285,0.00083750
+MSD Radix Sort,500,286,0.00085900
+MSD Radix Sort,500,287,0.00065320
+MSD Radix Sort,500,288,0.00085870
+MSD Radix Sort,500,289,0.00084410
+MSD Radix Sort,500,290,0.00085230
+MSD Radix Sort,500,291,0.00048720
+MSD Radix Sort,500,292,0.00085580
+MSD Radix Sort,500,293,0.00083380
+MSD Radix Sort,500,294,0.00057290
+MSD Radix Sort,500,295,0.00088800
+MSD Radix Sort,500,296,0.00083680
+MSD Radix Sort,500,297,0.00060300
+MSD Radix Sort,500,298,0.00082740
+MSD Radix Sort,500,299,0.00077230
+MSD Radix Sort,500,300,0.00089960
+MSD Radix Sort,500,301,0.00082190
+MSD Radix Sort,500,302,0.00084340
+MSD Radix Sort,500,303,0.00099850
+MSD Radix Sort,500,304,0.00081530
+MSD Radix Sort,500,305,0.00061690
+MSD Radix Sort,500,306,0.00085170
+MSD Radix Sort,500,307,0.00080450
+MSD Radix Sort,500,308,0.00083740
+MSD Radix Sort,500,309,0.00068100
+MSD Radix Sort,500,310,0.00076210
+MSD Radix Sort,500,311,0.00062590
+MSD Radix Sort,500,312,0.00071610
+MSD Radix Sort,500,313,0.00093060
+MSD Radix Sort,500,314,0.00083800
+MSD Radix Sort,500,315,0.00055900
+MSD Radix Sort,500,316,0.00061210
+MSD Radix Sort,500,317,0.00077000
+MSD Radix Sort,500,318,0.00055070
+MSD Radix Sort,500,319,0.00064760
+MSD Radix Sort,500,320,0.00063710
+MSD Radix Sort,500,321,0.00097980
+MSD Radix Sort,500,322,0.00051570
+MSD Radix Sort,500,323,0.00068850
+MSD Radix Sort,500,324,0.00091960
+MSD Radix Sort,500,325,0.00076350
+MSD Radix Sort,500,326,0.00077940
+MSD Radix Sort,500,327,0.00090430
+MSD Radix Sort,500,328,0.00088100
+MSD Radix Sort,500,329,0.00084250
+MSD Radix Sort,500,330,0.00059710
+MSD Radix Sort,500,331,0.00090810
+MSD Radix Sort,500,332,0.00089150
+MSD Radix Sort,500,333,0.00086140
+MSD Radix Sort,500,334,0.00055850
+MSD Radix Sort,500,335,0.00102570
+MSD Radix Sort,500,336,0.00092520
+MSD Radix Sort,500,337,0.00096230
+MSD Radix Sort,500,338,0.00073280
+MSD Radix Sort,500,339,0.00090770
+MSD Radix Sort,500,340,0.00089540
+MSD Radix Sort,500,341,0.00088010
+MSD Radix Sort,500,342,0.00095010
+MSD Radix Sort,500,343,0.00089880
+MSD Radix Sort,500,344,0.00083690
+MSD Radix Sort,500,345,0.00083410
+MSD Radix Sort,500,346,0.00087960
+MSD Radix Sort,500,347,0.00072210
+MSD Radix Sort,500,348,0.00087600
+MSD Radix Sort,500,349,0.00097030
+MSD Radix Sort,500,350,0.00088040
+MSD Radix Sort,500,351,0.00089410
+MSD Radix Sort,500,352,0.00091600
+MSD Radix Sort,500,353,0.00096740
+MSD Radix Sort,500,354,0.00068850
+MSD Radix Sort,500,355,0.00092040
+MSD Radix Sort,500,356,0.00090630
+MSD Radix Sort,500,357,0.00051720
+MSD Radix Sort,500,358,0.00098760
+MSD Radix Sort,500,359,0.00075630
+MSD Radix Sort,500,360,0.00060480
+MSD Radix Sort,500,361,0.00082020
+MSD Radix Sort,500,362,0.00095260
+MSD Radix Sort,500,363,0.00074770
+MSD Radix Sort,500,364,0.00050900
+MSD Radix Sort,500,365,0.00069030
+MSD Radix Sort,500,366,0.00077510
+MSD Radix Sort,500,367,0.00086300
+MSD Radix Sort,500,368,0.00094370
+MSD Radix Sort,500,369,0.00095510
+MSD Radix Sort,500,370,0.00100000
+MSD Radix Sort,500,371,0.00088750
+MSD Radix Sort,500,372,0.00061770
+MSD Radix Sort,500,373,0.00095980
+MSD Radix Sort,500,374,0.00105950
+MSD Radix Sort,500,375,0.00082950
+MSD Radix Sort,500,376,0.00094900
+MSD Radix Sort,500,377,0.00089330
+MSD Radix Sort,500,378,0.00076180
+MSD Radix Sort,500,379,0.00073720
+MSD Radix Sort,500,380,0.00096080
+MSD Radix Sort,500,381,0.00076790
+MSD Radix Sort,500,382,0.00082750
+MSD Radix Sort,500,383,0.00056340
+MSD Radix Sort,500,384,0.00083050
+MSD Radix Sort,500,385,0.00055520
+MSD Radix Sort,500,386,0.00051440
+MSD Radix Sort,500,387,0.00066790
+MSD Radix Sort,500,388,0.00050820
+MSD Radix Sort,500,389,0.00077640
+MSD Radix Sort,500,390,0.00077040
+MSD Radix Sort,500,391,0.00052510
+MSD Radix Sort,500,392,0.00069830
+MSD Radix Sort,500,393,0.00087530
+MSD Radix Sort,500,394,0.00066980
+MSD Radix Sort,500,395,0.00070040
+MSD Radix Sort,500,396,0.00089170
+MSD Radix Sort,500,397,0.00054690
+MSD Radix Sort,500,398,0.00087670
+MSD Radix Sort,500,399,0.00087910
+MSD Radix Sort,500,400,0.00102350
+MSD Radix Sort,500,401,0.00058080
+MSD Radix Sort,500,402,0.00087510
+MSD Radix Sort,500,403,0.00086190
+MSD Radix Sort,500,404,0.00074650
+MSD Radix Sort,500,405,0.00098980
+MSD Radix Sort,500,406,0.00061290
+MSD Radix Sort,500,407,0.00077000
+MSD Radix Sort,500,408,0.00081910
+MSD Radix Sort,500,409,0.00086030
+MSD Radix Sort,500,410,0.00078270
+MSD Radix Sort,500,411,0.00094640
+MSD Radix Sort,500,412,0.00054980
+MSD Radix Sort,500,413,0.00049060
+MSD Radix Sort,500,414,0.00087690
+MSD Radix Sort,500,415,0.00067610
+MSD Radix Sort,500,416,0.00082840
+MSD Radix Sort,500,417,0.00051210
+MSD Radix Sort,500,418,0.00060450
+MSD Radix Sort,500,419,0.00095720
+MSD Radix Sort,500,420,0.00064200
+MSD Radix Sort,500,421,0.00065380
+MSD Radix Sort,500,422,0.00090140
+MSD Radix Sort,500,423,0.00083220
+MSD Radix Sort,500,424,0.00084180
+MSD Radix Sort,500,425,0.00083280
+MSD Radix Sort,500,426,0.00079000
+MSD Radix Sort,500,427,0.00060120
+MSD Radix Sort,500,428,0.00062590
+MSD Radix Sort,500,429,0.00052210
+MSD Radix Sort,500,430,0.00053640
+MSD Radix Sort,500,431,0.00083720
+MSD Radix Sort,500,432,0.00080400
+MSD Radix Sort,500,433,0.00094180
+MSD Radix Sort,500,434,0.00084270
+MSD Radix Sort,500,435,0.00085910
+MSD Radix Sort,500,436,0.00065470
+MSD Radix Sort,500,437,0.00085380
+MSD Radix Sort,500,438,0.00085120
+MSD Radix Sort,500,439,0.00075190
+MSD Radix Sort,500,440,0.00051790
+MSD Radix Sort,500,441,0.00085200
+MSD Radix Sort,500,442,0.00090570
+MSD Radix Sort,500,443,0.00095790
+MSD Radix Sort,500,444,0.00054560
+MSD Radix Sort,500,445,0.00086730
+MSD Radix Sort,500,446,0.00088660
+MSD Radix Sort,500,447,0.00051000
+MSD Radix Sort,500,448,0.00078690
+MSD Radix Sort,500,449,0.00052550
+MSD Radix Sort,500,450,0.00085780
+MSD Radix Sort,500,451,0.00048290
+MSD Radix Sort,500,452,0.00058070
+MSD Radix Sort,500,453,0.00053460
+MSD Radix Sort,500,454,0.00049060
+MSD Radix Sort,500,455,0.00052700
+MSD Radix Sort,500,456,0.00086570
+MSD Radix Sort,500,457,0.00052700
+MSD Radix Sort,500,458,0.00053320
+MSD Radix Sort,500,459,0.00078780
+MSD Radix Sort,500,460,0.00058180
+MSD Radix Sort,500,461,0.00085960
+MSD Radix Sort,500,462,0.00068170
+MSD Radix Sort,500,463,0.00099950
+MSD Radix Sort,500,464,0.00084670
+MSD Radix Sort,500,465,0.00061140
+MSD Radix Sort,500,466,0.00083150
+MSD Radix Sort,500,467,0.00090620
+MSD Radix Sort,500,468,0.00057110
+MSD Radix Sort,500,469,0.00100980
+MSD Radix Sort,500,470,0.00089670
+MSD Radix Sort,500,471,0.00064740
+MSD Radix Sort,500,472,0.00051330
+MSD Radix Sort,500,473,0.00083450
+MSD Radix Sort,500,474,0.00088440
+MSD Radix Sort,500,475,0.00077220
+MSD Radix Sort,500,476,0.00055970
+MSD Radix Sort,500,477,0.00070190
+MSD Radix Sort,500,478,0.00059850
+MSD Radix Sort,500,479,0.00089200
+MSD Radix Sort,500,480,0.00054930
+MSD Radix Sort,500,481,0.00082320
+MSD Radix Sort,500,482,0.00054690
+MSD Radix Sort,500,483,0.00071180
+MSD Radix Sort,500,484,0.00101830
+MSD Radix Sort,500,485,0.00072560
+MSD Radix Sort,500,486,0.00085960
+MSD Radix Sort,500,487,0.00086430
+MSD Radix Sort,500,488,0.00060350
+MSD Radix Sort,500,489,0.00077190
+MSD Radix Sort,500,490,0.00084070
+MSD Radix Sort,500,491,0.00083230
+MSD Radix Sort,500,492,0.00074520
+MSD Radix Sort,500,493,0.00072850
+MSD Radix Sort,500,494,0.00088460
+MSD Radix Sort,500,495,0.00087300
+MSD Radix Sort,500,496,0.00066190
+MSD Radix Sort,500,497,0.00087150
+MSD Radix Sort,500,498,0.00085150
+MSD Radix Sort,500,499,0.00074610
+MSD Radix Sort,500,500,0.00071470
+MSD Radix Sort In-Place,500,1,0.00090470
+MSD Radix Sort In-Place,500,2,0.00091240
+MSD Radix Sort In-Place,500,3,0.00094210
+MSD Radix Sort In-Place,500,4,0.00083230
+MSD Radix Sort In-Place,500,5,0.00088240
+MSD Radix Sort In-Place,500,6,0.00095470
+MSD Radix Sort In-Place,500,7,0.00069930
+MSD Radix Sort In-Place,500,8,0.00092580
+MSD Radix Sort In-Place,500,9,0.00088280
+MSD Radix Sort In-Place,500,10,0.00082390
+MSD Radix Sort In-Place,500,11,0.00101610
+MSD Radix Sort In-Place,500,12,0.00091080
+MSD Radix Sort In-Place,500,13,0.00089110
+MSD Radix Sort In-Place,500,14,0.00086770
+MSD Radix Sort In-Place,500,15,0.00100540
+MSD Radix Sort In-Place,500,16,0.00085240
+MSD Radix Sort In-Place,500,17,0.00094830
+MSD Radix Sort In-Place,500,18,0.00110940
+MSD Radix Sort In-Place,500,19,0.00082910
+MSD Radix Sort In-Place,500,20,0.00081370
+MSD Radix Sort In-Place,500,21,0.00098450
+MSD Radix Sort In-Place,500,22,0.00095030
+MSD Radix Sort In-Place,500,23,0.00055060
+MSD Radix Sort In-Place,500,24,0.00071680
+MSD Radix Sort In-Place,500,25,0.00095560
+MSD Radix Sort In-Place,500,26,0.00053620
+MSD Radix Sort In-Place,500,27,0.00099990
+MSD Radix Sort In-Place,500,28,0.00096500
+MSD Radix Sort In-Place,500,29,0.00097030
+MSD Radix Sort In-Place,500,30,0.00096080
+MSD Radix Sort In-Place,500,31,0.00092840
+MSD Radix Sort In-Place,500,32,0.00090150
+MSD Radix Sort In-Place,500,33,0.00088790
+MSD Radix Sort In-Place,500,34,0.00093160
+MSD Radix Sort In-Place,500,35,0.00094130
+MSD Radix Sort In-Place,500,36,0.00087080
+MSD Radix Sort In-Place,500,37,0.00093460
+MSD Radix Sort In-Place,500,38,0.00090970
+MSD Radix Sort In-Place,500,39,0.00101030
+MSD Radix Sort In-Place,500,40,0.00089920
+MSD Radix Sort In-Place,500,41,0.00090860
+MSD Radix Sort In-Place,500,42,0.00099050
+MSD Radix Sort In-Place,500,43,0.00099270
+MSD Radix Sort In-Place,500,44,0.00098630
+MSD Radix Sort In-Place,500,45,0.00096310
+MSD Radix Sort In-Place,500,46,0.00096920
+MSD Radix Sort In-Place,500,47,0.00093790
+MSD Radix Sort In-Place,500,48,0.00092250
+MSD Radix Sort In-Place,500,49,0.00079280
+MSD Radix Sort In-Place,500,50,0.00100610
+MSD Radix Sort In-Place,500,51,0.00098080
+MSD Radix Sort In-Place,500,52,0.00094880
+MSD Radix Sort In-Place,500,53,0.00099450
+MSD Radix Sort In-Place,500,54,0.00087890
+MSD Radix Sort In-Place,500,55,0.00093940
+MSD Radix Sort In-Place,500,56,0.00093950
+MSD Radix Sort In-Place,500,57,0.00087190
+MSD Radix Sort In-Place,500,58,0.00069780
+MSD Radix Sort In-Place,500,59,0.00093130
+MSD Radix Sort In-Place,500,60,0.00090630
+MSD Radix Sort In-Place,500,61,0.00098090
+MSD Radix Sort In-Place,500,62,0.00093910
+MSD Radix Sort In-Place,500,63,0.00104040
+MSD Radix Sort In-Place,500,64,0.00091760
+MSD Radix Sort In-Place,500,65,0.00092180
+MSD Radix Sort In-Place,500,66,0.00095180
+MSD Radix Sort In-Place,500,67,0.00078150
+MSD Radix Sort In-Place,500,68,0.00096560
+MSD Radix Sort In-Place,500,69,0.00092400
+MSD Radix Sort In-Place,500,70,0.00109560
+MSD Radix Sort In-Place,500,71,0.00101610
+MSD Radix Sort In-Place,500,72,0.00113800
+MSD Radix Sort In-Place,500,73,0.00099500
+MSD Radix Sort In-Place,500,74,0.00090960
+MSD Radix Sort In-Place,500,75,0.00094500
+MSD Radix Sort In-Place,500,76,0.00089340
+MSD Radix Sort In-Place,500,77,0.00112540
+MSD Radix Sort In-Place,500,78,0.00070400
+MSD Radix Sort In-Place,500,79,0.00089450
+MSD Radix Sort In-Place,500,80,0.00093260
+MSD Radix Sort In-Place,500,81,0.00100590
+MSD Radix Sort In-Place,500,82,0.00057420
+MSD Radix Sort In-Place,500,83,0.00086260
+MSD Radix Sort In-Place,500,84,0.00097060
+MSD Radix Sort In-Place,500,85,0.00101410
+MSD Radix Sort In-Place,500,86,0.00090450
+MSD Radix Sort In-Place,500,87,0.00099860
+MSD Radix Sort In-Place,500,88,0.00090500
+MSD Radix Sort In-Place,500,89,0.00082250
+MSD Radix Sort In-Place,500,90,0.00056420
+MSD Radix Sort In-Place,500,91,0.00075230
+MSD Radix Sort In-Place,500,92,0.00055400
+MSD Radix Sort In-Place,500,93,0.00099660
+MSD Radix Sort In-Place,500,94,0.00096940
+MSD Radix Sort In-Place,500,95,0.00087580
+MSD Radix Sort In-Place,500,96,0.00094120
+MSD Radix Sort In-Place,500,97,0.00093280
+MSD Radix Sort In-Place,500,98,0.00097860
+MSD Radix Sort In-Place,500,99,0.00076290
+MSD Radix Sort In-Place,500,100,0.00096960
+MSD Radix Sort In-Place,500,101,0.00093140
+MSD Radix Sort In-Place,500,102,0.00097040
+MSD Radix Sort In-Place,500,103,0.00062080
+MSD Radix Sort In-Place,500,104,0.00094970
+MSD Radix Sort In-Place,500,105,0.00094140
+MSD Radix Sort In-Place,500,106,0.00093640
+MSD Radix Sort In-Place,500,107,0.00100340
+MSD Radix Sort In-Place,500,108,0.00091590
+MSD Radix Sort In-Place,500,109,0.00057940
+MSD Radix Sort In-Place,500,110,0.00085020
+MSD Radix Sort In-Place,500,111,0.00090310
+MSD Radix Sort In-Place,500,112,0.00074480
+MSD Radix Sort In-Place,500,113,0.00093100
+MSD Radix Sort In-Place,500,114,0.00097700
+MSD Radix Sort In-Place,500,115,0.00097100
+MSD Radix Sort In-Place,500,116,0.00088650
+MSD Radix Sort In-Place,500,117,0.00094110
+MSD Radix Sort In-Place,500,118,0.00094990
+MSD Radix Sort In-Place,500,119,0.00081810
+MSD Radix Sort In-Place,500,120,0.00072030
+MSD Radix Sort In-Place,500,121,0.00108950
+MSD Radix Sort In-Place,500,122,0.00076950
+MSD Radix Sort In-Place,500,123,0.00063570
+MSD Radix Sort In-Place,500,124,0.00088670
+MSD Radix Sort In-Place,500,125,0.00078660
+MSD Radix Sort In-Place,500,126,0.00097100
+MSD Radix Sort In-Place,500,127,0.00094480
+MSD Radix Sort In-Place,500,128,0.00092490
+MSD Radix Sort In-Place,500,129,0.00067410
+MSD Radix Sort In-Place,500,130,0.00092120
+MSD Radix Sort In-Place,500,131,0.00074170
+MSD Radix Sort In-Place,500,132,0.00092400
+MSD Radix Sort In-Place,500,133,0.00081970
+MSD Radix Sort In-Place,500,134,0.00077800
+MSD Radix Sort In-Place,500,135,0.00091030
+MSD Radix Sort In-Place,500,136,0.00093630
+MSD Radix Sort In-Place,500,137,0.00068650
+MSD Radix Sort In-Place,500,138,0.00101670
+MSD Radix Sort In-Place,500,139,0.00082550
+MSD Radix Sort In-Place,500,140,0.00110200
+MSD Radix Sort In-Place,500,141,0.00098910
+MSD Radix Sort In-Place,500,142,0.00093380
+MSD Radix Sort In-Place,500,143,0.00090920
+MSD Radix Sort In-Place,500,144,0.00097820
+MSD Radix Sort In-Place,500,145,0.00076960
+MSD Radix Sort In-Place,500,146,0.00098380
+MSD Radix Sort In-Place,500,147,0.00092320
+MSD Radix Sort In-Place,500,148,0.00068740
+MSD Radix Sort In-Place,500,149,0.00101010
+MSD Radix Sort In-Place,500,150,0.00094440
+MSD Radix Sort In-Place,500,151,0.00085270
+MSD Radix Sort In-Place,500,152,0.00102210
+MSD Radix Sort In-Place,500,153,0.00097660
+MSD Radix Sort In-Place,500,154,0.00082470
+MSD Radix Sort In-Place,500,155,0.00084510
+MSD Radix Sort In-Place,500,156,0.00107320
+MSD Radix Sort In-Place,500,157,0.00112510
+MSD Radix Sort In-Place,500,158,0.00082170
+MSD Radix Sort In-Place,500,159,0.00088510
+MSD Radix Sort In-Place,500,160,0.00111090
+MSD Radix Sort In-Place,500,161,0.00120520
+MSD Radix Sort In-Place,500,162,0.00104930
+MSD Radix Sort In-Place,500,163,0.00100700
+MSD Radix Sort In-Place,500,164,0.00089780
+MSD Radix Sort In-Place,500,165,0.00091590
+MSD Radix Sort In-Place,500,166,0.00111030
+MSD Radix Sort In-Place,500,167,0.00067480
+MSD Radix Sort In-Place,500,168,0.00094310
+MSD Radix Sort In-Place,500,169,0.00097580
+MSD Radix Sort In-Place,500,170,0.00111960
+MSD Radix Sort In-Place,500,171,0.00095600
+MSD Radix Sort In-Place,500,172,0.00067390
+MSD Radix Sort In-Place,500,173,0.00081170
+MSD Radix Sort In-Place,500,174,0.00101260
+MSD Radix Sort In-Place,500,175,0.00073540
+MSD Radix Sort In-Place,500,176,0.00086710
+MSD Radix Sort In-Place,500,177,0.00073290
+MSD Radix Sort In-Place,500,178,0.00094890
+MSD Radix Sort In-Place,500,179,0.00089610
+MSD Radix Sort In-Place,500,180,0.00093630
+MSD Radix Sort In-Place,500,181,0.00095750
+MSD Radix Sort In-Place,500,182,0.00094950
+MSD Radix Sort In-Place,500,183,0.00100730
+MSD Radix Sort In-Place,500,184,0.00102310
+MSD Radix Sort In-Place,500,185,0.00076130
+MSD Radix Sort In-Place,500,186,0.00099520
+MSD Radix Sort In-Place,500,187,0.00090270
+MSD Radix Sort In-Place,500,188,0.00067910
+MSD Radix Sort In-Place,500,189,0.00060890
+MSD Radix Sort In-Place,500,190,0.00083210
+MSD Radix Sort In-Place,500,191,0.00077650
+MSD Radix Sort In-Place,500,192,0.00097720
+MSD Radix Sort In-Place,500,193,0.00099310
+MSD Radix Sort In-Place,500,194,0.00086120
+MSD Radix Sort In-Place,500,195,0.00079190
+MSD Radix Sort In-Place,500,196,0.00087490
+MSD Radix Sort In-Place,500,197,0.00091330
+MSD Radix Sort In-Place,500,198,0.00100120
+MSD Radix Sort In-Place,500,199,0.00097330
+MSD Radix Sort In-Place,500,200,0.00105130
+MSD Radix Sort In-Place,500,201,0.00089430
+MSD Radix Sort In-Place,500,202,0.00090430
+MSD Radix Sort In-Place,500,203,0.00089820
+MSD Radix Sort In-Place,500,204,0.00090100
+MSD Radix Sort In-Place,500,205,0.00080670
+MSD Radix Sort In-Place,500,206,0.00052590
+MSD Radix Sort In-Place,500,207,0.00055620
+MSD Radix Sort In-Place,500,208,0.00078910
+MSD Radix Sort In-Place,500,209,0.00092640
+MSD Radix Sort In-Place,500,210,0.00062450
+MSD Radix Sort In-Place,500,211,0.00088870
+MSD Radix Sort In-Place,500,212,0.00093580
+MSD Radix Sort In-Place,500,213,0.00057010
+MSD Radix Sort In-Place,500,214,0.00094050
+MSD Radix Sort In-Place,500,215,0.00070910
+MSD Radix Sort In-Place,500,216,0.00097550
+MSD Radix Sort In-Place,500,217,0.00059210
+MSD Radix Sort In-Place,500,218,0.00075560
+MSD Radix Sort In-Place,500,219,0.00073060
+MSD Radix Sort In-Place,500,220,0.00079290
+MSD Radix Sort In-Place,500,221,0.00098230
+MSD Radix Sort In-Place,500,222,0.00089110
+MSD Radix Sort In-Place,500,223,0.00063670
+MSD Radix Sort In-Place,500,224,0.00104520
+MSD Radix Sort In-Place,500,225,0.00073640
+MSD Radix Sort In-Place,500,226,0.00096580
+MSD Radix Sort In-Place,500,227,0.00090050
+MSD Radix Sort In-Place,500,228,0.00084110
+MSD Radix Sort In-Place,500,229,0.00100230
+MSD Radix Sort In-Place,500,230,0.00057910
+MSD Radix Sort In-Place,500,231,0.00092320
+MSD Radix Sort In-Place,500,232,0.00069460
+MSD Radix Sort In-Place,500,233,0.00065960
+MSD Radix Sort In-Place,500,234,0.00055870
+MSD Radix Sort In-Place,500,235,0.00093550
+MSD Radix Sort In-Place,500,236,0.00104220
+MSD Radix Sort In-Place,500,237,0.00065370
+MSD Radix Sort In-Place,500,238,0.00092350
+MSD Radix Sort In-Place,500,239,0.00098090
+MSD Radix Sort In-Place,500,240,0.00090260
+MSD Radix Sort In-Place,500,241,0.00074800
+MSD Radix Sort In-Place,500,242,0.00095750
+MSD Radix Sort In-Place,500,243,0.00094160
+MSD Radix Sort In-Place,500,244,0.00098480
+MSD Radix Sort In-Place,500,245,0.00088700
+MSD Radix Sort In-Place,500,246,0.00090690
+MSD Radix Sort In-Place,500,247,0.00076420
+MSD Radix Sort In-Place,500,248,0.00103570
+MSD Radix Sort In-Place,500,249,0.00083300
+MSD Radix Sort In-Place,500,250,0.00092520
+MSD Radix Sort In-Place,500,251,0.00102720
+MSD Radix Sort In-Place,500,252,0.00090430
+MSD Radix Sort In-Place,500,253,0.00079770
+MSD Radix Sort In-Place,500,254,0.00091610
+MSD Radix Sort In-Place,500,255,0.00094910
+MSD Radix Sort In-Place,500,256,0.00078030
+MSD Radix Sort In-Place,500,257,0.00059100
+MSD Radix Sort In-Place,500,258,0.00096780
+MSD Radix Sort In-Place,500,259,0.00068720
+MSD Radix Sort In-Place,500,260,0.00076960
+MSD Radix Sort In-Place,500,261,0.00093610
+MSD Radix Sort In-Place,500,262,0.00096970
+MSD Radix Sort In-Place,500,263,0.00111350
+MSD Radix Sort In-Place,500,264,0.00074680
+MSD Radix Sort In-Place,500,265,0.00089700
+MSD Radix Sort In-Place,500,266,0.00094750
+MSD Radix Sort In-Place,500,267,0.00060100
+MSD Radix Sort In-Place,500,268,0.00101800
+MSD Radix Sort In-Place,500,269,0.00114790
+MSD Radix Sort In-Place,500,270,0.00077980
+MSD Radix Sort In-Place,500,271,0.00081320
+MSD Radix Sort In-Place,500,272,0.00101080
+MSD Radix Sort In-Place,500,273,0.00091430
+MSD Radix Sort In-Place,500,274,0.00093830
+MSD Radix Sort In-Place,500,275,0.00101350
+MSD Radix Sort In-Place,500,276,0.00095320
+MSD Radix Sort In-Place,500,277,0.00092020
+MSD Radix Sort In-Place,500,278,0.00090120
+MSD Radix Sort In-Place,500,279,0.00070800
+MSD Radix Sort In-Place,500,280,0.00078780
+MSD Radix Sort In-Place,500,281,0.00087740
+MSD Radix Sort In-Place,500,282,0.00096670
+MSD Radix Sort In-Place,500,283,0.00073560
+MSD Radix Sort In-Place,500,284,0.00051790
+MSD Radix Sort In-Place,500,285,0.00074520
+MSD Radix Sort In-Place,500,286,0.00095950
+MSD Radix Sort In-Place,500,287,0.00072040
+MSD Radix Sort In-Place,500,288,0.00093230
+MSD Radix Sort In-Place,500,289,0.00084440
+MSD Radix Sort In-Place,500,290,0.00055520
+MSD Radix Sort In-Place,500,291,0.00079450
+MSD Radix Sort In-Place,500,292,0.00056390
+MSD Radix Sort In-Place,500,293,0.00102290
+MSD Radix Sort In-Place,500,294,0.00053070
+MSD Radix Sort In-Place,500,295,0.00070380
+MSD Radix Sort In-Place,500,296,0.00101020
+MSD Radix Sort In-Place,500,297,0.00069340
+MSD Radix Sort In-Place,500,298,0.00062790
+MSD Radix Sort In-Place,500,299,0.00095930
+MSD Radix Sort In-Place,500,300,0.00054620
+MSD Radix Sort In-Place,500,301,0.00098260
+MSD Radix Sort In-Place,500,302,0.00064630
+MSD Radix Sort In-Place,500,303,0.00066240
+MSD Radix Sort In-Place,500,304,0.00097260
+MSD Radix Sort In-Place,500,305,0.00055300
+MSD Radix Sort In-Place,500,306,0.00094860
+MSD Radix Sort In-Place,500,307,0.00079900
+MSD Radix Sort In-Place,500,308,0.00055560
+MSD Radix Sort In-Place,500,309,0.00098040
+MSD Radix Sort In-Place,500,310,0.00100250
+MSD Radix Sort In-Place,500,311,0.00095040
+MSD Radix Sort In-Place,500,312,0.00095200
+MSD Radix Sort In-Place,500,313,0.00097410
+MSD Radix Sort In-Place,500,314,0.00097320
+MSD Radix Sort In-Place,500,315,0.00089360
+MSD Radix Sort In-Place,500,316,0.00098990
+MSD Radix Sort In-Place,500,317,0.00101470
+MSD Radix Sort In-Place,500,318,0.00100320
+MSD Radix Sort In-Place,500,319,0.00081170
+MSD Radix Sort In-Place,500,320,0.00055560
+MSD Radix Sort In-Place,500,321,0.00066390
+MSD Radix Sort In-Place,500,322,0.00068820
+MSD Radix Sort In-Place,500,323,0.00095810
+MSD Radix Sort In-Place,500,324,0.00090990
+MSD Radix Sort In-Place,500,325,0.00090680
+MSD Radix Sort In-Place,500,326,0.00080940
+MSD Radix Sort In-Place,500,327,0.00052370
+MSD Radix Sort In-Place,500,328,0.00053140
+MSD Radix Sort In-Place,500,329,0.00083000
+MSD Radix Sort In-Place,500,330,0.00122560
+MSD Radix Sort In-Place,500,331,0.00065120
+MSD Radix Sort In-Place,500,332,0.00084150
+MSD Radix Sort In-Place,500,333,0.00058680
+MSD Radix Sort In-Place,500,334,0.00093190
+MSD Radix Sort In-Place,500,335,0.00093590
+MSD Radix Sort In-Place,500,336,0.00102080
+MSD Radix Sort In-Place,500,337,0.00056320
+MSD Radix Sort In-Place,500,338,0.00092480
+MSD Radix Sort In-Place,500,339,0.00091570
+MSD Radix Sort In-Place,500,340,0.00055170
+MSD Radix Sort In-Place,500,341,0.00104300
+MSD Radix Sort In-Place,500,342,0.00073860
+MSD Radix Sort In-Place,500,343,0.00062350
+MSD Radix Sort In-Place,500,344,0.00092790
+MSD Radix Sort In-Place,500,345,0.00097810
+MSD Radix Sort In-Place,500,346,0.00066570
+MSD Radix Sort In-Place,500,347,0.00088900
+MSD Radix Sort In-Place,500,348,0.00087090
+MSD Radix Sort In-Place,500,349,0.00084240
+MSD Radix Sort In-Place,500,350,0.00089840
+MSD Radix Sort In-Place,500,351,0.00090380
+MSD Radix Sort In-Place,500,352,0.00095420
+MSD Radix Sort In-Place,500,353,0.00056990
+MSD Radix Sort In-Place,500,354,0.00089580
+MSD Radix Sort In-Place,500,355,0.00088360
+MSD Radix Sort In-Place,500,356,0.00093460
+MSD Radix Sort In-Place,500,357,0.00087900
+MSD Radix Sort In-Place,500,358,0.00086880
+MSD Radix Sort In-Place,500,359,0.00070470
+MSD Radix Sort In-Place,500,360,0.00091730
+MSD Radix Sort In-Place,500,361,0.00054680
+MSD Radix Sort In-Place,500,362,0.00069950
+MSD Radix Sort In-Place,500,363,0.00072950
+MSD Radix Sort In-Place,500,364,0.00056130
+MSD Radix Sort In-Place,500,365,0.00099120
+MSD Radix Sort In-Place,500,366,0.00092560
+MSD Radix Sort In-Place,500,367,0.00104600
+MSD Radix Sort In-Place,500,368,0.00116920
+MSD Radix Sort In-Place,500,369,0.00097570
+MSD Radix Sort In-Place,500,370,0.00093110
+MSD Radix Sort In-Place,500,371,0.00098850
+MSD Radix Sort In-Place,500,372,0.00077290
+MSD Radix Sort In-Place,500,373,0.00073710
+MSD Radix Sort In-Place,500,374,0.00092460
+MSD Radix Sort In-Place,500,375,0.00103760
+MSD Radix Sort In-Place,500,376,0.00080240
+MSD Radix Sort In-Place,500,377,0.00099330
+MSD Radix Sort In-Place,500,378,0.00091150
+MSD Radix Sort In-Place,500,379,0.00093770
+MSD Radix Sort In-Place,500,380,0.00092710
+MSD Radix Sort In-Place,500,381,0.00054870
+MSD Radix Sort In-Place,500,382,0.00089850
+MSD Radix Sort In-Place,500,383,0.00088330
+MSD Radix Sort In-Place,500,384,0.00095310
+MSD Radix Sort In-Place,500,385,0.00055270
+MSD Radix Sort In-Place,500,386,0.00096320
+MSD Radix Sort In-Place,500,387,0.00101480
+MSD Radix Sort In-Place,500,388,0.00064470
+MSD Radix Sort In-Place,500,389,0.00104570
+MSD Radix Sort In-Place,500,390,0.00107440
+MSD Radix Sort In-Place,500,391,0.00093060
+MSD Radix Sort In-Place,500,392,0.00059380
+MSD Radix Sort In-Place,500,393,0.00084020
+MSD Radix Sort In-Place,500,394,0.00091200
+MSD Radix Sort In-Place,500,395,0.00067080
+MSD Radix Sort In-Place,500,396,0.00099740
+MSD Radix Sort In-Place,500,397,0.00059070
+MSD Radix Sort In-Place,500,398,0.00085270
+MSD Radix Sort In-Place,500,399,0.00100830
+MSD Radix Sort In-Place,500,400,0.00070610
+MSD Radix Sort In-Place,500,401,0.00092630
+MSD Radix Sort In-Place,500,402,0.00081030
+MSD Radix Sort In-Place,500,403,0.00099170
+MSD Radix Sort In-Place,500,404,0.00097120
+MSD Radix Sort In-Place,500,405,0.00063600
+MSD Radix Sort In-Place,500,406,0.00086790
+MSD Radix Sort In-Place,500,407,0.00097840
+MSD Radix Sort In-Place,500,408,0.00053550
+MSD Radix Sort In-Place,500,409,0.00092180
+MSD Radix Sort In-Place,500,410,0.00101130
+MSD Radix Sort In-Place,500,411,0.00085160
+MSD Radix Sort In-Place,500,412,0.00095330
+MSD Radix Sort In-Place,500,413,0.00092460
+MSD Radix Sort In-Place,500,414,0.00077410
+MSD Radix Sort In-Place,500,415,0.00101670
+MSD Radix Sort In-Place,500,416,0.00105480
+MSD Radix Sort In-Place,500,417,0.00093780
+MSD Radix Sort In-Place,500,418,0.00102250
+MSD Radix Sort In-Place,500,419,0.00089530
+MSD Radix Sort In-Place,500,420,0.00106890
+MSD Radix Sort In-Place,500,421,0.00070360
+MSD Radix Sort In-Place,500,422,0.00099160
+MSD Radix Sort In-Place,500,423,0.00092580
+MSD Radix Sort In-Place,500,424,0.00106060
+MSD Radix Sort In-Place,500,425,0.00100520
+MSD Radix Sort In-Place,500,426,0.00104360
+MSD Radix Sort In-Place,500,427,0.00087760
+MSD Radix Sort In-Place,500,428,0.00070830
+MSD Radix Sort In-Place,500,429,0.00088860
+MSD Radix Sort In-Place,500,430,0.00079080
+MSD Radix Sort In-Place,500,431,0.00055500
+MSD Radix Sort In-Place,500,432,0.00085850
+MSD Radix Sort In-Place,500,433,0.00067240
+MSD Radix Sort In-Place,500,434,0.00057910
+MSD Radix Sort In-Place,500,435,0.00080220
+MSD Radix Sort In-Place,500,436,0.00093160
+MSD Radix Sort In-Place,500,437,0.00062320
+MSD Radix Sort In-Place,500,438,0.00068870
+MSD Radix Sort In-Place,500,439,0.00054590
+MSD Radix Sort In-Place,500,440,0.00063920
+MSD Radix Sort In-Place,500,441,0.00056010
+MSD Radix Sort In-Place,500,442,0.00053130
+MSD Radix Sort In-Place,500,443,0.00093050
+MSD Radix Sort In-Place,500,444,0.00071080
+MSD Radix Sort In-Place,500,445,0.00058750
+MSD Radix Sort In-Place,500,446,0.00093310
+MSD Radix Sort In-Place,500,447,0.00090030
+MSD Radix Sort In-Place,500,448,0.00083000
+MSD Radix Sort In-Place,500,449,0.00070210
+MSD Radix Sort In-Place,500,450,0.00066430
+MSD Radix Sort In-Place,500,451,0.00099940
+MSD Radix Sort In-Place,500,452,0.00055700
+MSD Radix Sort In-Place,500,453,0.00085220
+MSD Radix Sort In-Place,500,454,0.00059660
+MSD Radix Sort In-Place,500,455,0.00055850
+MSD Radix Sort In-Place,500,456,0.00052770
+MSD Radix Sort In-Place,500,457,0.00084730
+MSD Radix Sort In-Place,500,458,0.00084280
+MSD Radix Sort In-Place,500,459,0.00078410
+MSD Radix Sort In-Place,500,460,0.00084180
+MSD Radix Sort In-Place,500,461,0.00092290
+MSD Radix Sort In-Place,500,462,0.00057740
+MSD Radix Sort In-Place,500,463,0.00057380
+MSD Radix Sort In-Place,500,464,0.00058260
+MSD Radix Sort In-Place,500,465,0.00054710
+MSD Radix Sort In-Place,500,466,0.00052460
+MSD Radix Sort In-Place,500,467,0.00078960
+MSD Radix Sort In-Place,500,468,0.00067590
+MSD Radix Sort In-Place,500,469,0.00055390
+MSD Radix Sort In-Place,500,470,0.00060120
+MSD Radix Sort In-Place,500,471,0.00052530
+MSD Radix Sort In-Place,500,472,0.00078070
+MSD Radix Sort In-Place,500,473,0.00058170
+MSD Radix Sort In-Place,500,474,0.00067550
+MSD Radix Sort In-Place,500,475,0.00058340
+MSD Radix Sort In-Place,500,476,0.00074590
+MSD Radix Sort In-Place,500,477,0.00090840
+MSD Radix Sort In-Place,500,478,0.00086910
+MSD Radix Sort In-Place,500,479,0.00060460
+MSD Radix Sort In-Place,500,480,0.00090100
+MSD Radix Sort In-Place,500,481,0.00057140
+MSD Radix Sort In-Place,500,482,0.00089320
+MSD Radix Sort In-Place,500,483,0.00104120
+MSD Radix Sort In-Place,500,484,0.00074500
+MSD Radix Sort In-Place,500,485,0.00106200
+MSD Radix Sort In-Place,500,486,0.00097920
+MSD Radix Sort In-Place,500,487,0.00089020
+MSD Radix Sort In-Place,500,488,0.00106600
+MSD Radix Sort In-Place,500,489,0.00092560
+MSD Radix Sort In-Place,500,490,0.00092690
+MSD Radix Sort In-Place,500,491,0.00072610
+MSD Radix Sort In-Place,500,492,0.00080980
+MSD Radix Sort In-Place,500,493,0.00060270
+MSD Radix Sort In-Place,500,494,0.00082030
+MSD Radix Sort In-Place,500,495,0.00093340
+MSD Radix Sort In-Place,500,496,0.00109210
+MSD Radix Sort In-Place,500,497,0.00065680
+MSD Radix Sort In-Place,500,498,0.00069900
+MSD Radix Sort In-Place,500,499,0.00070050
+MSD Radix Sort In-Place,500,500,0.00056820
+Merge Insertion Sort,500,1,0.00095670
+Merge Insertion Sort,500,2,0.00072920
+Merge Insertion Sort,500,3,0.00076530
+Merge Insertion Sort,500,4,0.00078970
+Merge Insertion Sort,500,5,0.00087090
+Merge Insertion Sort,500,6,0.00101110
+Merge Insertion Sort,500,7,0.00078010
+Merge Insertion Sort,500,8,0.00121800
+Merge Insertion Sort,500,9,0.00080560
+Merge Insertion Sort,500,10,0.00089210
+Merge Insertion Sort,500,11,0.00081270
+Merge Insertion Sort,500,12,0.00081650
+Merge Insertion Sort,500,13,0.00095820
+Merge Insertion Sort,500,14,0.00075040
+Merge Insertion Sort,500,15,0.00077900
+Merge Insertion Sort,500,16,0.00076810
+Merge Insertion Sort,500,17,0.00079950
+Merge Insertion Sort,500,18,0.00078230
+Merge Insertion Sort,500,19,0.00054770
+Merge Insertion Sort,500,20,0.00061300
+Merge Insertion Sort,500,21,0.00080930
+Merge Insertion Sort,500,22,0.00079550
+Merge Insertion Sort,500,23,0.00086340
+Merge Insertion Sort,500,24,0.00051720
+Merge Insertion Sort,500,25,0.00071220
+Merge Insertion Sort,500,26,0.00079000
+Merge Insertion Sort,500,27,0.00075810
+Merge Insertion Sort,500,28,0.00090490
+Merge Insertion Sort,500,29,0.00065570
+Merge Insertion Sort,500,30,0.00049130
+Merge Insertion Sort,500,31,0.00046890
+Merge Insertion Sort,500,32,0.00091800
+Merge Insertion Sort,500,33,0.00094050
+Merge Insertion Sort,500,34,0.00076270
+Merge Insertion Sort,500,35,0.00083130
+Merge Insertion Sort,500,36,0.00087210
+Merge Insertion Sort,500,37,0.00076170
+Merge Insertion Sort,500,38,0.00072590
+Merge Insertion Sort,500,39,0.00078990
+Merge Insertion Sort,500,40,0.00061390
+Merge Insertion Sort,500,41,0.00074480
+Merge Insertion Sort,500,42,0.00077760
+Merge Insertion Sort,500,43,0.00045260
+Merge Insertion Sort,500,44,0.00047570
+Merge Insertion Sort,500,45,0.00076180
+Merge Insertion Sort,500,46,0.00079070
+Merge Insertion Sort,500,47,0.00089020
+Merge Insertion Sort,500,48,0.00077920
+Merge Insertion Sort,500,49,0.00083870
+Merge Insertion Sort,500,50,0.00082060
+Merge Insertion Sort,500,51,0.00078430
+Merge Insertion Sort,500,52,0.00047210
+Merge Insertion Sort,500,53,0.00090800
+Merge Insertion Sort,500,54,0.00057200
+Merge Insertion Sort,500,55,0.00084020
+Merge Insertion Sort,500,56,0.00063730
+Merge Insertion Sort,500,57,0.00077640
+Merge Insertion Sort,500,58,0.00068640
+Merge Insertion Sort,500,59,0.00051250
+Merge Insertion Sort,500,60,0.00068010
+Merge Insertion Sort,500,61,0.00090650
+Merge Insertion Sort,500,62,0.00089170
+Merge Insertion Sort,500,63,0.00074870
+Merge Insertion Sort,500,64,0.00079260
+Merge Insertion Sort,500,65,0.00077970
+Merge Insertion Sort,500,66,0.00086390
+Merge Insertion Sort,500,67,0.00074240
+Merge Insertion Sort,500,68,0.00086080
+Merge Insertion Sort,500,69,0.00085220
+Merge Insertion Sort,500,70,0.00084550
+Merge Insertion Sort,500,71,0.00082060
+Merge Insertion Sort,500,72,0.00079020
+Merge Insertion Sort,500,73,0.00077560
+Merge Insertion Sort,500,74,0.00068340
+Merge Insertion Sort,500,75,0.00082310
+Merge Insertion Sort,500,76,0.00052120
+Merge Insertion Sort,500,77,0.00064620
+Merge Insertion Sort,500,78,0.00054140
+Merge Insertion Sort,500,79,0.00080960
+Merge Insertion Sort,500,80,0.00076590
+Merge Insertion Sort,500,81,0.00049850
+Merge Insertion Sort,500,82,0.00077140
+Merge Insertion Sort,500,83,0.00084650
+Merge Insertion Sort,500,84,0.00087980
+Merge Insertion Sort,500,85,0.00066250
+Merge Insertion Sort,500,86,0.00077750
+Merge Insertion Sort,500,87,0.00077430
+Merge Insertion Sort,500,88,0.00093560
+Merge Insertion Sort,500,89,0.00085030
+Merge Insertion Sort,500,90,0.00105730
+Merge Insertion Sort,500,91,0.00075980
+Merge Insertion Sort,500,92,0.00090310
+Merge Insertion Sort,500,93,0.00055300
+Merge Insertion Sort,500,94,0.00051600
+Merge Insertion Sort,500,95,0.00076170
+Merge Insertion Sort,500,96,0.00076230
+Merge Insertion Sort,500,97,0.00078520
+Merge Insertion Sort,500,98,0.00067520
+Merge Insertion Sort,500,99,0.00077420
+Merge Insertion Sort,500,100,0.00080810
+Merge Insertion Sort,500,101,0.00085650
+Merge Insertion Sort,500,102,0.00055690
+Merge Insertion Sort,500,103,0.00077400
+Merge Insertion Sort,500,104,0.00088070
+Merge Insertion Sort,500,105,0.00087700
+Merge Insertion Sort,500,106,0.00069240
+Merge Insertion Sort,500,107,0.00082000
+Merge Insertion Sort,500,108,0.00075370
+Merge Insertion Sort,500,109,0.00100870
+Merge Insertion Sort,500,110,0.00084570
+Merge Insertion Sort,500,111,0.00050700
+Merge Insertion Sort,500,112,0.00075970
+Merge Insertion Sort,500,113,0.00087400
+Merge Insertion Sort,500,114,0.00084730
+Merge Insertion Sort,500,115,0.00080420
+Merge Insertion Sort,500,116,0.00126500
+Merge Insertion Sort,500,117,0.00116380
+Merge Insertion Sort,500,118,0.00090470
+Merge Insertion Sort,500,119,0.00067910
+Merge Insertion Sort,500,120,0.00083960
+Merge Insertion Sort,500,121,0.00068760
+Merge Insertion Sort,500,122,0.00085650
+Merge Insertion Sort,500,123,0.00078400
+Merge Insertion Sort,500,124,0.00078320
+Merge Insertion Sort,500,125,0.00075390
+Merge Insertion Sort,500,126,0.00076260
+Merge Insertion Sort,500,127,0.00092310
+Merge Insertion Sort,500,128,0.00083380
+Merge Insertion Sort,500,129,0.00082410
+Merge Insertion Sort,500,130,0.00075350
+Merge Insertion Sort,500,131,0.00087870
+Merge Insertion Sort,500,132,0.00075850
+Merge Insertion Sort,500,133,0.00075360
+Merge Insertion Sort,500,134,0.00086320
+Merge Insertion Sort,500,135,0.00087790
+Merge Insertion Sort,500,136,0.00059640
+Merge Insertion Sort,500,137,0.00086110
+Merge Insertion Sort,500,138,0.00094180
+Merge Insertion Sort,500,139,0.00107080
+Merge Insertion Sort,500,140,0.00083260
+Merge Insertion Sort,500,141,0.00071590
+Merge Insertion Sort,500,142,0.00059430
+Merge Insertion Sort,500,143,0.00084800
+Merge Insertion Sort,500,144,0.00082180
+Merge Insertion Sort,500,145,0.00051660
+Merge Insertion Sort,500,146,0.00048770
+Merge Insertion Sort,500,147,0.00065390
+Merge Insertion Sort,500,148,0.00087990
+Merge Insertion Sort,500,149,0.00063960
+Merge Insertion Sort,500,150,0.00085160
+Merge Insertion Sort,500,151,0.00082340
+Merge Insertion Sort,500,152,0.00078120
+Merge Insertion Sort,500,153,0.00089770
+Merge Insertion Sort,500,154,0.00078420
+Merge Insertion Sort,500,155,0.00077010
+Merge Insertion Sort,500,156,0.00076990
+Merge Insertion Sort,500,157,0.00081140
+Merge Insertion Sort,500,158,0.00063930
+Merge Insertion Sort,500,159,0.00082660
+Merge Insertion Sort,500,160,0.00080700
+Merge Insertion Sort,500,161,0.00091450
+Merge Insertion Sort,500,162,0.00078930
+Merge Insertion Sort,500,163,0.00073380
+Merge Insertion Sort,500,164,0.00069970
+Merge Insertion Sort,500,165,0.00067380
+Merge Insertion Sort,500,166,0.00075980
+Merge Insertion Sort,500,167,0.00082140
+Merge Insertion Sort,500,168,0.00064390
+Merge Insertion Sort,500,169,0.00080850
+Merge Insertion Sort,500,170,0.00077400
+Merge Insertion Sort,500,171,0.00077850
+Merge Insertion Sort,500,172,0.00066050
+Merge Insertion Sort,500,173,0.00060100
+Merge Insertion Sort,500,174,0.00071850
+Merge Insertion Sort,500,175,0.00074080
+Merge Insertion Sort,500,176,0.00068690
+Merge Insertion Sort,500,177,0.00070920
+Merge Insertion Sort,500,178,0.00046150
+Merge Insertion Sort,500,179,0.00048050
+Merge Insertion Sort,500,180,0.00073900
+Merge Insertion Sort,500,181,0.00074760
+Merge Insertion Sort,500,182,0.00047490
+Merge Insertion Sort,500,183,0.00047880
+Merge Insertion Sort,500,184,0.00065170
+Merge Insertion Sort,500,185,0.00045840
+Merge Insertion Sort,500,186,0.00065070
+Merge Insertion Sort,500,187,0.00045100
+Merge Insertion Sort,500,188,0.00048690
+Merge Insertion Sort,500,189,0.00075240
+Merge Insertion Sort,500,190,0.00083940
+Merge Insertion Sort,500,191,0.00061410
+Merge Insertion Sort,500,192,0.00078980
+Merge Insertion Sort,500,193,0.00062030
+Merge Insertion Sort,500,194,0.00079710
+Merge Insertion Sort,500,195,0.00084260
+Merge Insertion Sort,500,196,0.00079730
+Merge Insertion Sort,500,197,0.00082810
+Merge Insertion Sort,500,198,0.00053100
+Merge Insertion Sort,500,199,0.00085340
+Merge Insertion Sort,500,200,0.00064350
+Merge Insertion Sort,500,201,0.00045720
+Merge Insertion Sort,500,202,0.00083500
+Merge Insertion Sort,500,203,0.00075860
+Merge Insertion Sort,500,204,0.00089330
+Merge Insertion Sort,500,205,0.00047300
+Merge Insertion Sort,500,206,0.00053690
+Merge Insertion Sort,500,207,0.00077770
+Merge Insertion Sort,500,208,0.00080630
+Merge Insertion Sort,500,209,0.00085260
+Merge Insertion Sort,500,210,0.00046410
+Merge Insertion Sort,500,211,0.00074100
+Merge Insertion Sort,500,212,0.00078650
+Merge Insertion Sort,500,213,0.00046380
+Merge Insertion Sort,500,214,0.00069560
+Merge Insertion Sort,500,215,0.00074210
+Merge Insertion Sort,500,216,0.00075970
+Merge Insertion Sort,500,217,0.00063290
+Merge Insertion Sort,500,218,0.00085720
+Merge Insertion Sort,500,219,0.00076640
+Merge Insertion Sort,500,220,0.00045390
+Merge Insertion Sort,500,221,0.00076180
+Merge Insertion Sort,500,222,0.00086140
+Merge Insertion Sort,500,223,0.00047930
+Merge Insertion Sort,500,224,0.00051280
+Merge Insertion Sort,500,225,0.00076600
+Merge Insertion Sort,500,226,0.00072890
+Merge Insertion Sort,500,227,0.00083980
+Merge Insertion Sort,500,228,0.00091370
+Merge Insertion Sort,500,229,0.00083380
+Merge Insertion Sort,500,230,0.00065430
+Merge Insertion Sort,500,231,0.00070510
+Merge Insertion Sort,500,232,0.00053130
+Merge Insertion Sort,500,233,0.00050820
+Merge Insertion Sort,500,234,0.00080170
+Merge Insertion Sort,500,235,0.00077500
+Merge Insertion Sort,500,236,0.00084030
+Merge Insertion Sort,500,237,0.00052320
+Merge Insertion Sort,500,238,0.00079560
+Merge Insertion Sort,500,239,0.00052510
+Merge Insertion Sort,500,240,0.00072010
+Merge Insertion Sort,500,241,0.00086050
+Merge Insertion Sort,500,242,0.00059260
+Merge Insertion Sort,500,243,0.00079810
+Merge Insertion Sort,500,244,0.00058540
+Merge Insertion Sort,500,245,0.00086400
+Merge Insertion Sort,500,246,0.00057040
+Merge Insertion Sort,500,247,0.00052050
+Merge Insertion Sort,500,248,0.00048650
+Merge Insertion Sort,500,249,0.00051070
+Merge Insertion Sort,500,250,0.00070850
+Merge Insertion Sort,500,251,0.00049620
+Merge Insertion Sort,500,252,0.00047980
+Merge Insertion Sort,500,253,0.00047290
+Merge Insertion Sort,500,254,0.00087550
+Merge Insertion Sort,500,255,0.00045050
+Merge Insertion Sort,500,256,0.00045440
+Merge Insertion Sort,500,257,0.00061980
+Merge Insertion Sort,500,258,0.00093520
+Merge Insertion Sort,500,259,0.00076880
+Merge Insertion Sort,500,260,0.00077870
+Merge Insertion Sort,500,261,0.00084840
+Merge Insertion Sort,500,262,0.00070220
+Merge Insertion Sort,500,263,0.00067370
+Merge Insertion Sort,500,264,0.00076380
+Merge Insertion Sort,500,265,0.00085190
+Merge Insertion Sort,500,266,0.00047790
+Merge Insertion Sort,500,267,0.00045490
+Merge Insertion Sort,500,268,0.00079470
+Merge Insertion Sort,500,269,0.00075090
+Merge Insertion Sort,500,270,0.00045730
+Merge Insertion Sort,500,271,0.00090790
+Merge Insertion Sort,500,272,0.00081450
+Merge Insertion Sort,500,273,0.00050850
+Merge Insertion Sort,500,274,0.00059880
+Merge Insertion Sort,500,275,0.00069140
+Merge Insertion Sort,500,276,0.00047150
+Merge Insertion Sort,500,277,0.00062990
+Merge Insertion Sort,500,278,0.00061580
+Merge Insertion Sort,500,279,0.00060460
+Merge Insertion Sort,500,280,0.00067150
+Merge Insertion Sort,500,281,0.00075610
+Merge Insertion Sort,500,282,0.00062990
+Merge Insertion Sort,500,283,0.00062690
+Merge Insertion Sort,500,284,0.00053300
+Merge Insertion Sort,500,285,0.00081110
+Merge Insertion Sort,500,286,0.00057580
+Merge Insertion Sort,500,287,0.00089820
+Merge Insertion Sort,500,288,0.00074280
+Merge Insertion Sort,500,289,0.00088000
+Merge Insertion Sort,500,290,0.00075860
+Merge Insertion Sort,500,291,0.00090400
+Merge Insertion Sort,500,292,0.00062290
+Merge Insertion Sort,500,293,0.00077940
+Merge Insertion Sort,500,294,0.00075440
+Merge Insertion Sort,500,295,0.00087090
+Merge Insertion Sort,500,296,0.00099050
+Merge Insertion Sort,500,297,0.00086720
+Merge Insertion Sort,500,298,0.00098960
+Merge Insertion Sort,500,299,0.00080150
+Merge Insertion Sort,500,300,0.00058560
+Merge Insertion Sort,500,301,0.00072110
+Merge Insertion Sort,500,302,0.00047300
+Merge Insertion Sort,500,303,0.00069460
+Merge Insertion Sort,500,304,0.00075010
+Merge Insertion Sort,500,305,0.00046110
+Merge Insertion Sort,500,306,0.00071610
+Merge Insertion Sort,500,307,0.00069410
+Merge Insertion Sort,500,308,0.00080550
+Merge Insertion Sort,500,309,0.00060680
+Merge Insertion Sort,500,310,0.00083620
+Merge Insertion Sort,500,311,0.00099760
+Merge Insertion Sort,500,312,0.00081340
+Merge Insertion Sort,500,313,0.00078960
+Merge Insertion Sort,500,314,0.00079520
+Merge Insertion Sort,500,315,0.00089270
+Merge Insertion Sort,500,316,0.00079990
+Merge Insertion Sort,500,317,0.00076370
+Merge Insertion Sort,500,318,0.00073200
+Merge Insertion Sort,500,319,0.00077810
+Merge Insertion Sort,500,320,0.00046620
+Merge Insertion Sort,500,321,0.00080960
+Merge Insertion Sort,500,322,0.00093550
+Merge Insertion Sort,500,323,0.00075190
+Merge Insertion Sort,500,324,0.00089460
+Merge Insertion Sort,500,325,0.00075420
+Merge Insertion Sort,500,326,0.00055940
+Merge Insertion Sort,500,327,0.00051670
+Merge Insertion Sort,500,328,0.00087430
+Merge Insertion Sort,500,329,0.00070590
+Merge Insertion Sort,500,330,0.00078840
+Merge Insertion Sort,500,331,0.00076370
+Merge Insertion Sort,500,332,0.00066540
+Merge Insertion Sort,500,333,0.00089020
+Merge Insertion Sort,500,334,0.00075140
+Merge Insertion Sort,500,335,0.00074780
+Merge Insertion Sort,500,336,0.00044710
+Merge Insertion Sort,500,337,0.00090170
+Merge Insertion Sort,500,338,0.00078550
+Merge Insertion Sort,500,339,0.00061570
+Merge Insertion Sort,500,340,0.00053460
+Merge Insertion Sort,500,341,0.00053400
+Merge Insertion Sort,500,342,0.00045830
+Merge Insertion Sort,500,343,0.00086290
+Merge Insertion Sort,500,344,0.00082120
+Merge Insertion Sort,500,345,0.00072030
+Merge Insertion Sort,500,346,0.00057500
+Merge Insertion Sort,500,347,0.00079120
+Merge Insertion Sort,500,348,0.00082800
+Merge Insertion Sort,500,349,0.00080650
+Merge Insertion Sort,500,350,0.00079080
+Merge Insertion Sort,500,351,0.00074700
+Merge Insertion Sort,500,352,0.00076420
+Merge Insertion Sort,500,353,0.00068160
+Merge Insertion Sort,500,354,0.00075640
+Merge Insertion Sort,500,355,0.00088350
+Merge Insertion Sort,500,356,0.00072670
+Merge Insertion Sort,500,357,0.00044600
+Merge Insertion Sort,500,358,0.00076010
+Merge Insertion Sort,500,359,0.00046400
+Merge Insertion Sort,500,360,0.00077680
+Merge Insertion Sort,500,361,0.00071970
+Merge Insertion Sort,500,362,0.00081310
+Merge Insertion Sort,500,363,0.00078450
+Merge Insertion Sort,500,364,0.00077550
+Merge Insertion Sort,500,365,0.00075920
+Merge Insertion Sort,500,366,0.00078300
+Merge Insertion Sort,500,367,0.00078750
+Merge Insertion Sort,500,368,0.00077030
+Merge Insertion Sort,500,369,0.00064360
+Merge Insertion Sort,500,370,0.00078310
+Merge Insertion Sort,500,371,0.00078150
+Merge Insertion Sort,500,372,0.00069460
+Merge Insertion Sort,500,373,0.00080050
+Merge Insertion Sort,500,374,0.00052520
+Merge Insertion Sort,500,375,0.00075730
+Merge Insertion Sort,500,376,0.00064270
+Merge Insertion Sort,500,377,0.00075350
+Merge Insertion Sort,500,378,0.00057840
+Merge Insertion Sort,500,379,0.00072310
+Merge Insertion Sort,500,380,0.00076050
+Merge Insertion Sort,500,381,0.00045790
+Merge Insertion Sort,500,382,0.00045660
+Merge Insertion Sort,500,383,0.00073130
+Merge Insertion Sort,500,384,0.00075780
+Merge Insertion Sort,500,385,0.00083750
+Merge Insertion Sort,500,386,0.00046870
+Merge Insertion Sort,500,387,0.00074810
+Merge Insertion Sort,500,388,0.00078240
+Merge Insertion Sort,500,389,0.00072090
+Merge Insertion Sort,500,390,0.00079110
+Merge Insertion Sort,500,391,0.00073940
+Merge Insertion Sort,500,392,0.00059770
+Merge Insertion Sort,500,393,0.00080400
+Merge Insertion Sort,500,394,0.00071200
+Merge Insertion Sort,500,395,0.00079280
+Merge Insertion Sort,500,396,0.00060460
+Merge Insertion Sort,500,397,0.00075150
+Merge Insertion Sort,500,398,0.00077340
+Merge Insertion Sort,500,399,0.00071630
+Merge Insertion Sort,500,400,0.00090170
+Merge Insertion Sort,500,401,0.00073900
+Merge Insertion Sort,500,402,0.00076000
+Merge Insertion Sort,500,403,0.00072480
+Merge Insertion Sort,500,404,0.00085220
+Merge Insertion Sort,500,405,0.00070330
+Merge Insertion Sort,500,406,0.00074700
+Merge Insertion Sort,500,407,0.00075530
+Merge Insertion Sort,500,408,0.00074490
+Merge Insertion Sort,500,409,0.00085840
+Merge Insertion Sort,500,410,0.00045430
+Merge Insertion Sort,500,411,0.00081440
+Merge Insertion Sort,500,412,0.00061210
+Merge Insertion Sort,500,413,0.00083500
+Merge Insertion Sort,500,414,0.00057860
+Merge Insertion Sort,500,415,0.00085900
+Merge Insertion Sort,500,416,0.00051500
+Merge Insertion Sort,500,417,0.00074860
+Merge Insertion Sort,500,418,0.00067300
+Merge Insertion Sort,500,419,0.00047300
+Merge Insertion Sort,500,420,0.00083810
+Merge Insertion Sort,500,421,0.00050510
+Merge Insertion Sort,500,422,0.00075260
+Merge Insertion Sort,500,423,0.00068840
+Merge Insertion Sort,500,424,0.00090000
+Merge Insertion Sort,500,425,0.00088880
+Merge Insertion Sort,500,426,0.00080110
+Merge Insertion Sort,500,427,0.00054890
+Merge Insertion Sort,500,428,0.00064690
+Merge Insertion Sort,500,429,0.00087990
+Merge Insertion Sort,500,430,0.00083050
+Merge Insertion Sort,500,431,0.00078460
+Merge Insertion Sort,500,432,0.00049500
+Merge Insertion Sort,500,433,0.00085590
+Merge Insertion Sort,500,434,0.00079670
+Merge Insertion Sort,500,435,0.00079230
+Merge Insertion Sort,500,436,0.00045860
+Merge Insertion Sort,500,437,0.00085320
+Merge Insertion Sort,500,438,0.00069180
+Merge Insertion Sort,500,439,0.00058310
+Merge Insertion Sort,500,440,0.00079860
+Merge Insertion Sort,500,441,0.00076020
+Merge Insertion Sort,500,442,0.00062430
+Merge Insertion Sort,500,443,0.00071300
+Merge Insertion Sort,500,444,0.00059040
+Merge Insertion Sort,500,445,0.00062080
+Merge Insertion Sort,500,446,0.00082410
+Merge Insertion Sort,500,447,0.00045360
+Merge Insertion Sort,500,448,0.00048400
+Merge Insertion Sort,500,449,0.00070920
+Merge Insertion Sort,500,450,0.00045860
+Merge Insertion Sort,500,451,0.00060880
+Merge Insertion Sort,500,452,0.00081850
+Merge Insertion Sort,500,453,0.00055880
+Merge Insertion Sort,500,454,0.00092910
+Merge Insertion Sort,500,455,0.00085590
+Merge Insertion Sort,500,456,0.00081000
+Merge Insertion Sort,500,457,0.00081870
+Merge Insertion Sort,500,458,0.00072320
+Merge Insertion Sort,500,459,0.00051070
+Merge Insertion Sort,500,460,0.00054210
+Merge Insertion Sort,500,461,0.00080240
+Merge Insertion Sort,500,462,0.00106000
+Merge Insertion Sort,500,463,0.00047240
+Merge Insertion Sort,500,464,0.00074750
+Merge Insertion Sort,500,465,0.00062290
+Merge Insertion Sort,500,466,0.00048970
+Merge Insertion Sort,500,467,0.00064880
+Merge Insertion Sort,500,468,0.00088140
+Merge Insertion Sort,500,469,0.00045680
+Merge Insertion Sort,500,470,0.00057750
+Merge Insertion Sort,500,471,0.00059230
+Merge Insertion Sort,500,472,0.00076910
+Merge Insertion Sort,500,473,0.00077780
+Merge Insertion Sort,500,474,0.00084330
+Merge Insertion Sort,500,475,0.00045590
+Merge Insertion Sort,500,476,0.00066190
+Merge Insertion Sort,500,477,0.00083180
+Merge Insertion Sort,500,478,0.00088820
+Merge Insertion Sort,500,479,0.00065190
+Merge Insertion Sort,500,480,0.00080280
+Merge Insertion Sort,500,481,0.00062410
+Merge Insertion Sort,500,482,0.00079110
+Merge Insertion Sort,500,483,0.00079870
+Merge Insertion Sort,500,484,0.00080990
+Merge Insertion Sort,500,485,0.00078060
+Merge Insertion Sort,500,486,0.00077240
+Merge Insertion Sort,500,487,0.00086640
+Merge Insertion Sort,500,488,0.00087520
+Merge Insertion Sort,500,489,0.00078580
+Merge Insertion Sort,500,490,0.00066610
+Merge Insertion Sort,500,491,0.00080810
+Merge Insertion Sort,500,492,0.00078740
+Merge Insertion Sort,500,493,0.00077130
+Merge Insertion Sort,500,494,0.00075090
+Merge Insertion Sort,500,495,0.00088290
+Merge Insertion Sort,500,496,0.00066300
+Merge Insertion Sort,500,497,0.00077140
+Merge Insertion Sort,500,498,0.00075550
+Merge Insertion Sort,500,499,0.00087620
+Merge Insertion Sort,500,500,0.00077810
+Merge Sort,500,1,0.00131020
+Merge Sort,500,2,0.00132660
+Merge Sort,500,3,0.00128290
+Merge Sort,500,4,0.00118990
+Merge Sort,500,5,0.00116670
+Merge Sort,500,6,0.00114090
+Merge Sort,500,7,0.00149310
+Merge Sort,500,8,0.00132080
+Merge Sort,500,9,0.00134780
+Merge Sort,500,10,0.00131290
+Merge Sort,500,11,0.00142350
+Merge Sort,500,12,0.00144600
+Merge Sort,500,13,0.00134150
+Merge Sort,500,14,0.00127340
+Merge Sort,500,15,0.00148410
+Merge Sort,500,16,0.00132220
+Merge Sort,500,17,0.00135540
+Merge Sort,500,18,0.00126740
+Merge Sort,500,19,0.00120490
+Merge Sort,500,20,0.00145300
+Merge Sort,500,21,0.00122110
+Merge Sort,500,22,0.00090560
+Merge Sort,500,23,0.00126080
+Merge Sort,500,24,0.00085430
+Merge Sort,500,25,0.00146570
+Merge Sort,500,26,0.00098470
+Merge Sort,500,27,0.00162800
+Merge Sort,500,28,0.00131600
+Merge Sort,500,29,0.00122330
+Merge Sort,500,30,0.00155340
+Merge Sort,500,31,0.00118700
+Merge Sort,500,32,0.00138920
+Merge Sort,500,33,0.00173320
+Merge Sort,500,34,0.00154970
+Merge Sort,500,35,0.00123460
+Merge Sort,500,36,0.00126140
+Merge Sort,500,37,0.00129300
+Merge Sort,500,38,0.00142550
+Merge Sort,500,39,0.00078370
+Merge Sort,500,40,0.00095420
+Merge Sort,500,41,0.00131310
+Merge Sort,500,42,0.00133240
+Merge Sort,500,43,0.00142650
+Merge Sort,500,44,0.00089360
+Merge Sort,500,45,0.00120050
+Merge Sort,500,46,0.00125290
+Merge Sort,500,47,0.00130530
+Merge Sort,500,48,0.00141460
+Merge Sort,500,49,0.00128920
+Merge Sort,500,50,0.00096070
+Merge Sort,500,51,0.00085030
+Merge Sort,500,52,0.00155450
+Merge Sort,500,53,0.00130720
+Merge Sort,500,54,0.00128570
+Merge Sort,500,55,0.00142090
+Merge Sort,500,56,0.00152020
+Merge Sort,500,57,0.00111860
+Merge Sort,500,58,0.00081270
+Merge Sort,500,59,0.00142950
+Merge Sort,500,60,0.00125050
+Merge Sort,500,61,0.00161540
+Merge Sort,500,62,0.00129300
+Merge Sort,500,63,0.00119680
+Merge Sort,500,64,0.00120500
+Merge Sort,500,65,0.00109210
+Merge Sort,500,66,0.00151280
+Merge Sort,500,67,0.00153120
+Merge Sort,500,68,0.00135720
+Merge Sort,500,69,0.00133550
+Merge Sort,500,70,0.00144990
+Merge Sort,500,71,0.00132770
+Merge Sort,500,72,0.00127280
+Merge Sort,500,73,0.00089090
+Merge Sort,500,74,0.00196260
+Merge Sort,500,75,0.00148300
+Merge Sort,500,76,0.00133580
+Merge Sort,500,77,0.00141720
+Merge Sort,500,78,0.00134000
+Merge Sort,500,79,0.00133700
+Merge Sort,500,80,0.00133740
+Merge Sort,500,81,0.00141110
+Merge Sort,500,82,0.00110360
+Merge Sort,500,83,0.00133740
+Merge Sort,500,84,0.00145520
+Merge Sort,500,85,0.00166000
+Merge Sort,500,86,0.00133700
+Merge Sort,500,87,0.00114070
+Merge Sort,500,88,0.00129950
+Merge Sort,500,89,0.00130080
+Merge Sort,500,90,0.00127950
+Merge Sort,500,91,0.00105210
+Merge Sort,500,92,0.00159280
+Merge Sort,500,93,0.00165640
+Merge Sort,500,94,0.00142780
+Merge Sort,500,95,0.00127740
+Merge Sort,500,96,0.00080310
+Merge Sort,500,97,0.00147740
+Merge Sort,500,98,0.00128870
+Merge Sort,500,99,0.00137590
+Merge Sort,500,100,0.00094260
+Merge Sort,500,101,0.00141170
+Merge Sort,500,102,0.00143100
+Merge Sort,500,103,0.00140740
+Merge Sort,500,104,0.00158710
+Merge Sort,500,105,0.00108400
+Merge Sort,500,106,0.00150690
+Merge Sort,500,107,0.00110240
+Merge Sort,500,108,0.00145630
+Merge Sort,500,109,0.00155140
+Merge Sort,500,110,0.00099110
+Merge Sort,500,111,0.00127900
+Merge Sort,500,112,0.00138160
+Merge Sort,500,113,0.00131110
+Merge Sort,500,114,0.00152640
+Merge Sort,500,115,0.00086590
+Merge Sort,500,116,0.00171270
+Merge Sort,500,117,0.00133000
+Merge Sort,500,118,0.00132380
+Merge Sort,500,119,0.00147120
+Merge Sort,500,120,0.00135900
+Merge Sort,500,121,0.00109870
+Merge Sort,500,122,0.00104740
+Merge Sort,500,123,0.00150910
+Merge Sort,500,124,0.00127050
+Merge Sort,500,125,0.00096700
+Merge Sort,500,126,0.00150790
+Merge Sort,500,127,0.00119020
+Merge Sort,500,128,0.00077230
+Merge Sort,500,129,0.00127270
+Merge Sort,500,130,0.00131710
+Merge Sort,500,131,0.00116350
+Merge Sort,500,132,0.00075870
+Merge Sort,500,133,0.00132250
+Merge Sort,500,134,0.00091930
+Merge Sort,500,135,0.00135380
+Merge Sort,500,136,0.00146240
+Merge Sort,500,137,0.00100270
+Merge Sort,500,138,0.00128220
+Merge Sort,500,139,0.00126810
+Merge Sort,500,140,0.00110340
+Merge Sort,500,141,0.00126160
+Merge Sort,500,142,0.00137440
+Merge Sort,500,143,0.00119610
+Merge Sort,500,144,0.00155220
+Merge Sort,500,145,0.00133420
+Merge Sort,500,146,0.00133500
+Merge Sort,500,147,0.00133300
+Merge Sort,500,148,0.00147540
+Merge Sort,500,149,0.00162220
+Merge Sort,500,150,0.00141810
+Merge Sort,500,151,0.00168310
+Merge Sort,500,152,0.00145310
+Merge Sort,500,153,0.00128540
+Merge Sort,500,154,0.00133800
+Merge Sort,500,155,0.00127740
+Merge Sort,500,156,0.00145210
+Merge Sort,500,157,0.00124130
+Merge Sort,500,158,0.00134270
+Merge Sort,500,159,0.00128070
+Merge Sort,500,160,0.00120610
+Merge Sort,500,161,0.00125120
+Merge Sort,500,162,0.00125150
+Merge Sort,500,163,0.00127520
+Merge Sort,500,164,0.00105150
+Merge Sort,500,165,0.00132190
+Merge Sort,500,166,0.00130300
+Merge Sort,500,167,0.00141230
+Merge Sort,500,168,0.00103200
+Merge Sort,500,169,0.00123010
+Merge Sort,500,170,0.00118610
+Merge Sort,500,171,0.00155560
+Merge Sort,500,172,0.00110730
+Merge Sort,500,173,0.00141490
+Merge Sort,500,174,0.00144550
+Merge Sort,500,175,0.00102720
+Merge Sort,500,176,0.00121150
+Merge Sort,500,177,0.00092990
+Merge Sort,500,178,0.00107420
+Merge Sort,500,179,0.00147850
+Merge Sort,500,180,0.00125490
+Merge Sort,500,181,0.00133760
+Merge Sort,500,182,0.00131880
+Merge Sort,500,183,0.00112800
+Merge Sort,500,184,0.00129430
+Merge Sort,500,185,0.00127670
+Merge Sort,500,186,0.00129290
+Merge Sort,500,187,0.00105490
+Merge Sort,500,188,0.00142770
+Merge Sort,500,189,0.00127290
+Merge Sort,500,190,0.00104940
+Merge Sort,500,191,0.00123400
+Merge Sort,500,192,0.00096980
+Merge Sort,500,193,0.00140060
+Merge Sort,500,194,0.00157000
+Merge Sort,500,195,0.00132790
+Merge Sort,500,196,0.00100020
+Merge Sort,500,197,0.00124100
+Merge Sort,500,198,0.00117620
+Merge Sort,500,199,0.00131840
+Merge Sort,500,200,0.00079850
+Merge Sort,500,201,0.00107080
+Merge Sort,500,202,0.00127650
+Merge Sort,500,203,0.00151750
+Merge Sort,500,204,0.00099290
+Merge Sort,500,205,0.00077650
+Merge Sort,500,206,0.00127390
+Merge Sort,500,207,0.00111460
+Merge Sort,500,208,0.00151950
+Merge Sort,500,209,0.00082940
+Merge Sort,500,210,0.00120190
+Merge Sort,500,211,0.00139090
+Merge Sort,500,212,0.00121250
+Merge Sort,500,213,0.00129370
+Merge Sort,500,214,0.00105930
+Merge Sort,500,215,0.00126290
+Merge Sort,500,216,0.00121640
+Merge Sort,500,217,0.00147820
+Merge Sort,500,218,0.00124040
+Merge Sort,500,219,0.00120200
+Merge Sort,500,220,0.00139570
+Merge Sort,500,221,0.00111880
+Merge Sort,500,222,0.00133690
+Merge Sort,500,223,0.00096350
+Merge Sort,500,224,0.00128560
+Merge Sort,500,225,0.00125660
+Merge Sort,500,226,0.00138210
+Merge Sort,500,227,0.00140680
+Merge Sort,500,228,0.00121640
+Merge Sort,500,229,0.00160770
+Merge Sort,500,230,0.00076750
+Merge Sort,500,231,0.00120970
+Merge Sort,500,232,0.00095190
+Merge Sort,500,233,0.00097070
+Merge Sort,500,234,0.00138520
+Merge Sort,500,235,0.00127650
+Merge Sort,500,236,0.00094460
+Merge Sort,500,237,0.00129810
+Merge Sort,500,238,0.00121480
+Merge Sort,500,239,0.00133250
+Merge Sort,500,240,0.00132400
+Merge Sort,500,241,0.00128290
+Merge Sort,500,242,0.00125410
+Merge Sort,500,243,0.00134130
+Merge Sort,500,244,0.00132450
+Merge Sort,500,245,0.00091450
+Merge Sort,500,246,0.00117030
+Merge Sort,500,247,0.00126860
+Merge Sort,500,248,0.00098190
+Merge Sort,500,249,0.00094920
+Merge Sort,500,250,0.00103620
+Merge Sort,500,251,0.00076820
+Merge Sort,500,252,0.00127780
+Merge Sort,500,253,0.00127280
+Merge Sort,500,254,0.00103830
+Merge Sort,500,255,0.00086600
+Merge Sort,500,256,0.00126360
+Merge Sort,500,257,0.00126870
+Merge Sort,500,258,0.00105240
+Merge Sort,500,259,0.00076980
+Merge Sort,500,260,0.00094950
+Merge Sort,500,261,0.00106010
+Merge Sort,500,262,0.00126840
+Merge Sort,500,263,0.00125860
+Merge Sort,500,264,0.00091940
+Merge Sort,500,265,0.00126900
+Merge Sort,500,266,0.00113770
+Merge Sort,500,267,0.00092000
+Merge Sort,500,268,0.00095310
+Merge Sort,500,269,0.00106630
+Merge Sort,500,270,0.00133460
+Merge Sort,500,271,0.00132570
+Merge Sort,500,272,0.00132220
+Merge Sort,500,273,0.00107570
+Merge Sort,500,274,0.00122630
+Merge Sort,500,275,0.00132840
+Merge Sort,500,276,0.00131800
+Merge Sort,500,277,0.00103850
+Merge Sort,500,278,0.00108600
+Merge Sort,500,279,0.00132960
+Merge Sort,500,280,0.00131950
+Merge Sort,500,281,0.00103710
+Merge Sort,500,282,0.00123690
+Merge Sort,500,283,0.00133220
+Merge Sort,500,284,0.00133170
+Merge Sort,500,285,0.00133120
+Merge Sort,500,286,0.00126040
+Merge Sort,500,287,0.00144740
+Merge Sort,500,288,0.00132530
+Merge Sort,500,289,0.00131410
+Merge Sort,500,290,0.00146280
+Merge Sort,500,291,0.00134840
+Merge Sort,500,292,0.00131420
+Merge Sort,500,293,0.00124260
+Merge Sort,500,294,0.00132470
+Merge Sort,500,295,0.00144290
+Merge Sort,500,296,0.00107970
+Merge Sort,500,297,0.00127760
+Merge Sort,500,298,0.00134120
+Merge Sort,500,299,0.00132950
+Merge Sort,500,300,0.00131750
+Merge Sort,500,301,0.00127970
+Merge Sort,500,302,0.00118040
+Merge Sort,500,303,0.00112520
+Merge Sort,500,304,0.00127800
+Merge Sort,500,305,0.00145460
+Merge Sort,500,306,0.00135010
+Merge Sort,500,307,0.00146890
+Merge Sort,500,308,0.00127670
+Merge Sort,500,309,0.00145030
+Merge Sort,500,310,0.00112800
+Merge Sort,500,311,0.00116080
+Merge Sort,500,312,0.00118600
+Merge Sort,500,313,0.00144400
+Merge Sort,500,314,0.00096410
+Merge Sort,500,315,0.00135020
+Merge Sort,500,316,0.00096580
+Merge Sort,500,317,0.00122940
+Merge Sort,500,318,0.00133400
+Merge Sort,500,319,0.00126160
+Merge Sort,500,320,0.00134240
+Merge Sort,500,321,0.00137870
+Merge Sort,500,322,0.00120830
+Merge Sort,500,323,0.00131160
+Merge Sort,500,324,0.00137070
+Merge Sort,500,325,0.00135850
+Merge Sort,500,326,0.00110810
+Merge Sort,500,327,0.00133560
+Merge Sort,500,328,0.00103750
+Merge Sort,500,329,0.00137240
+Merge Sort,500,330,0.00126820
+Merge Sort,500,331,0.00117470
+Merge Sort,500,332,0.00079440
+Merge Sort,500,333,0.00124960
+Merge Sort,500,334,0.00129160
+Merge Sort,500,335,0.00110430
+Merge Sort,500,336,0.00126650
+Merge Sort,500,337,0.00152160
+Merge Sort,500,338,0.00132860
+Merge Sort,500,339,0.00134270
+Merge Sort,500,340,0.00129560
+Merge Sort,500,341,0.00154880
+Merge Sort,500,342,0.00086060
+Merge Sort,500,343,0.00138070
+Merge Sort,500,344,0.00136960
+Merge Sort,500,345,0.00126340
+Merge Sort,500,346,0.00138040
+Merge Sort,500,347,0.00126740
+Merge Sort,500,348,0.00086170
+Merge Sort,500,349,0.00111960
+Merge Sort,500,350,0.00127120
+Merge Sort,500,351,0.00128960
+Merge Sort,500,352,0.00093620
+Merge Sort,500,353,0.00091580
+Merge Sort,500,354,0.00132530
+Merge Sort,500,355,0.00098170
+Merge Sort,500,356,0.00147940
+Merge Sort,500,357,0.00124410
+Merge Sort,500,358,0.00098370
+Merge Sort,500,359,0.00082570
+Merge Sort,500,360,0.00147790
+Merge Sort,500,361,0.00095790
+Merge Sort,500,362,0.00111750
+Merge Sort,500,363,0.00097210
+Merge Sort,500,364,0.00081860
+Merge Sort,500,365,0.00126170
+Merge Sort,500,366,0.00121650
+Merge Sort,500,367,0.00091420
+Merge Sort,500,368,0.00078000
+Merge Sort,500,369,0.00133220
+Merge Sort,500,370,0.00134660
+Merge Sort,500,371,0.00090440
+Merge Sort,500,372,0.00091380
+Merge Sort,500,373,0.00134560
+Merge Sort,500,374,0.00079810
+Merge Sort,500,375,0.00144580
+Merge Sort,500,376,0.00119050
+Merge Sort,500,377,0.00080160
+Merge Sort,500,378,0.00126100
+Merge Sort,500,379,0.00080980
+Merge Sort,500,380,0.00077570
+Merge Sort,500,381,0.00132800
+Merge Sort,500,382,0.00128750
+Merge Sort,500,383,0.00103910
+Merge Sort,500,384,0.00090200
+Merge Sort,500,385,0.00121250
+Merge Sort,500,386,0.00128020
+Merge Sort,500,387,0.00075090
+Merge Sort,500,388,0.00076360
+Merge Sort,500,389,0.00150420
+Merge Sort,500,390,0.00076530
+Merge Sort,500,391,0.00086540
+Merge Sort,500,392,0.00117630
+Merge Sort,500,393,0.00127170
+Merge Sort,500,394,0.00111540
+Merge Sort,500,395,0.00139300
+Merge Sort,500,396,0.00124770
+Merge Sort,500,397,0.00114150
+Merge Sort,500,398,0.00075900
+Merge Sort,500,399,0.00152100
+Merge Sort,500,400,0.00139600
+Merge Sort,500,401,0.00104420
+Merge Sort,500,402,0.00135020
+Merge Sort,500,403,0.00147700
+Merge Sort,500,404,0.00099620
+Merge Sort,500,405,0.00133020
+Merge Sort,500,406,0.00132080
+Merge Sort,500,407,0.00082610
+Merge Sort,500,408,0.00144130
+Merge Sort,500,409,0.00130810
+Merge Sort,500,410,0.00134180
+Merge Sort,500,411,0.00104870
+Merge Sort,500,412,0.00144190
+Merge Sort,500,413,0.00125390
+Merge Sort,500,414,0.00086320
+Merge Sort,500,415,0.00134000
+Merge Sort,500,416,0.00080150
+Merge Sort,500,417,0.00125950
+Merge Sort,500,418,0.00144380
+Merge Sort,500,419,0.00132780
+Merge Sort,500,420,0.00111750
+Merge Sort,500,421,0.00125180
+Merge Sort,500,422,0.00106800
+Merge Sort,500,423,0.00081730
+Merge Sort,500,424,0.00077070
+Merge Sort,500,425,0.00125540
+Merge Sort,500,426,0.00078200
+Merge Sort,500,427,0.00078420
+Merge Sort,500,428,0.00133320
+Merge Sort,500,429,0.00129840
+Merge Sort,500,430,0.00082430
+Merge Sort,500,431,0.00107480
+Merge Sort,500,432,0.00142790
+Merge Sort,500,433,0.00103740
+Merge Sort,500,434,0.00126700
+Merge Sort,500,435,0.00128560
+Merge Sort,500,436,0.00114880
+Merge Sort,500,437,0.00117400
+Merge Sort,500,438,0.00127970
+Merge Sort,500,439,0.00127110
+Merge Sort,500,440,0.00128950
+Merge Sort,500,441,0.00120490
+Merge Sort,500,442,0.00092380
+Merge Sort,500,443,0.00127980
+Merge Sort,500,444,0.00083350
+Merge Sort,500,445,0.00145180
+Merge Sort,500,446,0.00085680
+Merge Sort,500,447,0.00125080
+Merge Sort,500,448,0.00130890
+Merge Sort,500,449,0.00139820
+Merge Sort,500,450,0.00082950
+Merge Sort,500,451,0.00120480
+Merge Sort,500,452,0.00109980
+Merge Sort,500,453,0.00135240
+Merge Sort,500,454,0.00112210
+Merge Sort,500,455,0.00131860
+Merge Sort,500,456,0.00117540
+Merge Sort,500,457,0.00126360
+Merge Sort,500,458,0.00150260
+Merge Sort,500,459,0.00104160
+Merge Sort,500,460,0.00132140
+Merge Sort,500,461,0.00126820
+Merge Sort,500,462,0.00141210
+Merge Sort,500,463,0.00102250
+Merge Sort,500,464,0.00094760
+Merge Sort,500,465,0.00131060
+Merge Sort,500,466,0.00128290
+Merge Sort,500,467,0.00139500
+Merge Sort,500,468,0.00099360
+Merge Sort,500,469,0.00106840
+Merge Sort,500,470,0.00127880
+Merge Sort,500,471,0.00086930
+Merge Sort,500,472,0.00139630
+Merge Sort,500,473,0.00104510
+Merge Sort,500,474,0.00128980
+Merge Sort,500,475,0.00129500
+Merge Sort,500,476,0.00129530
+Merge Sort,500,477,0.00078980
+Merge Sort,500,478,0.00125940
+Merge Sort,500,479,0.00130520
+Merge Sort,500,480,0.00082690
+Merge Sort,500,481,0.00149580
+Merge Sort,500,482,0.00105470
+Merge Sort,500,483,0.00118020
+Merge Sort,500,484,0.00112640
+Merge Sort,500,485,0.00125860
+Merge Sort,500,486,0.00079850
+Merge Sort,500,487,0.00125940
+Merge Sort,500,488,0.00101590
+Merge Sort,500,489,0.00078040
+Merge Sort,500,490,0.00139950
+Merge Sort,500,491,0.00110470
+Merge Sort,500,492,0.00118160
+Merge Sort,500,493,0.00089340
+Merge Sort,500,494,0.00141040
+Merge Sort,500,495,0.00145750
+Merge Sort,500,496,0.00125770
+Merge Sort,500,497,0.00127810
+Merge Sort,500,498,0.00107820
+Merge Sort,500,499,0.00114090
+Merge Sort,500,500,0.00146130
+Merge Sort In-Place,500,1,0.00169660
+Merge Sort In-Place,500,2,0.00188780
+Merge Sort In-Place,500,3,0.00192650
+Merge Sort In-Place,500,4,0.00175810
+Merge Sort In-Place,500,5,0.00147940
+Merge Sort In-Place,500,6,0.00172780
+Merge Sort In-Place,500,7,0.00157110
+Merge Sort In-Place,500,8,0.00181880
+Merge Sort In-Place,500,9,0.00182180
+Merge Sort In-Place,500,10,0.00125920
+Merge Sort In-Place,500,11,0.00166740
+Merge Sort In-Place,500,12,0.00137710
+Merge Sort In-Place,500,13,0.00195430
+Merge Sort In-Place,500,14,0.00118190
+Merge Sort In-Place,500,15,0.00187120
+Merge Sort In-Place,500,16,0.00196650
+Merge Sort In-Place,500,17,0.00184550
+Merge Sort In-Place,500,18,0.00184140
+Merge Sort In-Place,500,19,0.00178260
+Merge Sort In-Place,500,20,0.00176420
+Merge Sort In-Place,500,21,0.00160420
+Merge Sort In-Place,500,22,0.00165390
+Merge Sort In-Place,500,23,0.00126730
+Merge Sort In-Place,500,24,0.00175930
+Merge Sort In-Place,500,25,0.00157350
+Merge Sort In-Place,500,26,0.00194820
+Merge Sort In-Place,500,27,0.00101700
+Merge Sort In-Place,500,28,0.00149530
+Merge Sort In-Place,500,29,0.00179790
+Merge Sort In-Place,500,30,0.00129060
+Merge Sort In-Place,500,31,0.00182870
+Merge Sort In-Place,500,32,0.00186850
+Merge Sort In-Place,500,33,0.00157930
+Merge Sort In-Place,500,34,0.00183600
+Merge Sort In-Place,500,35,0.00180650
+Merge Sort In-Place,500,36,0.00143350
+Merge Sort In-Place,500,37,0.00169550
+Merge Sort In-Place,500,38,0.00166670
+Merge Sort In-Place,500,39,0.00130190
+Merge Sort In-Place,500,40,0.00109520
+Merge Sort In-Place,500,41,0.00168280
+Merge Sort In-Place,500,42,0.00136070
+Merge Sort In-Place,500,43,0.00161120
+Merge Sort In-Place,500,44,0.00181930
+Merge Sort In-Place,500,45,0.00175890
+Merge Sort In-Place,500,46,0.00152740
+Merge Sort In-Place,500,47,0.00198780
+Merge Sort In-Place,500,48,0.00186860
+Merge Sort In-Place,500,49,0.00155820
+Merge Sort In-Place,500,50,0.00179880
+Merge Sort In-Place,500,51,0.00172460
+Merge Sort In-Place,500,52,0.00163900
+Merge Sort In-Place,500,53,0.00100780
+Merge Sort In-Place,500,54,0.00173380
+Merge Sort In-Place,500,55,0.00150110
+Merge Sort In-Place,500,56,0.00119040
+Merge Sort In-Place,500,57,0.00177490
+Merge Sort In-Place,500,58,0.00175560
+Merge Sort In-Place,500,59,0.00168490
+Merge Sort In-Place,500,60,0.00200310
+Merge Sort In-Place,500,61,0.00185790
+Merge Sort In-Place,500,62,0.00117430
+Merge Sort In-Place,500,63,0.00177570
+Merge Sort In-Place,500,64,0.00134080
+Merge Sort In-Place,500,65,0.00146090
+Merge Sort In-Place,500,66,0.00155760
+Merge Sort In-Place,500,67,0.00158070
+Merge Sort In-Place,500,68,0.00181410
+Merge Sort In-Place,500,69,0.00134950
+Merge Sort In-Place,500,70,0.00167010
+Merge Sort In-Place,500,71,0.00133840
+Merge Sort In-Place,500,72,0.00103370
+Merge Sort In-Place,500,73,0.00104420
+Merge Sort In-Place,500,74,0.00175150
+Merge Sort In-Place,500,75,0.00179850
+Merge Sort In-Place,500,76,0.00181850
+Merge Sort In-Place,500,77,0.00186040
+Merge Sort In-Place,500,78,0.00185390
+Merge Sort In-Place,500,79,0.00180360
+Merge Sort In-Place,500,80,0.00182750
+Merge Sort In-Place,500,81,0.00187520
+Merge Sort In-Place,500,82,0.00151430
+Merge Sort In-Place,500,83,0.00178320
+Merge Sort In-Place,500,84,0.00150390
+Merge Sort In-Place,500,85,0.00138290
+Merge Sort In-Place,500,86,0.00155670
+Merge Sort In-Place,500,87,0.00129250
+Merge Sort In-Place,500,88,0.00170070
+Merge Sort In-Place,500,89,0.00170540
+Merge Sort In-Place,500,90,0.00159540
+Merge Sort In-Place,500,91,0.00114280
+Merge Sort In-Place,500,92,0.00148740
+Merge Sort In-Place,500,93,0.00144380
+Merge Sort In-Place,500,94,0.00123420
+Merge Sort In-Place,500,95,0.00175100
+Merge Sort In-Place,500,96,0.00174170
+Merge Sort In-Place,500,97,0.00154720
+Merge Sort In-Place,500,98,0.00108280
+Merge Sort In-Place,500,99,0.00177580
+Merge Sort In-Place,500,100,0.00173150
+Merge Sort In-Place,500,101,0.00149170
+Merge Sort In-Place,500,102,0.00116300
+Merge Sort In-Place,500,103,0.00110990
+Merge Sort In-Place,500,104,0.00170770
+Merge Sort In-Place,500,105,0.00185490
+Merge Sort In-Place,500,106,0.00116030
+Merge Sort In-Place,500,107,0.00179610
+Merge Sort In-Place,500,108,0.00183220
+Merge Sort In-Place,500,109,0.00159790
+Merge Sort In-Place,500,110,0.00150910
+Merge Sort In-Place,500,111,0.00122260
+Merge Sort In-Place,500,112,0.00161420
+Merge Sort In-Place,500,113,0.00177910
+Merge Sort In-Place,500,114,0.00147860
+Merge Sort In-Place,500,115,0.00156460
+Merge Sort In-Place,500,116,0.00180430
+Merge Sort In-Place,500,117,0.00198950
+Merge Sort In-Place,500,118,0.00175910
+Merge Sort In-Place,500,119,0.00168920
+Merge Sort In-Place,500,120,0.00161240
+Merge Sort In-Place,500,121,0.00143400
+Merge Sort In-Place,500,122,0.00192880
+Merge Sort In-Place,500,123,0.00185320
+Merge Sort In-Place,500,124,0.00159550
+Merge Sort In-Place,500,125,0.00140390
+Merge Sort In-Place,500,126,0.00208820
+Merge Sort In-Place,500,127,0.00136600
+Merge Sort In-Place,500,128,0.00181500
+Merge Sort In-Place,500,129,0.00184010
+Merge Sort In-Place,500,130,0.00187650
+Merge Sort In-Place,500,131,0.00156510
+Merge Sort In-Place,500,132,0.00186050
+Merge Sort In-Place,500,133,0.00152860
+Merge Sort In-Place,500,134,0.00168680
+Merge Sort In-Place,500,135,0.00168180
+Merge Sort In-Place,500,136,0.00178750
+Merge Sort In-Place,500,137,0.00196690
+Merge Sort In-Place,500,138,0.00161640
+Merge Sort In-Place,500,139,0.00105860
+Merge Sort In-Place,500,140,0.00170660
+Merge Sort In-Place,500,141,0.00138380
+Merge Sort In-Place,500,142,0.00188350
+Merge Sort In-Place,500,143,0.00169250
+Merge Sort In-Place,500,144,0.00168710
+Merge Sort In-Place,500,145,0.00144390
+Merge Sort In-Place,500,146,0.00167150
+Merge Sort In-Place,500,147,0.00116320
+Merge Sort In-Place,500,148,0.00179600
+Merge Sort In-Place,500,149,0.00162470
+Merge Sort In-Place,500,150,0.00179110
+Merge Sort In-Place,500,151,0.00172590
+Merge Sort In-Place,500,152,0.00137410
+Merge Sort In-Place,500,153,0.00173730
+Merge Sort In-Place,500,154,0.00175650
+Merge Sort In-Place,500,155,0.00181090
+Merge Sort In-Place,500,156,0.00175460
+Merge Sort In-Place,500,157,0.00182860
+Merge Sort In-Place,500,158,0.00185510
+Merge Sort In-Place,500,159,0.00175060
+Merge Sort In-Place,500,160,0.00147590
+Merge Sort In-Place,500,161,0.00165900
+Merge Sort In-Place,500,162,0.00186410
+Merge Sort In-Place,500,163,0.00176040
+Merge Sort In-Place,500,164,0.00147020
+Merge Sort In-Place,500,165,0.00121400
+Merge Sort In-Place,500,166,0.00135910
+Merge Sort In-Place,500,167,0.00138670
+Merge Sort In-Place,500,168,0.00157110
+Merge Sort In-Place,500,169,0.00154690
+Merge Sort In-Place,500,170,0.00117490
+Merge Sort In-Place,500,171,0.00174020
+Merge Sort In-Place,500,172,0.00119010
+Merge Sort In-Place,500,173,0.00110790
+Merge Sort In-Place,500,174,0.00102730
+Merge Sort In-Place,500,175,0.00179540
+Merge Sort In-Place,500,176,0.00131970
+Merge Sort In-Place,500,177,0.00127780
+Merge Sort In-Place,500,178,0.00112490
+Merge Sort In-Place,500,179,0.00137840
+Merge Sort In-Place,500,180,0.00194660
+Merge Sort In-Place,500,181,0.00171670
+Merge Sort In-Place,500,182,0.00109920
+Merge Sort In-Place,500,183,0.00182080
+Merge Sort In-Place,500,184,0.00182180
+Merge Sort In-Place,500,185,0.00178950
+Merge Sort In-Place,500,186,0.00164790
+Merge Sort In-Place,500,187,0.00183230
+Merge Sort In-Place,500,188,0.00152660
+Merge Sort In-Place,500,189,0.00124720
+Merge Sort In-Place,500,190,0.00178470
+Merge Sort In-Place,500,191,0.00147390
+Merge Sort In-Place,500,192,0.00161470
+Merge Sort In-Place,500,193,0.00145960
+Merge Sort In-Place,500,194,0.00150940
+Merge Sort In-Place,500,195,0.00115860
+Merge Sort In-Place,500,196,0.00169250
+Merge Sort In-Place,500,197,0.00143590
+Merge Sort In-Place,500,198,0.00172400
+Merge Sort In-Place,500,199,0.00174680
+Merge Sort In-Place,500,200,0.00178370
+Merge Sort In-Place,500,201,0.00176730
+Merge Sort In-Place,500,202,0.00141560
+Merge Sort In-Place,500,203,0.00113980
+Merge Sort In-Place,500,204,0.00168580
+Merge Sort In-Place,500,205,0.00118330
+Merge Sort In-Place,500,206,0.00113930
+Merge Sort In-Place,500,207,0.00173010
+Merge Sort In-Place,500,208,0.00169630
+Merge Sort In-Place,500,209,0.00161070
+Merge Sort In-Place,500,210,0.00171800
+Merge Sort In-Place,500,211,0.00174660
+Merge Sort In-Place,500,212,0.00164390
+Merge Sort In-Place,500,213,0.00108410
+Merge Sort In-Place,500,214,0.00134460
+Merge Sort In-Place,500,215,0.00173080
+Merge Sort In-Place,500,216,0.00173760
+Merge Sort In-Place,500,217,0.00154640
+Merge Sort In-Place,500,218,0.00104160
+Merge Sort In-Place,500,219,0.00102860
+Merge Sort In-Place,500,220,0.00174840
+Merge Sort In-Place,500,221,0.00176200
+Merge Sort In-Place,500,222,0.00162480
+Merge Sort In-Place,500,223,0.00156600
+Merge Sort In-Place,500,224,0.00183730
+Merge Sort In-Place,500,225,0.00158480
+Merge Sort In-Place,500,226,0.00172300
+Merge Sort In-Place,500,227,0.00107350
+Merge Sort In-Place,500,228,0.00142320
+Merge Sort In-Place,500,229,0.00178720
+Merge Sort In-Place,500,230,0.00152730
+Merge Sort In-Place,500,231,0.00171000
+Merge Sort In-Place,500,232,0.00098890
+Merge Sort In-Place,500,233,0.00136710
+Merge Sort In-Place,500,234,0.00170870
+Merge Sort In-Place,500,235,0.00122190
+Merge Sort In-Place,500,236,0.00149340
+Merge Sort In-Place,500,237,0.00111500
+Merge Sort In-Place,500,238,0.00135360
+Merge Sort In-Place,500,239,0.00173310
+Merge Sort In-Place,500,240,0.00171750
+Merge Sort In-Place,500,241,0.00103950
+Merge Sort In-Place,500,242,0.00174890
+Merge Sort In-Place,500,243,0.00108650
+Merge Sort In-Place,500,244,0.00170800
+Merge Sort In-Place,500,245,0.00173660
+Merge Sort In-Place,500,246,0.00163180
+Merge Sort In-Place,500,247,0.00109260
+Merge Sort In-Place,500,248,0.00166400
+Merge Sort In-Place,500,249,0.00132290
+Merge Sort In-Place,500,250,0.00100790
+Merge Sort In-Place,500,251,0.00178090
+Merge Sort In-Place,500,252,0.00139020
+Merge Sort In-Place,500,253,0.00177350
+Merge Sort In-Place,500,254,0.00137460
+Merge Sort In-Place,500,255,0.00180250
+Merge Sort In-Place,500,256,0.00179120
+Merge Sort In-Place,500,257,0.00104390
+Merge Sort In-Place,500,258,0.00174390
+Merge Sort In-Place,500,259,0.00164300
+Merge Sort In-Place,500,260,0.00126830
+Merge Sort In-Place,500,261,0.00177980
+Merge Sort In-Place,500,262,0.00176370
+Merge Sort In-Place,500,263,0.00151060
+Merge Sort In-Place,500,264,0.00107250
+Merge Sort In-Place,500,265,0.00178880
+Merge Sort In-Place,500,266,0.00132120
+Merge Sort In-Place,500,267,0.00115890
+Merge Sort In-Place,500,268,0.00143790
+Merge Sort In-Place,500,269,0.00105090
+Merge Sort In-Place,500,270,0.00179500
+Merge Sort In-Place,500,271,0.00104380
+Merge Sort In-Place,500,272,0.00182150
+Merge Sort In-Place,500,273,0.00104630
+Merge Sort In-Place,500,274,0.00114940
+Merge Sort In-Place,500,275,0.00150760
+Merge Sort In-Place,500,276,0.00168950
+Merge Sort In-Place,500,277,0.00176770
+Merge Sort In-Place,500,278,0.00177930
+Merge Sort In-Place,500,279,0.00143440
+Merge Sort In-Place,500,280,0.00105460
+Merge Sort In-Place,500,281,0.00171070
+Merge Sort In-Place,500,282,0.00154090
+Merge Sort In-Place,500,283,0.00143380
+Merge Sort In-Place,500,284,0.00170060
+Merge Sort In-Place,500,285,0.00120570
+Merge Sort In-Place,500,286,0.00107260
+Merge Sort In-Place,500,287,0.00171410
+Merge Sort In-Place,500,288,0.00135050
+Merge Sort In-Place,500,289,0.00105410
+Merge Sort In-Place,500,290,0.00101500
+Merge Sort In-Place,500,291,0.00118280
+Merge Sort In-Place,500,292,0.00182060
+Merge Sort In-Place,500,293,0.00174560
+Merge Sort In-Place,500,294,0.00188290
+Merge Sort In-Place,500,295,0.00111830
+Merge Sort In-Place,500,296,0.00152060
+Merge Sort In-Place,500,297,0.00187660
+Merge Sort In-Place,500,298,0.00166650
+Merge Sort In-Place,500,299,0.00148330
+Merge Sort In-Place,500,300,0.00168070
+Merge Sort In-Place,500,301,0.00121040
+Merge Sort In-Place,500,302,0.00136710
+Merge Sort In-Place,500,303,0.00116740
+Merge Sort In-Place,500,304,0.00101360
+Merge Sort In-Place,500,305,0.00101400
+Merge Sort In-Place,500,306,0.00173990
+Merge Sort In-Place,500,307,0.00171150
+Merge Sort In-Place,500,308,0.00162840
+Merge Sort In-Place,500,309,0.00134520
+Merge Sort In-Place,500,310,0.00174570
+Merge Sort In-Place,500,311,0.00181850
+Merge Sort In-Place,500,312,0.00113930
+Merge Sort In-Place,500,313,0.00202420
+Merge Sort In-Place,500,314,0.00121410
+Merge Sort In-Place,500,315,0.00176740
+Merge Sort In-Place,500,316,0.00122430
+Merge Sort In-Place,500,317,0.00175750
+Merge Sort In-Place,500,318,0.00106580
+Merge Sort In-Place,500,319,0.00124130
+Merge Sort In-Place,500,320,0.00176950
+Merge Sort In-Place,500,321,0.00127390
+Merge Sort In-Place,500,322,0.00133830
+Merge Sort In-Place,500,323,0.00125950
+Merge Sort In-Place,500,324,0.00119650
+Merge Sort In-Place,500,325,0.00173860
+Merge Sort In-Place,500,326,0.00104620
+Merge Sort In-Place,500,327,0.00104320
+Merge Sort In-Place,500,328,0.00113320
+Merge Sort In-Place,500,329,0.00158760
+Merge Sort In-Place,500,330,0.00159500
+Merge Sort In-Place,500,331,0.00128320
+Merge Sort In-Place,500,332,0.00224960
+Merge Sort In-Place,500,333,0.00130900
+Merge Sort In-Place,500,334,0.00161220
+Merge Sort In-Place,500,335,0.00107350
+Merge Sort In-Place,500,336,0.00148220
+Merge Sort In-Place,500,337,0.00163180
+Merge Sort In-Place,500,338,0.00120600
+Merge Sort In-Place,500,339,0.00151360
+Merge Sort In-Place,500,340,0.00135550
+Merge Sort In-Place,500,341,0.00172480
+Merge Sort In-Place,500,342,0.00117280
+Merge Sort In-Place,500,343,0.00126250
+Merge Sort In-Place,500,344,0.00119430
+Merge Sort In-Place,500,345,0.00105490
+Merge Sort In-Place,500,346,0.00129410
+Merge Sort In-Place,500,347,0.00151040
+Merge Sort In-Place,500,348,0.00158350
+Merge Sort In-Place,500,349,0.00128260
+Merge Sort In-Place,500,350,0.00134390
+Merge Sort In-Place,500,351,0.00126110
+Merge Sort In-Place,500,352,0.00183170
+Merge Sort In-Place,500,353,0.00168110
+Merge Sort In-Place,500,354,0.00129890
+Merge Sort In-Place,500,355,0.00135540
+Merge Sort In-Place,500,356,0.00152360
+Merge Sort In-Place,500,357,0.00111850
+Merge Sort In-Place,500,358,0.00173220
+Merge Sort In-Place,500,359,0.00172020
+Merge Sort In-Place,500,360,0.00110590
+Merge Sort In-Place,500,361,0.00174840
+Merge Sort In-Place,500,362,0.00145080
+Merge Sort In-Place,500,363,0.00178390
+Merge Sort In-Place,500,364,0.00119040
+Merge Sort In-Place,500,365,0.00132320
+Merge Sort In-Place,500,366,0.00188140
+Merge Sort In-Place,500,367,0.00158490
+Merge Sort In-Place,500,368,0.00177230
+Merge Sort In-Place,500,369,0.00157040
+Merge Sort In-Place,500,370,0.00163900
+Merge Sort In-Place,500,371,0.00141760
+Merge Sort In-Place,500,372,0.00173190
+Merge Sort In-Place,500,373,0.00132080
+Merge Sort In-Place,500,374,0.00102170
+Merge Sort In-Place,500,375,0.00103930
+Merge Sort In-Place,500,376,0.00170630
+Merge Sort In-Place,500,377,0.00125070
+Merge Sort In-Place,500,378,0.00138740
+Merge Sort In-Place,500,379,0.00114120
+Merge Sort In-Place,500,380,0.00101490
+Merge Sort In-Place,500,381,0.00103340
+Merge Sort In-Place,500,382,0.00170650
+Merge Sort In-Place,500,383,0.00149490
+Merge Sort In-Place,500,384,0.00101430
+Merge Sort In-Place,500,385,0.00102490
+Merge Sort In-Place,500,386,0.00179210
+Merge Sort In-Place,500,387,0.00184120
+Merge Sort In-Place,500,388,0.00113070
+Merge Sort In-Place,500,389,0.00137320
+Merge Sort In-Place,500,390,0.00104410
+Merge Sort In-Place,500,391,0.00172380
+Merge Sort In-Place,500,392,0.00109390
+Merge Sort In-Place,500,393,0.00175620
+Merge Sort In-Place,500,394,0.00115620
+Merge Sort In-Place,500,395,0.00124060
+Merge Sort In-Place,500,396,0.00168380
+Merge Sort In-Place,500,397,0.00179860
+Merge Sort In-Place,500,398,0.00122890
+Merge Sort In-Place,500,399,0.00102000
+Merge Sort In-Place,500,400,0.00108720
+Merge Sort In-Place,500,401,0.00177240
+Merge Sort In-Place,500,402,0.00137440
+Merge Sort In-Place,500,403,0.00226230
+Merge Sort In-Place,500,404,0.00181910
+Merge Sort In-Place,500,405,0.00189640
+Merge Sort In-Place,500,406,0.00175130
+Merge Sort In-Place,500,407,0.00146400
+Merge Sort In-Place,500,408,0.00167250
+Merge Sort In-Place,500,409,0.00153010
+Merge Sort In-Place,500,410,0.00170060
+Merge Sort In-Place,500,411,0.00175960
+Merge Sort In-Place,500,412,0.00141310
+Merge Sort In-Place,500,413,0.00114110
+Merge Sort In-Place,500,414,0.00173480
+Merge Sort In-Place,500,415,0.00173710
+Merge Sort In-Place,500,416,0.00152170
+Merge Sort In-Place,500,417,0.00148470
+Merge Sort In-Place,500,418,0.00131870
+Merge Sort In-Place,500,419,0.00169620
+Merge Sort In-Place,500,420,0.00153000
+Merge Sort In-Place,500,421,0.00140440
+Merge Sort In-Place,500,422,0.00127590
+Merge Sort In-Place,500,423,0.00105400
+Merge Sort In-Place,500,424,0.00128280
+Merge Sort In-Place,500,425,0.00155840
+Merge Sort In-Place,500,426,0.00121490
+Merge Sort In-Place,500,427,0.00144590
+Merge Sort In-Place,500,428,0.00114060
+Merge Sort In-Place,500,429,0.00174250
+Merge Sort In-Place,500,430,0.00106990
+Merge Sort In-Place,500,431,0.00188560
+Merge Sort In-Place,500,432,0.00101140
+Merge Sort In-Place,500,433,0.00188250
+Merge Sort In-Place,500,434,0.00182410
+Merge Sort In-Place,500,435,0.00174500
+Merge Sort In-Place,500,436,0.00155380
+Merge Sort In-Place,500,437,0.00178510
+Merge Sort In-Place,500,438,0.00180220
+Merge Sort In-Place,500,439,0.00174390
+Merge Sort In-Place,500,440,0.00161110
+Merge Sort In-Place,500,441,0.00179510
+Merge Sort In-Place,500,442,0.00144380
+Merge Sort In-Place,500,443,0.00182690
+Merge Sort In-Place,500,444,0.00104270
+Merge Sort In-Place,500,445,0.00166480
+Merge Sort In-Place,500,446,0.00183800
+Merge Sort In-Place,500,447,0.00127530
+Merge Sort In-Place,500,448,0.00179910
+Merge Sort In-Place,500,449,0.00173660
+Merge Sort In-Place,500,450,0.00183920
+Merge Sort In-Place,500,451,0.00182410
+Merge Sort In-Place,500,452,0.00122930
+Merge Sort In-Place,500,453,0.00165820
+Merge Sort In-Place,500,454,0.00168820
+Merge Sort In-Place,500,455,0.00160730
+Merge Sort In-Place,500,456,0.00166250
+Merge Sort In-Place,500,457,0.00133930
+Merge Sort In-Place,500,458,0.00149690
+Merge Sort In-Place,500,459,0.00174010
+Merge Sort In-Place,500,460,0.00161300
+Merge Sort In-Place,500,461,0.00157900
+Merge Sort In-Place,500,462,0.00117790
+Merge Sort In-Place,500,463,0.00172570
+Merge Sort In-Place,500,464,0.00179130
+Merge Sort In-Place,500,465,0.00125210
+Merge Sort In-Place,500,466,0.00139690
+Merge Sort In-Place,500,467,0.00183290
+Merge Sort In-Place,500,468,0.00156620
+Merge Sort In-Place,500,469,0.00107960
+Merge Sort In-Place,500,470,0.00178660
+Merge Sort In-Place,500,471,0.00178100
+Merge Sort In-Place,500,472,0.00147840
+Merge Sort In-Place,500,473,0.00128620
+Merge Sort In-Place,500,474,0.00172910
+Merge Sort In-Place,500,475,0.00144400
+Merge Sort In-Place,500,476,0.00177320
+Merge Sort In-Place,500,477,0.00123360
+Merge Sort In-Place,500,478,0.00105330
+Merge Sort In-Place,500,479,0.00102960
+Merge Sort In-Place,500,480,0.00173730
+Merge Sort In-Place,500,481,0.00141150
+Merge Sort In-Place,500,482,0.00105500
+Merge Sort In-Place,500,483,0.00147820
+Merge Sort In-Place,500,484,0.00107690
+Merge Sort In-Place,500,485,0.00182310
+Merge Sort In-Place,500,486,0.00171950
+Merge Sort In-Place,500,487,0.00126960
+Merge Sort In-Place,500,488,0.00141630
+Merge Sort In-Place,500,489,0.00103770
+Merge Sort In-Place,500,490,0.00174650
+Merge Sort In-Place,500,491,0.00144020
+Merge Sort In-Place,500,492,0.00151880
+Merge Sort In-Place,500,493,0.00163780
+Merge Sort In-Place,500,494,0.00176110
+Merge Sort In-Place,500,495,0.00131700
+Merge Sort In-Place,500,496,0.00121550
+Merge Sort In-Place,500,497,0.00184530
+Merge Sort In-Place,500,498,0.00148070
+Merge Sort In-Place,500,499,0.00176780
+Merge Sort In-Place,500,500,0.00178270
+Odd-Even Sort,500,1,0.01507260
+Odd-Even Sort,500,2,0.01443900
+Odd-Even Sort,500,3,0.01309850
+Odd-Even Sort,500,4,0.01522470
+Odd-Even Sort,500,5,0.01063210
+Odd-Even Sort,500,6,0.01433480
+Odd-Even Sort,500,7,0.01363290
+Odd-Even Sort,500,8,0.01275220
+Odd-Even Sort,500,9,0.01445700
+Odd-Even Sort,500,10,0.01235520
+Odd-Even Sort,500,11,0.01385040
+Odd-Even Sort,500,12,0.01311460
+Odd-Even Sort,500,13,0.01583880
+Odd-Even Sort,500,14,0.01413210
+Odd-Even Sort,500,15,0.01082300
+Odd-Even Sort,500,16,0.01237190
+Odd-Even Sort,500,17,0.01171980
+Odd-Even Sort,500,18,0.01437760
+Odd-Even Sort,500,19,0.01414170
+Odd-Even Sort,500,20,0.01425660
+Odd-Even Sort,500,21,0.01342760
+Odd-Even Sort,500,22,0.01541770
+Odd-Even Sort,500,23,0.01431240
+Odd-Even Sort,500,24,0.01336540
+Odd-Even Sort,500,25,0.01384810
+Odd-Even Sort,500,26,0.01288640
+Odd-Even Sort,500,27,0.01425540
+Odd-Even Sort,500,28,0.01565980
+Odd-Even Sort,500,29,0.01448350
+Odd-Even Sort,500,30,0.01280950
+Odd-Even Sort,500,31,0.01301530
+Odd-Even Sort,500,32,0.01515070
+Odd-Even Sort,500,33,0.01421320
+Odd-Even Sort,500,34,0.01478240
+Odd-Even Sort,500,35,0.01558110
+Odd-Even Sort,500,36,0.01282750
+Odd-Even Sort,500,37,0.01299550
+Odd-Even Sort,500,38,0.01376100
+Odd-Even Sort,500,39,0.01202790
+Odd-Even Sort,500,40,0.01514940
+Odd-Even Sort,500,41,0.01030810
+Odd-Even Sort,500,42,0.01393160
+Odd-Even Sort,500,43,0.01515640
+Odd-Even Sort,500,44,0.01582770
+Odd-Even Sort,500,45,0.01410230
+Odd-Even Sort,500,46,0.01150180
+Odd-Even Sort,500,47,0.01091710
+Odd-Even Sort,500,48,0.01338570
+Odd-Even Sort,500,49,0.01540550
+Odd-Even Sort,500,50,0.01383230
+Odd-Even Sort,500,51,0.01459190
+Odd-Even Sort,500,52,0.01217090
+Odd-Even Sort,500,53,0.01046350
+Odd-Even Sort,500,54,0.01161320
+Odd-Even Sort,500,55,0.01303710
+Odd-Even Sort,500,56,0.01251700
+Odd-Even Sort,500,57,0.01417950
+Odd-Even Sort,500,58,0.01209430
+Odd-Even Sort,500,59,0.01261020
+Odd-Even Sort,500,60,0.01332900
+Odd-Even Sort,500,61,0.01289720
+Odd-Even Sort,500,62,0.01312930
+Odd-Even Sort,500,63,0.01577270
+Odd-Even Sort,500,64,0.01442160
+Odd-Even Sort,500,65,0.01361470
+Odd-Even Sort,500,66,0.01347680
+Odd-Even Sort,500,67,0.01444130
+Odd-Even Sort,500,68,0.01500830
+Odd-Even Sort,500,69,0.01276220
+Odd-Even Sort,500,70,0.01517960
+Odd-Even Sort,500,71,0.01449820
+Odd-Even Sort,500,72,0.01674560
+Odd-Even Sort,500,73,0.01290110
+Odd-Even Sort,500,74,0.01497700
+Odd-Even Sort,500,75,0.01668180
+Odd-Even Sort,500,76,0.01567330
+Odd-Even Sort,500,77,0.01491990
+Odd-Even Sort,500,78,0.01562350
+Odd-Even Sort,500,79,0.01301830
+Odd-Even Sort,500,80,0.01262850
+Odd-Even Sort,500,81,0.01416880
+Odd-Even Sort,500,82,0.01171540
+Odd-Even Sort,500,83,0.01200530
+Odd-Even Sort,500,84,0.01313380
+Odd-Even Sort,500,85,0.01155790
+Odd-Even Sort,500,86,0.01342610
+Odd-Even Sort,500,87,0.01353670
+Odd-Even Sort,500,88,0.01102120
+Odd-Even Sort,500,89,0.01683980
+Odd-Even Sort,500,90,0.01078030
+Odd-Even Sort,500,91,0.01454630
+Odd-Even Sort,500,92,0.01395560
+Odd-Even Sort,500,93,0.01400380
+Odd-Even Sort,500,94,0.01168410
+Odd-Even Sort,500,95,0.01366180
+Odd-Even Sort,500,96,0.01376840
+Odd-Even Sort,500,97,0.01336940
+Odd-Even Sort,500,98,0.01476850
+Odd-Even Sort,500,99,0.01368630
+Odd-Even Sort,500,100,0.01182310
+Odd-Even Sort,500,101,0.01503040
+Odd-Even Sort,500,102,0.01424210
+Odd-Even Sort,500,103,0.01551930
+Odd-Even Sort,500,104,0.01410340
+Odd-Even Sort,500,105,0.01372390
+Odd-Even Sort,500,106,0.01528850
+Odd-Even Sort,500,107,0.01560600
+Odd-Even Sort,500,108,0.01615590
+Odd-Even Sort,500,109,0.01730280
+Odd-Even Sort,500,110,0.01554100
+Odd-Even Sort,500,111,0.01738360
+Odd-Even Sort,500,112,0.01652500
+Odd-Even Sort,500,113,0.01713600
+Odd-Even Sort,500,114,0.01497680
+Odd-Even Sort,500,115,0.01456930
+Odd-Even Sort,500,116,0.01515840
+Odd-Even Sort,500,117,0.01463930
+Odd-Even Sort,500,118,0.01600170
+Odd-Even Sort,500,119,0.01537020
+Odd-Even Sort,500,120,0.01614040
+Odd-Even Sort,500,121,0.01439670
+Odd-Even Sort,500,122,0.01479830
+Odd-Even Sort,500,123,0.01553910
+Odd-Even Sort,500,124,0.01665770
+Odd-Even Sort,500,125,0.01564470
+Odd-Even Sort,500,126,0.01734370
+Odd-Even Sort,500,127,0.01519940
+Odd-Even Sort,500,128,0.01599300
+Odd-Even Sort,500,129,0.01550160
+Odd-Even Sort,500,130,0.01570950
+Odd-Even Sort,500,131,0.01625970
+Odd-Even Sort,500,132,0.01479530
+Odd-Even Sort,500,133,0.01513600
+Odd-Even Sort,500,134,0.01494330
+Odd-Even Sort,500,135,0.01333540
+Odd-Even Sort,500,136,0.01424770
+Odd-Even Sort,500,137,0.01082990
+Odd-Even Sort,500,138,0.01454720
+Odd-Even Sort,500,139,0.01423310
+Odd-Even Sort,500,140,0.01531490
+Odd-Even Sort,500,141,0.01249490
+Odd-Even Sort,500,142,0.01474250
+Odd-Even Sort,500,143,0.01232470
+Odd-Even Sort,500,144,0.01309210
+Odd-Even Sort,500,145,0.01181470
+Odd-Even Sort,500,146,0.01613320
+Odd-Even Sort,500,147,0.01425810
+Odd-Even Sort,500,148,0.01364840
+Odd-Even Sort,500,149,0.01380410
+Odd-Even Sort,500,150,0.01545600
+Odd-Even Sort,500,151,0.01546170
+Odd-Even Sort,500,152,0.01194810
+Odd-Even Sort,500,153,0.01232180
+Odd-Even Sort,500,154,0.01290870
+Odd-Even Sort,500,155,0.01281800
+Odd-Even Sort,500,156,0.01427580
+Odd-Even Sort,500,157,0.01168600
+Odd-Even Sort,500,158,0.01554740
+Odd-Even Sort,500,159,0.01327250
+Odd-Even Sort,500,160,0.01579670
+Odd-Even Sort,500,161,0.01079470
+Odd-Even Sort,500,162,0.01241910
+Odd-Even Sort,500,163,0.01254900
+Odd-Even Sort,500,164,0.01599810
+Odd-Even Sort,500,165,0.01398360
+Odd-Even Sort,500,166,0.01434960
+Odd-Even Sort,500,167,0.01361000
+Odd-Even Sort,500,168,0.01488200
+Odd-Even Sort,500,169,0.01296800
+Odd-Even Sort,500,170,0.01248740
+Odd-Even Sort,500,171,0.01492510
+Odd-Even Sort,500,172,0.01219970
+Odd-Even Sort,500,173,0.01466130
+Odd-Even Sort,500,174,0.01645640
+Odd-Even Sort,500,175,0.01382000
+Odd-Even Sort,500,176,0.01553150
+Odd-Even Sort,500,177,0.01423010
+Odd-Even Sort,500,178,0.01249870
+Odd-Even Sort,500,179,0.01313060
+Odd-Even Sort,500,180,0.01226050
+Odd-Even Sort,500,181,0.01307180
+Odd-Even Sort,500,182,0.01297330
+Odd-Even Sort,500,183,0.01134170
+Odd-Even Sort,500,184,0.01405270
+Odd-Even Sort,500,185,0.01327810
+Odd-Even Sort,500,186,0.01313240
+Odd-Even Sort,500,187,0.01107370
+Odd-Even Sort,500,188,0.01471410
+Odd-Even Sort,500,189,0.01338120
+Odd-Even Sort,500,190,0.01450980
+Odd-Even Sort,500,191,0.01175330
+Odd-Even Sort,500,192,0.01271450
+Odd-Even Sort,500,193,0.01297750
+Odd-Even Sort,500,194,0.01507900
+Odd-Even Sort,500,195,0.01445100
+Odd-Even Sort,500,196,0.01354680
+Odd-Even Sort,500,197,0.01311960
+Odd-Even Sort,500,198,0.01310250
+Odd-Even Sort,500,199,0.01334590
+Odd-Even Sort,500,200,0.01595100
+Odd-Even Sort,500,201,0.01558410
+Odd-Even Sort,500,202,0.01482670
+Odd-Even Sort,500,203,0.01265830
+Odd-Even Sort,500,204,0.01343390
+Odd-Even Sort,500,205,0.01424850
+Odd-Even Sort,500,206,0.01470140
+Odd-Even Sort,500,207,0.01448240
+Odd-Even Sort,500,208,0.01450760
+Odd-Even Sort,500,209,0.01150070
+Odd-Even Sort,500,210,0.01357200
+Odd-Even Sort,500,211,0.01254780
+Odd-Even Sort,500,212,0.01283320
+Odd-Even Sort,500,213,0.01470140
+Odd-Even Sort,500,214,0.01366260
+Odd-Even Sort,500,215,0.01396210
+Odd-Even Sort,500,216,0.01586580
+Odd-Even Sort,500,217,0.01442150
+Odd-Even Sort,500,218,0.01061230
+Odd-Even Sort,500,219,0.01547850
+Odd-Even Sort,500,220,0.01470230
+Odd-Even Sort,500,221,0.01702360
+Odd-Even Sort,500,222,0.01251920
+Odd-Even Sort,500,223,0.01406070
+Odd-Even Sort,500,224,0.01491470
+Odd-Even Sort,500,225,0.01525650
+Odd-Even Sort,500,226,0.01574300
+Odd-Even Sort,500,227,0.01426420
+Odd-Even Sort,500,228,0.01249860
+Odd-Even Sort,500,229,0.01266050
+Odd-Even Sort,500,230,0.01320760
+Odd-Even Sort,500,231,0.01195790
+Odd-Even Sort,500,232,0.01198510
+Odd-Even Sort,500,233,0.01250030
+Odd-Even Sort,500,234,0.01326090
+Odd-Even Sort,500,235,0.01243480
+Odd-Even Sort,500,236,0.01427080
+Odd-Even Sort,500,237,0.01192230
+Odd-Even Sort,500,238,0.01286410
+Odd-Even Sort,500,239,0.01200770
+Odd-Even Sort,500,240,0.01171780
+Odd-Even Sort,500,241,0.01442640
+Odd-Even Sort,500,242,0.01443560
+Odd-Even Sort,500,243,0.01672130
+Odd-Even Sort,500,244,0.01316550
+Odd-Even Sort,500,245,0.01436290
+Odd-Even Sort,500,246,0.01696610
+Odd-Even Sort,500,247,0.01413290
+Odd-Even Sort,500,248,0.01214540
+Odd-Even Sort,500,249,0.01478900
+Odd-Even Sort,500,250,0.01310390
+Odd-Even Sort,500,251,0.01226820
+Odd-Even Sort,500,252,0.01407660
+Odd-Even Sort,500,253,0.01316260
+Odd-Even Sort,500,254,0.01397930
+Odd-Even Sort,500,255,0.01098060
+Odd-Even Sort,500,256,0.01518640
+Odd-Even Sort,500,257,0.01050360
+Odd-Even Sort,500,258,0.01215270
+Odd-Even Sort,500,259,0.01386270
+Odd-Even Sort,500,260,0.01097770
+Odd-Even Sort,500,261,0.01429950
+Odd-Even Sort,500,262,0.01414350
+Odd-Even Sort,500,263,0.01299980
+Odd-Even Sort,500,264,0.01132620
+Odd-Even Sort,500,265,0.01431080
+Odd-Even Sort,500,266,0.00979170
+Odd-Even Sort,500,267,0.01477240
+Odd-Even Sort,500,268,0.01449330
+Odd-Even Sort,500,269,0.01565930
+Odd-Even Sort,500,270,0.01244810
+Odd-Even Sort,500,271,0.01355630
+Odd-Even Sort,500,272,0.01486020
+Odd-Even Sort,500,273,0.01625310
+Odd-Even Sort,500,274,0.01308490
+Odd-Even Sort,500,275,0.01307030
+Odd-Even Sort,500,276,0.01454110
+Odd-Even Sort,500,277,0.01469010
+Odd-Even Sort,500,278,0.01171760
+Odd-Even Sort,500,279,0.01208070
+Odd-Even Sort,500,280,0.01211480
+Odd-Even Sort,500,281,0.01525050
+Odd-Even Sort,500,282,0.01372820
+Odd-Even Sort,500,283,0.01425830
+Odd-Even Sort,500,284,0.01313140
+Odd-Even Sort,500,285,0.01350980
+Odd-Even Sort,500,286,0.01349620
+Odd-Even Sort,500,287,0.01323210
+Odd-Even Sort,500,288,0.01153080
+Odd-Even Sort,500,289,0.01216370
+Odd-Even Sort,500,290,0.01209610
+Odd-Even Sort,500,291,0.01440290
+Odd-Even Sort,500,292,0.01032200
+Odd-Even Sort,500,293,0.01223360
+Odd-Even Sort,500,294,0.01402890
+Odd-Even Sort,500,295,0.00975830
+Odd-Even Sort,500,296,0.01284360
+Odd-Even Sort,500,297,0.01467530
+Odd-Even Sort,500,298,0.01382600
+Odd-Even Sort,500,299,0.01272560
+Odd-Even Sort,500,300,0.01408700
+Odd-Even Sort,500,301,0.01412040
+Odd-Even Sort,500,302,0.01276270
+Odd-Even Sort,500,303,0.01398860
+Odd-Even Sort,500,304,0.01155420
+Odd-Even Sort,500,305,0.01112960
+Odd-Even Sort,500,306,0.01095930
+Odd-Even Sort,500,307,0.01593810
+Odd-Even Sort,500,308,0.01325030
+Odd-Even Sort,500,309,0.01383330
+Odd-Even Sort,500,310,0.01144030
+Odd-Even Sort,500,311,0.01163200
+Odd-Even Sort,500,312,0.01224270
+Odd-Even Sort,500,313,0.01365890
+Odd-Even Sort,500,314,0.01176740
+Odd-Even Sort,500,315,0.01367150
+Odd-Even Sort,500,316,0.01367580
+Odd-Even Sort,500,317,0.01232710
+Odd-Even Sort,500,318,0.01520850
+Odd-Even Sort,500,319,0.01475810
+Odd-Even Sort,500,320,0.01631890
+Odd-Even Sort,500,321,0.01466250
+Odd-Even Sort,500,322,0.01403850
+Odd-Even Sort,500,323,0.01508390
+Odd-Even Sort,500,324,0.01327940
+Odd-Even Sort,500,325,0.01425360
+Odd-Even Sort,500,326,0.01324570
+Odd-Even Sort,500,327,0.01202970
+Odd-Even Sort,500,328,0.01364630
+Odd-Even Sort,500,329,0.01465020
+Odd-Even Sort,500,330,0.01242240
+Odd-Even Sort,500,331,0.01387550
+Odd-Even Sort,500,332,0.01482680
+Odd-Even Sort,500,333,0.01466690
+Odd-Even Sort,500,334,0.01342480
+Odd-Even Sort,500,335,0.01320740
+Odd-Even Sort,500,336,0.01638490
+Odd-Even Sort,500,337,0.01395790
+Odd-Even Sort,500,338,0.01160090
+Odd-Even Sort,500,339,0.01490800
+Odd-Even Sort,500,340,0.01299530
+Odd-Even Sort,500,341,0.01167900
+Odd-Even Sort,500,342,0.01362950
+Odd-Even Sort,500,343,0.01199210
+Odd-Even Sort,500,344,0.01456960
+Odd-Even Sort,500,345,0.01633150
+Odd-Even Sort,500,346,0.01441220
+Odd-Even Sort,500,347,0.01289360
+Odd-Even Sort,500,348,0.01438340
+Odd-Even Sort,500,349,0.01435580
+Odd-Even Sort,500,350,0.01295900
+Odd-Even Sort,500,351,0.01213970
+Odd-Even Sort,500,352,0.01301720
+Odd-Even Sort,500,353,0.01426940
+Odd-Even Sort,500,354,0.01291070
+Odd-Even Sort,500,355,0.01366470
+Odd-Even Sort,500,356,0.01369450
+Odd-Even Sort,500,357,0.01387370
+Odd-Even Sort,500,358,0.01402420
+Odd-Even Sort,500,359,0.01474530
+Odd-Even Sort,500,360,0.01320570
+Odd-Even Sort,500,361,0.01393820
+Odd-Even Sort,500,362,0.01496680
+Odd-Even Sort,500,363,0.01442730
+Odd-Even Sort,500,364,0.01494110
+Odd-Even Sort,500,365,0.01421330
+Odd-Even Sort,500,366,0.01279180
+Odd-Even Sort,500,367,0.01503720
+Odd-Even Sort,500,368,0.01205320
+Odd-Even Sort,500,369,0.01355430
+Odd-Even Sort,500,370,0.01589640
+Odd-Even Sort,500,371,0.01491830
+Odd-Even Sort,500,372,0.01455770
+Odd-Even Sort,500,373,0.01347930
+Odd-Even Sort,500,374,0.01265870
+Odd-Even Sort,500,375,0.01339690
+Odd-Even Sort,500,376,0.01450340
+Odd-Even Sort,500,377,0.01560930
+Odd-Even Sort,500,378,0.01340920
+Odd-Even Sort,500,379,0.01248400
+Odd-Even Sort,500,380,0.01475960
+Odd-Even Sort,500,381,0.01529630
+Odd-Even Sort,500,382,0.01461890
+Odd-Even Sort,500,383,0.01620810
+Odd-Even Sort,500,384,0.01519180
+Odd-Even Sort,500,385,0.01530110
+Odd-Even Sort,500,386,0.01366870
+Odd-Even Sort,500,387,0.01534700
+Odd-Even Sort,500,388,0.01491090
+Odd-Even Sort,500,389,0.01316720
+Odd-Even Sort,500,390,0.01224790
+Odd-Even Sort,500,391,0.01405010
+Odd-Even Sort,500,392,0.01505360
+Odd-Even Sort,500,393,0.01540140
+Odd-Even Sort,500,394,0.01394890
+Odd-Even Sort,500,395,0.01200540
+Odd-Even Sort,500,396,0.01237050
+Odd-Even Sort,500,397,0.01478580
+Odd-Even Sort,500,398,0.01351710
+Odd-Even Sort,500,399,0.00968090
+Odd-Even Sort,500,400,0.01093790
+Odd-Even Sort,500,401,0.01461190
+Odd-Even Sort,500,402,0.01195640
+Odd-Even Sort,500,403,0.01164820
+Odd-Even Sort,500,404,0.01447400
+Odd-Even Sort,500,405,0.01493000
+Odd-Even Sort,500,406,0.01195010
+Odd-Even Sort,500,407,0.01347910
+Odd-Even Sort,500,408,0.01268250
+Odd-Even Sort,500,409,0.01457580
+Odd-Even Sort,500,410,0.01054670
+Odd-Even Sort,500,411,0.01332450
+Odd-Even Sort,500,412,0.01143430
+Odd-Even Sort,500,413,0.01503260
+Odd-Even Sort,500,414,0.01545290
+Odd-Even Sort,500,415,0.01192790
+Odd-Even Sort,500,416,0.01465670
+Odd-Even Sort,500,417,0.01586480
+Odd-Even Sort,500,418,0.01584500
+Odd-Even Sort,500,419,0.01425590
+Odd-Even Sort,500,420,0.01550040
+Odd-Even Sort,500,421,0.01331140
+Odd-Even Sort,500,422,0.01426200
+Odd-Even Sort,500,423,0.01480430
+Odd-Even Sort,500,424,0.01565800
+Odd-Even Sort,500,425,0.01220530
+Odd-Even Sort,500,426,0.01284710
+Odd-Even Sort,500,427,0.01577810
+Odd-Even Sort,500,428,0.01541570
+Odd-Even Sort,500,429,0.01588720
+Odd-Even Sort,500,430,0.01660930
+Odd-Even Sort,500,431,0.01635690
+Odd-Even Sort,500,432,0.01723030
+Odd-Even Sort,500,433,0.01600940
+Odd-Even Sort,500,434,0.01622700
+Odd-Even Sort,500,435,0.01545670
+Odd-Even Sort,500,436,0.01481500
+Odd-Even Sort,500,437,0.01170050
+Odd-Even Sort,500,438,0.01471520
+Odd-Even Sort,500,439,0.01531590
+Odd-Even Sort,500,440,0.01384130
+Odd-Even Sort,500,441,0.01372490
+Odd-Even Sort,500,442,0.01466130
+Odd-Even Sort,500,443,0.01005670
+Odd-Even Sort,500,444,0.01198220
+Odd-Even Sort,500,445,0.01287100
+Odd-Even Sort,500,446,0.01124200
+Odd-Even Sort,500,447,0.01285590
+Odd-Even Sort,500,448,0.01285230
+Odd-Even Sort,500,449,0.01153050
+Odd-Even Sort,500,450,0.01263810
+Odd-Even Sort,500,451,0.01272520
+Odd-Even Sort,500,452,0.01178880
+Odd-Even Sort,500,453,0.01252740
+Odd-Even Sort,500,454,0.01255980
+Odd-Even Sort,500,455,0.01027910
+Odd-Even Sort,500,456,0.01083720
+Odd-Even Sort,500,457,0.01171220
+Odd-Even Sort,500,458,0.01402830
+Odd-Even Sort,500,459,0.01156060
+Odd-Even Sort,500,460,0.01198750
+Odd-Even Sort,500,461,0.01178260
+Odd-Even Sort,500,462,0.01326600
+Odd-Even Sort,500,463,0.01088110
+Odd-Even Sort,500,464,0.01284760
+Odd-Even Sort,500,465,0.01375020
+Odd-Even Sort,500,466,0.01474010
+Odd-Even Sort,500,467,0.01120360
+Odd-Even Sort,500,468,0.01574230
+Odd-Even Sort,500,469,0.01429350
+Odd-Even Sort,500,470,0.01408150
+Odd-Even Sort,500,471,0.01199020
+Odd-Even Sort,500,472,0.01353620
+Odd-Even Sort,500,473,0.01349500
+Odd-Even Sort,500,474,0.01389210
+Odd-Even Sort,500,475,0.01414380
+Odd-Even Sort,500,476,0.01362000
+Odd-Even Sort,500,477,0.01428620
+Odd-Even Sort,500,478,0.01573830
+Odd-Even Sort,500,479,0.01131040
+Odd-Even Sort,500,480,0.01389130
+Odd-Even Sort,500,481,0.01341310
+Odd-Even Sort,500,482,0.01493800
+Odd-Even Sort,500,483,0.01389150
+Odd-Even Sort,500,484,0.01542490
+Odd-Even Sort,500,485,0.01413670
+Odd-Even Sort,500,486,0.01499700
+Odd-Even Sort,500,487,0.01257650
+Odd-Even Sort,500,488,0.01459270
+Odd-Even Sort,500,489,0.01165000
+Odd-Even Sort,500,490,0.01387480
+Odd-Even Sort,500,491,0.01376020
+Odd-Even Sort,500,492,0.01262360
+Odd-Even Sort,500,493,0.01489650
+Odd-Even Sort,500,494,0.01136400
+Odd-Even Sort,500,495,0.01359420
+Odd-Even Sort,500,496,0.01472190
+Odd-Even Sort,500,497,0.01398540
+Odd-Even Sort,500,498,0.01231600
+Odd-Even Sort,500,499,0.01243730
+Odd-Even Sort,500,500,0.01211810
+Pancake Sort,500,1,0.00882910
+Pancake Sort,500,2,0.00814210
+Pancake Sort,500,3,0.00971540
+Pancake Sort,500,4,0.00941530
+Pancake Sort,500,5,0.00947690
+Pancake Sort,500,6,0.01093870
+Pancake Sort,500,7,0.00761460
+Pancake Sort,500,8,0.00793060
+Pancake Sort,500,9,0.01002420
+Pancake Sort,500,10,0.01000290
+Pancake Sort,500,11,0.01070090
+Pancake Sort,500,12,0.00858400
+Pancake Sort,500,13,0.01081480
+Pancake Sort,500,14,0.00932710
+Pancake Sort,500,15,0.00928070
+Pancake Sort,500,16,0.01147640
+Pancake Sort,500,17,0.00808350
+Pancake Sort,500,18,0.01000970
+Pancake Sort,500,19,0.01141120
+Pancake Sort,500,20,0.00806090
+Pancake Sort,500,21,0.01015190
+Pancake Sort,500,22,0.01116410
+Pancake Sort,500,23,0.00903780
+Pancake Sort,500,24,0.01069880
+Pancake Sort,500,25,0.01124490
+Pancake Sort,500,26,0.00972080
+Pancake Sort,500,27,0.01081600
+Pancake Sort,500,28,0.00921490
+Pancake Sort,500,29,0.00930150
+Pancake Sort,500,30,0.00831620
+Pancake Sort,500,31,0.00921460
+Pancake Sort,500,32,0.00900980
+Pancake Sort,500,33,0.00952440
+Pancake Sort,500,34,0.00953770
+Pancake Sort,500,35,0.00992530
+Pancake Sort,500,36,0.00945190
+Pancake Sort,500,37,0.01115610
+Pancake Sort,500,38,0.01022010
+Pancake Sort,500,39,0.01104330
+Pancake Sort,500,40,0.01041150
+Pancake Sort,500,41,0.01040170
+Pancake Sort,500,42,0.01101420
+Pancake Sort,500,43,0.01163210
+Pancake Sort,500,44,0.00993900
+Pancake Sort,500,45,0.00822540
+Pancake Sort,500,46,0.01030600
+Pancake Sort,500,47,0.00812340
+Pancake Sort,500,48,0.00998760
+Pancake Sort,500,49,0.01119830
+Pancake Sort,500,50,0.00867100
+Pancake Sort,500,51,0.01043460
+Pancake Sort,500,52,0.00911640
+Pancake Sort,500,53,0.01093750
+Pancake Sort,500,54,0.00875860
+Pancake Sort,500,55,0.00935750
+Pancake Sort,500,56,0.00841320
+Pancake Sort,500,57,0.00864710
+Pancake Sort,500,58,0.01156850
+Pancake Sort,500,59,0.00818100
+Pancake Sort,500,60,0.00674640
+Pancake Sort,500,61,0.00918550
+Pancake Sort,500,62,0.01000610
+Pancake Sort,500,63,0.01077630
+Pancake Sort,500,64,0.00890260
+Pancake Sort,500,65,0.00750810
+Pancake Sort,500,66,0.00851130
+Pancake Sort,500,67,0.00941880
+Pancake Sort,500,68,0.00970320
+Pancake Sort,500,69,0.00953480
+Pancake Sort,500,70,0.00865120
+Pancake Sort,500,71,0.00868070
+Pancake Sort,500,72,0.00749920
+Pancake Sort,500,73,0.00783730
+Pancake Sort,500,74,0.01011990
+Pancake Sort,500,75,0.00885410
+Pancake Sort,500,76,0.01021260
+Pancake Sort,500,77,0.00998220
+Pancake Sort,500,78,0.00977260
+Pancake Sort,500,79,0.00966800
+Pancake Sort,500,80,0.00959140
+Pancake Sort,500,81,0.00833500
+Pancake Sort,500,82,0.00938860
+Pancake Sort,500,83,0.00910170
+Pancake Sort,500,84,0.01077670
+Pancake Sort,500,85,0.00920060
+Pancake Sort,500,86,0.00887680
+Pancake Sort,500,87,0.01075180
+Pancake Sort,500,88,0.00733800
+Pancake Sort,500,89,0.00807020
+Pancake Sort,500,90,0.00864940
+Pancake Sort,500,91,0.00742590
+Pancake Sort,500,92,0.01053120
+Pancake Sort,500,93,0.01003720
+Pancake Sort,500,94,0.00823900
+Pancake Sort,500,95,0.00863390
+Pancake Sort,500,96,0.01019010
+Pancake Sort,500,97,0.00947490
+Pancake Sort,500,98,0.00775320
+Pancake Sort,500,99,0.01161140
+Pancake Sort,500,100,0.00867550
+Pancake Sort,500,101,0.00822310
+Pancake Sort,500,102,0.00984980
+Pancake Sort,500,103,0.01088950
+Pancake Sort,500,104,0.00795570
+Pancake Sort,500,105,0.00825710
+Pancake Sort,500,106,0.00906620
+Pancake Sort,500,107,0.01021760
+Pancake Sort,500,108,0.00997240
+Pancake Sort,500,109,0.00915720
+Pancake Sort,500,110,0.00903160
+Pancake Sort,500,111,0.01159350
+Pancake Sort,500,112,0.00863560
+Pancake Sort,500,113,0.01227650
+Pancake Sort,500,114,0.01013490
+Pancake Sort,500,115,0.01160450
+Pancake Sort,500,116,0.01139720
+Pancake Sort,500,117,0.01150130
+Pancake Sort,500,118,0.00963180
+Pancake Sort,500,119,0.01110880
+Pancake Sort,500,120,0.00929150
+Pancake Sort,500,121,0.01076990
+Pancake Sort,500,122,0.00984410
+Pancake Sort,500,123,0.00978790
+Pancake Sort,500,124,0.00988360
+Pancake Sort,500,125,0.00966040
+Pancake Sort,500,126,0.00863140
+Pancake Sort,500,127,0.00707210
+Pancake Sort,500,128,0.00782010
+Pancake Sort,500,129,0.00725930
+Pancake Sort,500,130,0.01079560
+Pancake Sort,500,131,0.00843160
+Pancake Sort,500,132,0.00865580
+Pancake Sort,500,133,0.00807490
+Pancake Sort,500,134,0.00987910
+Pancake Sort,500,135,0.00904050
+Pancake Sort,500,136,0.00925850
+Pancake Sort,500,137,0.00889530
+Pancake Sort,500,138,0.00890970
+Pancake Sort,500,139,0.01079280
+Pancake Sort,500,140,0.01036730
+Pancake Sort,500,141,0.00747280
+Pancake Sort,500,142,0.00827440
+Pancake Sort,500,143,0.01012630
+Pancake Sort,500,144,0.00923800
+Pancake Sort,500,145,0.01094230
+Pancake Sort,500,146,0.00980340
+Pancake Sort,500,147,0.01141640
+Pancake Sort,500,148,0.01102700
+Pancake Sort,500,149,0.01049730
+Pancake Sort,500,150,0.01099060
+Pancake Sort,500,151,0.01137080
+Pancake Sort,500,152,0.01028750
+Pancake Sort,500,153,0.01051550
+Pancake Sort,500,154,0.01022850
+Pancake Sort,500,155,0.00769480
+Pancake Sort,500,156,0.01087000
+Pancake Sort,500,157,0.00962890
+Pancake Sort,500,158,0.00959130
+Pancake Sort,500,159,0.00893680
+Pancake Sort,500,160,0.00723790
+Pancake Sort,500,161,0.00741600
+Pancake Sort,500,162,0.00907150
+Pancake Sort,500,163,0.00987290
+Pancake Sort,500,164,0.01106160
+Pancake Sort,500,165,0.00886980
+Pancake Sort,500,166,0.00957780
+Pancake Sort,500,167,0.00898900
+Pancake Sort,500,168,0.01132350
+Pancake Sort,500,169,0.01111340
+Pancake Sort,500,170,0.00792890
+Pancake Sort,500,171,0.01111370
+Pancake Sort,500,172,0.00980590
+Pancake Sort,500,173,0.01032010
+Pancake Sort,500,174,0.01129190
+Pancake Sort,500,175,0.01090760
+Pancake Sort,500,176,0.00875230
+Pancake Sort,500,177,0.01173320
+Pancake Sort,500,178,0.01120150
+Pancake Sort,500,179,0.00855240
+Pancake Sort,500,180,0.00985540
+Pancake Sort,500,181,0.01132080
+Pancake Sort,500,182,0.01068120
+Pancake Sort,500,183,0.01108540
+Pancake Sort,500,184,0.01151570
+Pancake Sort,500,185,0.00853050
+Pancake Sort,500,186,0.00945830
+Pancake Sort,500,187,0.00863510
+Pancake Sort,500,188,0.01016240
+Pancake Sort,500,189,0.00810200
+Pancake Sort,500,190,0.00923770
+Pancake Sort,500,191,0.00994730
+Pancake Sort,500,192,0.01065170
+Pancake Sort,500,193,0.01107130
+Pancake Sort,500,194,0.01071260
+Pancake Sort,500,195,0.01052230
+Pancake Sort,500,196,0.01103610
+Pancake Sort,500,197,0.01114570
+Pancake Sort,500,198,0.01047840
+Pancake Sort,500,199,0.01106690
+Pancake Sort,500,200,0.00934020
+Pancake Sort,500,201,0.01021410
+Pancake Sort,500,202,0.00872960
+Pancake Sort,500,203,0.00854370
+Pancake Sort,500,204,0.00944840
+Pancake Sort,500,205,0.00775690
+Pancake Sort,500,206,0.00982880
+Pancake Sort,500,207,0.00905650
+Pancake Sort,500,208,0.00845090
+Pancake Sort,500,209,0.00886090
+Pancake Sort,500,210,0.01089280
+Pancake Sort,500,211,0.00981580
+Pancake Sort,500,212,0.00918610
+Pancake Sort,500,213,0.01113050
+Pancake Sort,500,214,0.00849920
+Pancake Sort,500,215,0.00843750
+Pancake Sort,500,216,0.00828650
+Pancake Sort,500,217,0.01016910
+Pancake Sort,500,218,0.01001820
+Pancake Sort,500,219,0.01045790
+Pancake Sort,500,220,0.00737500
+Pancake Sort,500,221,0.00733310
+Pancake Sort,500,222,0.01054880
+Pancake Sort,500,223,0.00810600
+Pancake Sort,500,224,0.00989040
+Pancake Sort,500,225,0.00840370
+Pancake Sort,500,226,0.00866710
+Pancake Sort,500,227,0.01116130
+Pancake Sort,500,228,0.00992000
+Pancake Sort,500,229,0.00880950
+Pancake Sort,500,230,0.00840600
+Pancake Sort,500,231,0.00736600
+Pancake Sort,500,232,0.00897700
+Pancake Sort,500,233,0.00733620
+Pancake Sort,500,234,0.01139430
+Pancake Sort,500,235,0.00849800
+Pancake Sort,500,236,0.00803400
+Pancake Sort,500,237,0.01095480
+Pancake Sort,500,238,0.01031850
+Pancake Sort,500,239,0.00982090
+Pancake Sort,500,240,0.00932910
+Pancake Sort,500,241,0.00962830
+Pancake Sort,500,242,0.01109430
+Pancake Sort,500,243,0.01111210
+Pancake Sort,500,244,0.01081300
+Pancake Sort,500,245,0.01106000
+Pancake Sort,500,246,0.00968840
+Pancake Sort,500,247,0.00945550
+Pancake Sort,500,248,0.01081170
+Pancake Sort,500,249,0.00968700
+Pancake Sort,500,250,0.01049240
+Pancake Sort,500,251,0.00943310
+Pancake Sort,500,252,0.00972600
+Pancake Sort,500,253,0.01086480
+Pancake Sort,500,254,0.00933230
+Pancake Sort,500,255,0.00825350
+Pancake Sort,500,256,0.01079920
+Pancake Sort,500,257,0.01070550
+Pancake Sort,500,258,0.00987420
+Pancake Sort,500,259,0.00812810
+Pancake Sort,500,260,0.00903120
+Pancake Sort,500,261,0.01051630
+Pancake Sort,500,262,0.00839980
+Pancake Sort,500,263,0.01037030
+Pancake Sort,500,264,0.00989490
+Pancake Sort,500,265,0.00816680
+Pancake Sort,500,266,0.00982580
+Pancake Sort,500,267,0.01014590
+Pancake Sort,500,268,0.01099880
+Pancake Sort,500,269,0.00960500
+Pancake Sort,500,270,0.00996000
+Pancake Sort,500,271,0.00936740
+Pancake Sort,500,272,0.01033500
+Pancake Sort,500,273,0.00992550
+Pancake Sort,500,274,0.01103860
+Pancake Sort,500,275,0.00885320
+Pancake Sort,500,276,0.00764390
+Pancake Sort,500,277,0.00879250
+Pancake Sort,500,278,0.01034280
+Pancake Sort,500,279,0.00952300
+Pancake Sort,500,280,0.00801940
+Pancake Sort,500,281,0.01006850
+Pancake Sort,500,282,0.01002740
+Pancake Sort,500,283,0.00924380
+Pancake Sort,500,284,0.00815030
+Pancake Sort,500,285,0.00764730
+Pancake Sort,500,286,0.00860530
+Pancake Sort,500,287,0.00916420
+Pancake Sort,500,288,0.00806530
+Pancake Sort,500,289,0.00855490
+Pancake Sort,500,290,0.00940430
+Pancake Sort,500,291,0.00977230
+Pancake Sort,500,292,0.01062150
+Pancake Sort,500,293,0.01070720
+Pancake Sort,500,294,0.00792290
+Pancake Sort,500,295,0.00839560
+Pancake Sort,500,296,0.00946180
+Pancake Sort,500,297,0.00789960
+Pancake Sort,500,298,0.00777860
+Pancake Sort,500,299,0.01104170
+Pancake Sort,500,300,0.00928140
+Pancake Sort,500,301,0.00998080
+Pancake Sort,500,302,0.00968120
+Pancake Sort,500,303,0.01057790
+Pancake Sort,500,304,0.00944220
+Pancake Sort,500,305,0.01052330
+Pancake Sort,500,306,0.01085550
+Pancake Sort,500,307,0.01120840
+Pancake Sort,500,308,0.01069950
+Pancake Sort,500,309,0.01091640
+Pancake Sort,500,310,0.01031900
+Pancake Sort,500,311,0.01115600
+Pancake Sort,500,312,0.01022500
+Pancake Sort,500,313,0.01055860
+Pancake Sort,500,314,0.01108950
+Pancake Sort,500,315,0.01152920
+Pancake Sort,500,316,0.01103620
+Pancake Sort,500,317,0.01069800
+Pancake Sort,500,318,0.01006670
+Pancake Sort,500,319,0.01115200
+Pancake Sort,500,320,0.00840590
+Pancake Sort,500,321,0.01060810
+Pancake Sort,500,322,0.00798740
+Pancake Sort,500,323,0.01125330
+Pancake Sort,500,324,0.00849320
+Pancake Sort,500,325,0.00898010
+Pancake Sort,500,326,0.00840090
+Pancake Sort,500,327,0.00896640
+Pancake Sort,500,328,0.00968450
+Pancake Sort,500,329,0.00758840
+Pancake Sort,500,330,0.00950460
+Pancake Sort,500,331,0.00875980
+Pancake Sort,500,332,0.01101630
+Pancake Sort,500,333,0.00932940
+Pancake Sort,500,334,0.01072200
+Pancake Sort,500,335,0.00905470
+Pancake Sort,500,336,0.01002820
+Pancake Sort,500,337,0.00852410
+Pancake Sort,500,338,0.00882870
+Pancake Sort,500,339,0.01091510
+Pancake Sort,500,340,0.00904490
+Pancake Sort,500,341,0.00939850
+Pancake Sort,500,342,0.01162990
+Pancake Sort,500,343,0.00843270
+Pancake Sort,500,344,0.00858880
+Pancake Sort,500,345,0.01115330
+Pancake Sort,500,346,0.00704870
+Pancake Sort,500,347,0.00741160
+Pancake Sort,500,348,0.00867750
+Pancake Sort,500,349,0.00904130
+Pancake Sort,500,350,0.00963310
+Pancake Sort,500,351,0.00825590
+Pancake Sort,500,352,0.01111010
+Pancake Sort,500,353,0.00831010
+Pancake Sort,500,354,0.01067730
+Pancake Sort,500,355,0.01064740
+Pancake Sort,500,356,0.01104460
+Pancake Sort,500,357,0.01034710
+Pancake Sort,500,358,0.00963170
+Pancake Sort,500,359,0.00867530
+Pancake Sort,500,360,0.00886140
+Pancake Sort,500,361,0.00856040
+Pancake Sort,500,362,0.00951900
+Pancake Sort,500,363,0.00933420
+Pancake Sort,500,364,0.01126620
+Pancake Sort,500,365,0.01140960
+Pancake Sort,500,366,0.01030790
+Pancake Sort,500,367,0.00802170
+Pancake Sort,500,368,0.00875920
+Pancake Sort,500,369,0.00895710
+Pancake Sort,500,370,0.00927090
+Pancake Sort,500,371,0.00728520
+Pancake Sort,500,372,0.00827260
+Pancake Sort,500,373,0.01049960
+Pancake Sort,500,374,0.00964200
+Pancake Sort,500,375,0.00867580
+Pancake Sort,500,376,0.01017060
+Pancake Sort,500,377,0.00855910
+Pancake Sort,500,378,0.01008070
+Pancake Sort,500,379,0.00793830
+Pancake Sort,500,380,0.00937970
+Pancake Sort,500,381,0.01007710
+Pancake Sort,500,382,0.01124010
+Pancake Sort,500,383,0.00892140
+Pancake Sort,500,384,0.01115360
+Pancake Sort,500,385,0.00910720
+Pancake Sort,500,386,0.01027270
+Pancake Sort,500,387,0.00846370
+Pancake Sort,500,388,0.01156750
+Pancake Sort,500,389,0.01029580
+Pancake Sort,500,390,0.01111970
+Pancake Sort,500,391,0.00841130
+Pancake Sort,500,392,0.00966820
+Pancake Sort,500,393,0.01108870
+Pancake Sort,500,394,0.01021000
+Pancake Sort,500,395,0.00980450
+Pancake Sort,500,396,0.01118130
+Pancake Sort,500,397,0.00859340
+Pancake Sort,500,398,0.01122550
+Pancake Sort,500,399,0.01009350
+Pancake Sort,500,400,0.01096970
+Pancake Sort,500,401,0.00958840
+Pancake Sort,500,402,0.01140520
+Pancake Sort,500,403,0.01079870
+Pancake Sort,500,404,0.00956190
+Pancake Sort,500,405,0.01023750
+Pancake Sort,500,406,0.00934500
+Pancake Sort,500,407,0.00934650
+Pancake Sort,500,408,0.00927320
+Pancake Sort,500,409,0.01066750
+Pancake Sort,500,410,0.01037620
+Pancake Sort,500,411,0.01050840
+Pancake Sort,500,412,0.01007170
+Pancake Sort,500,413,0.01057120
+Pancake Sort,500,414,0.01146910
+Pancake Sort,500,415,0.01183160
+Pancake Sort,500,416,0.01016270
+Pancake Sort,500,417,0.01018070
+Pancake Sort,500,418,0.01165220
+Pancake Sort,500,419,0.01129110
+Pancake Sort,500,420,0.01087100
+Pancake Sort,500,421,0.00821830
+Pancake Sort,500,422,0.00840620
+Pancake Sort,500,423,0.01128980
+Pancake Sort,500,424,0.00936380
+Pancake Sort,500,425,0.00887960
+Pancake Sort,500,426,0.00871660
+Pancake Sort,500,427,0.00988980
+Pancake Sort,500,428,0.00865940
+Pancake Sort,500,429,0.01069160
+Pancake Sort,500,430,0.00913240
+Pancake Sort,500,431,0.00929600
+Pancake Sort,500,432,0.00742500
+Pancake Sort,500,433,0.00990630
+Pancake Sort,500,434,0.00937100
+Pancake Sort,500,435,0.01136290
+Pancake Sort,500,436,0.01108640
+Pancake Sort,500,437,0.01069910
+Pancake Sort,500,438,0.00840760
+Pancake Sort,500,439,0.00887210
+Pancake Sort,500,440,0.00991430
+Pancake Sort,500,441,0.01103580
+Pancake Sort,500,442,0.00912980
+Pancake Sort,500,443,0.00969190
+Pancake Sort,500,444,0.00942350
+Pancake Sort,500,445,0.00872610
+Pancake Sort,500,446,0.00822440
+Pancake Sort,500,447,0.00935060
+Pancake Sort,500,448,0.00742310
+Pancake Sort,500,449,0.01143090
+Pancake Sort,500,450,0.00869180
+Pancake Sort,500,451,0.00879290
+Pancake Sort,500,452,0.00918890
+Pancake Sort,500,453,0.00868020
+Pancake Sort,500,454,0.01130030
+Pancake Sort,500,455,0.00999160
+Pancake Sort,500,456,0.00941130
+Pancake Sort,500,457,0.00749240
+Pancake Sort,500,458,0.01074130
+Pancake Sort,500,459,0.00905140
+Pancake Sort,500,460,0.00756010
+Pancake Sort,500,461,0.01085980
+Pancake Sort,500,462,0.00848810
+Pancake Sort,500,463,0.00886960
+Pancake Sort,500,464,0.00896370
+Pancake Sort,500,465,0.00991830
+Pancake Sort,500,466,0.00978040
+Pancake Sort,500,467,0.00928010
+Pancake Sort,500,468,0.00829600
+Pancake Sort,500,469,0.00764600
+Pancake Sort,500,470,0.00968040
+Pancake Sort,500,471,0.01028190
+Pancake Sort,500,472,0.00846070
+Pancake Sort,500,473,0.00842360
+Pancake Sort,500,474,0.00835350
+Pancake Sort,500,475,0.01134040
+Pancake Sort,500,476,0.01073320
+Pancake Sort,500,477,0.01170030
+Pancake Sort,500,478,0.00781110
+Pancake Sort,500,479,0.00897550
+Pancake Sort,500,480,0.01130300
+Pancake Sort,500,481,0.00791410
+Pancake Sort,500,482,0.00717020
+Pancake Sort,500,483,0.00785700
+Pancake Sort,500,484,0.00899800
+Pancake Sort,500,485,0.01074920
+Pancake Sort,500,486,0.00765100
+Pancake Sort,500,487,0.00901510
+Pancake Sort,500,488,0.01084660
+Pancake Sort,500,489,0.00724280
+Pancake Sort,500,490,0.00945970
+Pancake Sort,500,491,0.00938030
+Pancake Sort,500,492,0.00849990
+Pancake Sort,500,493,0.00793430
+Pancake Sort,500,494,0.00932100
+Pancake Sort,500,495,0.01094550
+Pancake Sort,500,496,0.00971530
+Pancake Sort,500,497,0.00759470
+Pancake Sort,500,498,0.00919810
+Pancake Sort,500,499,0.00989310
+Pancake Sort,500,500,0.01098210
+Patience Sort,500,1,0.00053580
+Patience Sort,500,2,0.00055440
+Patience Sort,500,3,0.00085440
+Patience Sort,500,4,0.00050940
+Patience Sort,500,5,0.00092020
+Patience Sort,500,6,0.00086580
+Patience Sort,500,7,0.00085850
+Patience Sort,500,8,0.00082640
+Patience Sort,500,9,0.00060320
+Patience Sort,500,10,0.00085630
+Patience Sort,500,11,0.00049840
+Patience Sort,500,12,0.00049440
+Patience Sort,500,13,0.00087400
+Patience Sort,500,14,0.00052420
+Patience Sort,500,15,0.00053240
+Patience Sort,500,16,0.00063780
+Patience Sort,500,17,0.00079830
+Patience Sort,500,18,0.00081710
+Patience Sort,500,19,0.00052680
+Patience Sort,500,20,0.00078750
+Patience Sort,500,21,0.00082980
+Patience Sort,500,22,0.00054330
+Patience Sort,500,23,0.00064670
+Patience Sort,500,24,0.00053990
+Patience Sort,500,25,0.00080780
+Patience Sort,500,26,0.00083790
+Patience Sort,500,27,0.00054960
+Patience Sort,500,28,0.00050430
+Patience Sort,500,29,0.00083000
+Patience Sort,500,30,0.00084260
+Patience Sort,500,31,0.00099970
+Patience Sort,500,32,0.00078440
+Patience Sort,500,33,0.00053580
+Patience Sort,500,34,0.00069610
+Patience Sort,500,35,0.00081180
+Patience Sort,500,36,0.00082120
+Patience Sort,500,37,0.00050390
+Patience Sort,500,38,0.00074740
+Patience Sort,500,39,0.00083160
+Patience Sort,500,40,0.00086360
+Patience Sort,500,41,0.00056170
+Patience Sort,500,42,0.00072050
+Patience Sort,500,43,0.00070080
+Patience Sort,500,44,0.00051150
+Patience Sort,500,45,0.00046420
+Patience Sort,500,46,0.00084820
+Patience Sort,500,47,0.00060580
+Patience Sort,500,48,0.00061800
+Patience Sort,500,49,0.00055240
+Patience Sort,500,50,0.00080770
+Patience Sort,500,51,0.00053610
+Patience Sort,500,52,0.00057650
+Patience Sort,500,53,0.00075340
+Patience Sort,500,54,0.00079520
+Patience Sort,500,55,0.00081450
+Patience Sort,500,56,0.00075530
+Patience Sort,500,57,0.00065630
+Patience Sort,500,58,0.00081240
+Patience Sort,500,59,0.00057870
+Patience Sort,500,60,0.00057550
+Patience Sort,500,61,0.00055010
+Patience Sort,500,62,0.00059950
+Patience Sort,500,63,0.00079740
+Patience Sort,500,64,0.00080190
+Patience Sort,500,65,0.00047540
+Patience Sort,500,66,0.00044810
+Patience Sort,500,67,0.00066800
+Patience Sort,500,68,0.00073670
+Patience Sort,500,69,0.00087130
+Patience Sort,500,70,0.00083460
+Patience Sort,500,71,0.00066270
+Patience Sort,500,72,0.00079760
+Patience Sort,500,73,0.00085860
+Patience Sort,500,74,0.00083950
+Patience Sort,500,75,0.00088040
+Patience Sort,500,76,0.00071830
+Patience Sort,500,77,0.00053710
+Patience Sort,500,78,0.00082200
+Patience Sort,500,79,0.00086960
+Patience Sort,500,80,0.00081130
+Patience Sort,500,81,0.00068960
+Patience Sort,500,82,0.00052160
+Patience Sort,500,83,0.00086580
+Patience Sort,500,84,0.00088390
+Patience Sort,500,85,0.00083340
+Patience Sort,500,86,0.00049100
+Patience Sort,500,87,0.00082450
+Patience Sort,500,88,0.00048580
+Patience Sort,500,89,0.00089840
+Patience Sort,500,90,0.00080260
+Patience Sort,500,91,0.00090640
+Patience Sort,500,92,0.00072740
+Patience Sort,500,93,0.00057870
+Patience Sort,500,94,0.00062020
+Patience Sort,500,95,0.00085930
+Patience Sort,500,96,0.00050730
+Patience Sort,500,97,0.00076860
+Patience Sort,500,98,0.00067780
+Patience Sort,500,99,0.00048500
+Patience Sort,500,100,0.00066160
+Patience Sort,500,101,0.00065540
+Patience Sort,500,102,0.00083090
+Patience Sort,500,103,0.00045040
+Patience Sort,500,104,0.00052300
+Patience Sort,500,105,0.00077470
+Patience Sort,500,106,0.00052860
+Patience Sort,500,107,0.00086850
+Patience Sort,500,108,0.00053170
+Patience Sort,500,109,0.00063490
+Patience Sort,500,110,0.00082060
+Patience Sort,500,111,0.00047740
+Patience Sort,500,112,0.00085380
+Patience Sort,500,113,0.00067770
+Patience Sort,500,114,0.00049290
+Patience Sort,500,115,0.00077500
+Patience Sort,500,116,0.00078440
+Patience Sort,500,117,0.00060240
+Patience Sort,500,118,0.00047680
+Patience Sort,500,119,0.00080910
+Patience Sort,500,120,0.00046990
+Patience Sort,500,121,0.00049370
+Patience Sort,500,122,0.00066860
+Patience Sort,500,123,0.00083290
+Patience Sort,500,124,0.00053690
+Patience Sort,500,125,0.00082040
+Patience Sort,500,126,0.00064620
+Patience Sort,500,127,0.00049620
+Patience Sort,500,128,0.00080730
+Patience Sort,500,129,0.00083620
+Patience Sort,500,130,0.00078610
+Patience Sort,500,131,0.00049410
+Patience Sort,500,132,0.00086460
+Patience Sort,500,133,0.00047980
+Patience Sort,500,134,0.00080490
+Patience Sort,500,135,0.00085270
+Patience Sort,500,136,0.00047310
+Patience Sort,500,137,0.00084720
+Patience Sort,500,138,0.00082650
+Patience Sort,500,139,0.00085580
+Patience Sort,500,140,0.00057060
+Patience Sort,500,141,0.00056190
+Patience Sort,500,142,0.00075580
+Patience Sort,500,143,0.00069500
+Patience Sort,500,144,0.00085010
+Patience Sort,500,145,0.00085050
+Patience Sort,500,146,0.00048160
+Patience Sort,500,147,0.00045810
+Patience Sort,500,148,0.00084070
+Patience Sort,500,149,0.00101720
+Patience Sort,500,150,0.00082190
+Patience Sort,500,151,0.00100800
+Patience Sort,500,152,0.00085900
+Patience Sort,500,153,0.00052000
+Patience Sort,500,154,0.00080330
+Patience Sort,500,155,0.00077670
+Patience Sort,500,156,0.00085200
+Patience Sort,500,157,0.00058640
+Patience Sort,500,158,0.00083940
+Patience Sort,500,159,0.00081420
+Patience Sort,500,160,0.00080890
+Patience Sort,500,161,0.00082560
+Patience Sort,500,162,0.00081320
+Patience Sort,500,163,0.00077940
+Patience Sort,500,164,0.00076410
+Patience Sort,500,165,0.00077770
+Patience Sort,500,166,0.00070940
+Patience Sort,500,167,0.00049540
+Patience Sort,500,168,0.00078950
+Patience Sort,500,169,0.00066060
+Patience Sort,500,170,0.00067420
+Patience Sort,500,171,0.00074460
+Patience Sort,500,172,0.00077720
+Patience Sort,500,173,0.00076240
+Patience Sort,500,174,0.00089760
+Patience Sort,500,175,0.00073530
+Patience Sort,500,176,0.00066300
+Patience Sort,500,177,0.00087750
+Patience Sort,500,178,0.00048230
+Patience Sort,500,179,0.00078060
+Patience Sort,500,180,0.00070030
+Patience Sort,500,181,0.00087290
+Patience Sort,500,182,0.00078620
+Patience Sort,500,183,0.00084900
+Patience Sort,500,184,0.00090890
+Patience Sort,500,185,0.00076150
+Patience Sort,500,186,0.00048480
+Patience Sort,500,187,0.00079500
+Patience Sort,500,188,0.00083800
+Patience Sort,500,189,0.00052820
+Patience Sort,500,190,0.00083710
+Patience Sort,500,191,0.00087300
+Patience Sort,500,192,0.00084100
+Patience Sort,500,193,0.00049300
+Patience Sort,500,194,0.00102770
+Patience Sort,500,195,0.00050470
+Patience Sort,500,196,0.00077120
+Patience Sort,500,197,0.00099900
+Patience Sort,500,198,0.00083920
+Patience Sort,500,199,0.00078360
+Patience Sort,500,200,0.00080410
+Patience Sort,500,201,0.00083630
+Patience Sort,500,202,0.00087700
+Patience Sort,500,203,0.00087540
+Patience Sort,500,204,0.00083800
+Patience Sort,500,205,0.00086050
+Patience Sort,500,206,0.00081570
+Patience Sort,500,207,0.00080790
+Patience Sort,500,208,0.00083940
+Patience Sort,500,209,0.00087210
+Patience Sort,500,210,0.00073720
+Patience Sort,500,211,0.00058490
+Patience Sort,500,212,0.00070210
+Patience Sort,500,213,0.00067790
+Patience Sort,500,214,0.00075950
+Patience Sort,500,215,0.00067410
+Patience Sort,500,216,0.00075670
+Patience Sort,500,217,0.00084120
+Patience Sort,500,218,0.00048770
+Patience Sort,500,219,0.00067770
+Patience Sort,500,220,0.00064480
+Patience Sort,500,221,0.00061510
+Patience Sort,500,222,0.00070480
+Patience Sort,500,223,0.00056720
+Patience Sort,500,224,0.00083380
+Patience Sort,500,225,0.00074230
+Patience Sort,500,226,0.00072690
+Patience Sort,500,227,0.00079460
+Patience Sort,500,228,0.00080700
+Patience Sort,500,229,0.00082890
+Patience Sort,500,230,0.00082720
+Patience Sort,500,231,0.00080780
+Patience Sort,500,232,0.00076990
+Patience Sort,500,233,0.00084700
+Patience Sort,500,234,0.00086230
+Patience Sort,500,235,0.00053040
+Patience Sort,500,236,0.00083520
+Patience Sort,500,237,0.00053010
+Patience Sort,500,238,0.00079690
+Patience Sort,500,239,0.00049850
+Patience Sort,500,240,0.00063720
+Patience Sort,500,241,0.00081060
+Patience Sort,500,242,0.00051720
+Patience Sort,500,243,0.00053680
+Patience Sort,500,244,0.00046440
+Patience Sort,500,245,0.00083080
+Patience Sort,500,246,0.00063740
+Patience Sort,500,247,0.00069490
+Patience Sort,500,248,0.00078640
+Patience Sort,500,249,0.00082150
+Patience Sort,500,250,0.00048600
+Patience Sort,500,251,0.00050580
+Patience Sort,500,252,0.00080230
+Patience Sort,500,253,0.00068410
+Patience Sort,500,254,0.00046880
+Patience Sort,500,255,0.00069540
+Patience Sort,500,256,0.00079640
+Patience Sort,500,257,0.00089380
+Patience Sort,500,258,0.00085220
+Patience Sort,500,259,0.00052980
+Patience Sort,500,260,0.00091710
+Patience Sort,500,261,0.00083660
+Patience Sort,500,262,0.00080630
+Patience Sort,500,263,0.00056790
+Patience Sort,500,264,0.00056370
+Patience Sort,500,265,0.00051000
+Patience Sort,500,266,0.00087870
+Patience Sort,500,267,0.00088940
+Patience Sort,500,268,0.00050600
+Patience Sort,500,269,0.00050450
+Patience Sort,500,270,0.00083750
+Patience Sort,500,271,0.00084080
+Patience Sort,500,272,0.00062580
+Patience Sort,500,273,0.00049290
+Patience Sort,500,274,0.00058940
+Patience Sort,500,275,0.00064160
+Patience Sort,500,276,0.00083290
+Patience Sort,500,277,0.00079010
+Patience Sort,500,278,0.00062190
+Patience Sort,500,279,0.00065300
+Patience Sort,500,280,0.00080380
+Patience Sort,500,281,0.00081230
+Patience Sort,500,282,0.00055640
+Patience Sort,500,283,0.00081930
+Patience Sort,500,284,0.00083250
+Patience Sort,500,285,0.00052540
+Patience Sort,500,286,0.00086230
+Patience Sort,500,287,0.00074830
+Patience Sort,500,288,0.00058720
+Patience Sort,500,289,0.00085540
+Patience Sort,500,290,0.00082830
+Patience Sort,500,291,0.00050900
+Patience Sort,500,292,0.00088480
+Patience Sort,500,293,0.00076530
+Patience Sort,500,294,0.00060980
+Patience Sort,500,295,0.00081400
+Patience Sort,500,296,0.00078050
+Patience Sort,500,297,0.00056200
+Patience Sort,500,298,0.00083640
+Patience Sort,500,299,0.00083060
+Patience Sort,500,300,0.00088760
+Patience Sort,500,301,0.00083200
+Patience Sort,500,302,0.00072870
+Patience Sort,500,303,0.00069810
+Patience Sort,500,304,0.00089380
+Patience Sort,500,305,0.00087350
+Patience Sort,500,306,0.00082180
+Patience Sort,500,307,0.00056170
+Patience Sort,500,308,0.00063890
+Patience Sort,500,309,0.00089210
+Patience Sort,500,310,0.00056910
+Patience Sort,500,311,0.00082840
+Patience Sort,500,312,0.00088920
+Patience Sort,500,313,0.00083520
+Patience Sort,500,314,0.00096940
+Patience Sort,500,315,0.00086490
+Patience Sort,500,316,0.00087740
+Patience Sort,500,317,0.00086140
+Patience Sort,500,318,0.00081550
+Patience Sort,500,319,0.00083070
+Patience Sort,500,320,0.00077020
+Patience Sort,500,321,0.00082340
+Patience Sort,500,322,0.00090720
+Patience Sort,500,323,0.00084830
+Patience Sort,500,324,0.00083150
+Patience Sort,500,325,0.00086800
+Patience Sort,500,326,0.00073500
+Patience Sort,500,327,0.00045400
+Patience Sort,500,328,0.00073720
+Patience Sort,500,329,0.00082080
+Patience Sort,500,330,0.00078770
+Patience Sort,500,331,0.00052360
+Patience Sort,500,332,0.00053420
+Patience Sort,500,333,0.00089130
+Patience Sort,500,334,0.00081630
+Patience Sort,500,335,0.00085450
+Patience Sort,500,336,0.00056590
+Patience Sort,500,337,0.00084090
+Patience Sort,500,338,0.00048260
+Patience Sort,500,339,0.00078180
+Patience Sort,500,340,0.00082580
+Patience Sort,500,341,0.00056460
+Patience Sort,500,342,0.00063960
+Patience Sort,500,343,0.00083930
+Patience Sort,500,344,0.00072720
+Patience Sort,500,345,0.00051920
+Patience Sort,500,346,0.00050550
+Patience Sort,500,347,0.00088290
+Patience Sort,500,348,0.00050030
+Patience Sort,500,349,0.00077120
+Patience Sort,500,350,0.00065000
+Patience Sort,500,351,0.00061700
+Patience Sort,500,352,0.00070740
+Patience Sort,500,353,0.00045200
+Patience Sort,500,354,0.00047270
+Patience Sort,500,355,0.00079330
+Patience Sort,500,356,0.00048050
+Patience Sort,500,357,0.00081350
+Patience Sort,500,358,0.00090250
+Patience Sort,500,359,0.00081440
+Patience Sort,500,360,0.00048830
+Patience Sort,500,361,0.00077770
+Patience Sort,500,362,0.00086110
+Patience Sort,500,363,0.00066260
+Patience Sort,500,364,0.00087580
+Patience Sort,500,365,0.00086440
+Patience Sort,500,366,0.00088790
+Patience Sort,500,367,0.00090520
+Patience Sort,500,368,0.00076450
+Patience Sort,500,369,0.00079740
+Patience Sort,500,370,0.00090010
+Patience Sort,500,371,0.00060550
+Patience Sort,500,372,0.00086180
+Patience Sort,500,373,0.00088050
+Patience Sort,500,374,0.00079290
+Patience Sort,500,375,0.00084240
+Patience Sort,500,376,0.00083610
+Patience Sort,500,377,0.00091220
+Patience Sort,500,378,0.00078410
+Patience Sort,500,379,0.00088990
+Patience Sort,500,380,0.00087640
+Patience Sort,500,381,0.00080010
+Patience Sort,500,382,0.00087590
+Patience Sort,500,383,0.00092090
+Patience Sort,500,384,0.00088190
+Patience Sort,500,385,0.00082080
+Patience Sort,500,386,0.00086370
+Patience Sort,500,387,0.00076300
+Patience Sort,500,388,0.00092060
+Patience Sort,500,389,0.00082100
+Patience Sort,500,390,0.00072790
+Patience Sort,500,391,0.00069320
+Patience Sort,500,392,0.00090980
+Patience Sort,500,393,0.00081320
+Patience Sort,500,394,0.00057470
+Patience Sort,500,395,0.00078090
+Patience Sort,500,396,0.00090290
+Patience Sort,500,397,0.00084400
+Patience Sort,500,398,0.00088100
+Patience Sort,500,399,0.00086490
+Patience Sort,500,400,0.00077930
+Patience Sort,500,401,0.00058840
+Patience Sort,500,402,0.00086580
+Patience Sort,500,403,0.00089020
+Patience Sort,500,404,0.00053010
+Patience Sort,500,405,0.00076380
+Patience Sort,500,406,0.00086310
+Patience Sort,500,407,0.00090490
+Patience Sort,500,408,0.00047790
+Patience Sort,500,409,0.00090290
+Patience Sort,500,410,0.00086470
+Patience Sort,500,411,0.00083490
+Patience Sort,500,412,0.00082630
+Patience Sort,500,413,0.00088850
+Patience Sort,500,414,0.00049440
+Patience Sort,500,415,0.00067130
+Patience Sort,500,416,0.00067240
+Patience Sort,500,417,0.00080970
+Patience Sort,500,418,0.00083860
+Patience Sort,500,419,0.00088990
+Patience Sort,500,420,0.00075080
+Patience Sort,500,421,0.00093870
+Patience Sort,500,422,0.00083850
+Patience Sort,500,423,0.00083450
+Patience Sort,500,424,0.00081070
+Patience Sort,500,425,0.00083780
+Patience Sort,500,426,0.00086860
+Patience Sort,500,427,0.00070790
+Patience Sort,500,428,0.00066550
+Patience Sort,500,429,0.00065780
+Patience Sort,500,430,0.00076740
+Patience Sort,500,431,0.00071420
+Patience Sort,500,432,0.00079790
+Patience Sort,500,433,0.00081510
+Patience Sort,500,434,0.00090220
+Patience Sort,500,435,0.00089890
+Patience Sort,500,436,0.00079100
+Patience Sort,500,437,0.00084290
+Patience Sort,500,438,0.00083570
+Patience Sort,500,439,0.00079720
+Patience Sort,500,440,0.00060050
+Patience Sort,500,441,0.00080630
+Patience Sort,500,442,0.00074640
+Patience Sort,500,443,0.00086540
+Patience Sort,500,444,0.00088950
+Patience Sort,500,445,0.00057670
+Patience Sort,500,446,0.00077030
+Patience Sort,500,447,0.00061880
+Patience Sort,500,448,0.00086550
+Patience Sort,500,449,0.00078300
+Patience Sort,500,450,0.00085530
+Patience Sort,500,451,0.00052680
+Patience Sort,500,452,0.00045900
+Patience Sort,500,453,0.00085090
+Patience Sort,500,454,0.00048470
+Patience Sort,500,455,0.00049010
+Patience Sort,500,456,0.00087880
+Patience Sort,500,457,0.00058220
+Patience Sort,500,458,0.00068340
+Patience Sort,500,459,0.00062430
+Patience Sort,500,460,0.00049720
+Patience Sort,500,461,0.00079890
+Patience Sort,500,462,0.00051770
+Patience Sort,500,463,0.00082690
+Patience Sort,500,464,0.00048480
+Patience Sort,500,465,0.00083550
+Patience Sort,500,466,0.00051070
+Patience Sort,500,467,0.00051680
+Patience Sort,500,468,0.00090000
+Patience Sort,500,469,0.00052680
+Patience Sort,500,470,0.00049460
+Patience Sort,500,471,0.00071980
+Patience Sort,500,472,0.00078930
+Patience Sort,500,473,0.00077660
+Patience Sort,500,474,0.00055920
+Patience Sort,500,475,0.00064650
+Patience Sort,500,476,0.00090740
+Patience Sort,500,477,0.00051720
+Patience Sort,500,478,0.00075260
+Patience Sort,500,479,0.00057390
+Patience Sort,500,480,0.00078390
+Patience Sort,500,481,0.00075960
+Patience Sort,500,482,0.00086500
+Patience Sort,500,483,0.00068650
+Patience Sort,500,484,0.00082270
+Patience Sort,500,485,0.00084140
+Patience Sort,500,486,0.00083840
+Patience Sort,500,487,0.00074460
+Patience Sort,500,488,0.00078530
+Patience Sort,500,489,0.00055450
+Patience Sort,500,490,0.00077690
+Patience Sort,500,491,0.00073900
+Patience Sort,500,492,0.00085570
+Patience Sort,500,493,0.00082460
+Patience Sort,500,494,0.00086480
+Patience Sort,500,495,0.00069530
+Patience Sort,500,496,0.00069650
+Patience Sort,500,497,0.00081050
+Patience Sort,500,498,0.00082260
+Patience Sort,500,499,0.00086650
+Patience Sort,500,500,0.00082770
+Pigeonhole Sort,500,1,1.12166950
+Pigeonhole Sort,500,2,1.12102240
+Pigeonhole Sort,500,3,1.11979270
+Pigeonhole Sort,500,4,1.11848520
+Pigeonhole Sort,500,5,1.09003270
+Pigeonhole Sort,500,6,1.24432530
+Pigeonhole Sort,500,7,1.21987080
+Pigeonhole Sort,500,8,1.23727430
+Pigeonhole Sort,500,9,1.19650000
+Pigeonhole Sort,500,10,1.22553640
+Pigeonhole Sort,500,11,1.26853130
+Pigeonhole Sort,500,12,1.25415430
+Pigeonhole Sort,500,13,1.25152090
+Pigeonhole Sort,500,14,1.23342410
+Pigeonhole Sort,500,15,1.22866440
+Pigeonhole Sort,500,16,1.18133860
+Pigeonhole Sort,500,17,1.29527930
+Pigeonhole Sort,500,18,1.38628910
+Pigeonhole Sort,500,19,1.37201880
+Pigeonhole Sort,500,20,1.33876630
+Pigeonhole Sort,500,21,1.36306140
+Pigeonhole Sort,500,22,1.21631760
+Pigeonhole Sort,500,23,1.08865990
+Pigeonhole Sort,500,24,1.23512710
+Pigeonhole Sort,500,25,1.34733270
+Pigeonhole Sort,500,26,1.33128590
+Pigeonhole Sort,500,27,1.30052120
+Pigeonhole Sort,500,28,1.33790880
+Pigeonhole Sort,500,29,1.20634120
+Pigeonhole Sort,500,30,1.24216260
+Pigeonhole Sort,500,31,1.26617040
+Pigeonhole Sort,500,32,1.34652850
+Pigeonhole Sort,500,33,1.19578970
+Pigeonhole Sort,500,34,1.46083210
+Pigeonhole Sort,500,35,1.43967970
+Pigeonhole Sort,500,36,1.39383100
+Pigeonhole Sort,500,37,1.43673530
+Pigeonhole Sort,500,38,1.57308180
+Pigeonhole Sort,500,39,1.64633440
+Pigeonhole Sort,500,40,1.41714000
+Pigeonhole Sort,500,41,1.44573680
+Pigeonhole Sort,500,42,1.70724010
+Pigeonhole Sort,500,43,1.72696910
+Pigeonhole Sort,500,44,1.65240500
+Pigeonhole Sort,500,45,1.55395180
+Pigeonhole Sort,500,46,1.63304200
+Pigeonhole Sort,500,47,1.65379640
+Pigeonhole Sort,500,48,1.50193930
+Pigeonhole Sort,500,49,1.51585180
+Pigeonhole Sort,500,50,1.58580790
+Pigeonhole Sort,500,51,1.37720250
+Pigeonhole Sort,500,52,1.62654630
+Pigeonhole Sort,500,53,1.52113010
+Pigeonhole Sort,500,54,1.42598570
+Pigeonhole Sort,500,55,1.59283130
+Pigeonhole Sort,500,56,1.59248110
+Pigeonhole Sort,500,57,1.49321340
+Pigeonhole Sort,500,58,1.63121320
+Pigeonhole Sort,500,59,1.56912730
+Pigeonhole Sort,500,60,1.57450280
+Pigeonhole Sort,500,61,1.65784480
+Pigeonhole Sort,500,62,1.50506940
+Pigeonhole Sort,500,63,1.55397600
+Pigeonhole Sort,500,64,1.47120380
+Pigeonhole Sort,500,65,1.71228380
+Pigeonhole Sort,500,66,1.47799160
+Pigeonhole Sort,500,67,1.66967270
+Pigeonhole Sort,500,68,1.56537360
+Pigeonhole Sort,500,69,1.58977290
+Pigeonhole Sort,500,70,1.62412540
+Pigeonhole Sort,500,71,1.54706660
+Pigeonhole Sort,500,72,1.49469160
+Pigeonhole Sort,500,73,1.40378790
+Pigeonhole Sort,500,74,1.66006800
+Pigeonhole Sort,500,75,1.37130830
+Pigeonhole Sort,500,76,1.49284570
+Pigeonhole Sort,500,77,1.54048660
+Pigeonhole Sort,500,78,1.62184430
+Pigeonhole Sort,500,79,1.57232060
+Pigeonhole Sort,500,80,1.52993790
+Pigeonhole Sort,500,81,1.61025220
+Pigeonhole Sort,500,82,1.55177600
+Pigeonhole Sort,500,83,1.33149060
+Pigeonhole Sort,500,84,1.50501500
+Pigeonhole Sort,500,85,1.45387770
+Pigeonhole Sort,500,86,1.56264930
+Pigeonhole Sort,500,87,1.52545370
+Pigeonhole Sort,500,88,1.52706620
+Pigeonhole Sort,500,89,1.60289590
+Pigeonhole Sort,500,90,1.59058840
+Pigeonhole Sort,500,91,1.58609990
+Pigeonhole Sort,500,92,1.50997110
+Pigeonhole Sort,500,93,1.47546320
+Pigeonhole Sort,500,94,1.49951330
+Pigeonhole Sort,500,95,1.56578250
+Pigeonhole Sort,500,96,1.50614840
+Pigeonhole Sort,500,97,1.52615390
+Pigeonhole Sort,500,98,1.58762770
+Pigeonhole Sort,500,99,1.57647790
+Pigeonhole Sort,500,100,1.46905550
+Pigeonhole Sort,500,101,1.48990810
+Pigeonhole Sort,500,102,1.72287430
+Pigeonhole Sort,500,103,1.68998660
+Pigeonhole Sort,500,104,1.64592230
+Pigeonhole Sort,500,105,1.57792040
+Pigeonhole Sort,500,106,1.55077730
+Pigeonhole Sort,500,107,1.62734980
+Pigeonhole Sort,500,108,1.60004090
+Pigeonhole Sort,500,109,1.72428150
+Pigeonhole Sort,500,110,1.52881840
+Pigeonhole Sort,500,111,1.53519770
+Pigeonhole Sort,500,112,1.50670580
+Pigeonhole Sort,500,113,1.64924890
+Pigeonhole Sort,500,114,1.57233260
+Pigeonhole Sort,500,115,1.49107890
+Pigeonhole Sort,500,116,1.48407240
+Pigeonhole Sort,500,117,1.43476350
+Pigeonhole Sort,500,118,1.65393430
+Pigeonhole Sort,500,119,1.71216620
+Pigeonhole Sort,500,120,1.69789930
+Pigeonhole Sort,500,121,1.45431680
+Pigeonhole Sort,500,122,1.66385200
+Pigeonhole Sort,500,123,1.50905430
+Pigeonhole Sort,500,124,1.53312760
+Pigeonhole Sort,500,125,1.85004840
+Pigeonhole Sort,500,126,1.61577940
+Pigeonhole Sort,500,127,1.46016110
+Pigeonhole Sort,500,128,1.66124950
+Pigeonhole Sort,500,129,1.56971830
+Pigeonhole Sort,500,130,1.53321490
+Pigeonhole Sort,500,131,1.53811650
+Pigeonhole Sort,500,132,1.64026400
+Pigeonhole Sort,500,133,1.51718400
+Pigeonhole Sort,500,134,1.53056920
+Pigeonhole Sort,500,135,1.68376830
+Pigeonhole Sort,500,136,1.59082630
+Pigeonhole Sort,500,137,1.54725900
+Pigeonhole Sort,500,138,1.52120440
+Pigeonhole Sort,500,139,1.73010520
+Pigeonhole Sort,500,140,1.64946740
+Pigeonhole Sort,500,141,1.72958400
+Pigeonhole Sort,500,142,1.51761020
+Pigeonhole Sort,500,143,1.50374640
+Pigeonhole Sort,500,144,1.58097670
+Pigeonhole Sort,500,145,1.62827040
+Pigeonhole Sort,500,146,1.63186350
+Pigeonhole Sort,500,147,1.49005790
+Pigeonhole Sort,500,148,1.64304680
+Pigeonhole Sort,500,149,1.66314520
+Pigeonhole Sort,500,150,1.45576800
+Pigeonhole Sort,500,151,1.67784220
+Pigeonhole Sort,500,152,1.68416050
+Pigeonhole Sort,500,153,1.57754650
+Pigeonhole Sort,500,154,1.49309210
+Pigeonhole Sort,500,155,1.70082120
+Pigeonhole Sort,500,156,1.61888750
+Pigeonhole Sort,500,157,1.67510040
+Pigeonhole Sort,500,158,1.48457800
+Pigeonhole Sort,500,159,1.60488720
+Pigeonhole Sort,500,160,1.69044610
+Pigeonhole Sort,500,161,1.59182740
+Pigeonhole Sort,500,162,1.54824140
+Pigeonhole Sort,500,163,1.63486790
+Pigeonhole Sort,500,164,1.52016650
+Pigeonhole Sort,500,165,1.63104120
+Pigeonhole Sort,500,166,1.54473970
+Pigeonhole Sort,500,167,1.62632960
+Pigeonhole Sort,500,168,1.55646620
+Pigeonhole Sort,500,169,1.51242100
+Pigeonhole Sort,500,170,1.64356500
+Pigeonhole Sort,500,171,1.53852400
+Pigeonhole Sort,500,172,1.52099300
+Pigeonhole Sort,500,173,1.57323220
+Pigeonhole Sort,500,174,1.49058270
+Pigeonhole Sort,500,175,1.40503350
+Pigeonhole Sort,500,176,1.62782360
+Pigeonhole Sort,500,177,1.59147450
+Pigeonhole Sort,500,178,1.50659460
+Pigeonhole Sort,500,179,1.48426430
+Pigeonhole Sort,500,180,1.51313390
+Pigeonhole Sort,500,181,1.48197130
+Pigeonhole Sort,500,182,1.45693240
+Pigeonhole Sort,500,183,1.47493310
+Pigeonhole Sort,500,184,1.47742160
+Pigeonhole Sort,500,185,1.45946590
+Pigeonhole Sort,500,186,1.46930150
+Pigeonhole Sort,500,187,1.43759930
+Pigeonhole Sort,500,188,1.62862000
+Pigeonhole Sort,500,189,1.60598500
+Pigeonhole Sort,500,190,1.52667510
+Pigeonhole Sort,500,191,1.66041760
+Pigeonhole Sort,500,192,1.55122560
+Pigeonhole Sort,500,193,1.65007000
+Pigeonhole Sort,500,194,1.49671280
+Pigeonhole Sort,500,195,1.52334170
+Pigeonhole Sort,500,196,1.44803500
+Pigeonhole Sort,500,197,1.64394360
+Pigeonhole Sort,500,198,1.57964160
+Pigeonhole Sort,500,199,1.44876010
+Pigeonhole Sort,500,200,1.63358570
+Pigeonhole Sort,500,201,1.62561080
+Pigeonhole Sort,500,202,1.45550960
+Pigeonhole Sort,500,203,1.71867200
+Pigeonhole Sort,500,204,1.60407160
+Pigeonhole Sort,500,205,1.62476600
+Pigeonhole Sort,500,206,1.61112220
+Pigeonhole Sort,500,207,1.60170020
+Pigeonhole Sort,500,208,1.67770360
+Pigeonhole Sort,500,209,1.66022430
+Pigeonhole Sort,500,210,1.56104740
+Pigeonhole Sort,500,211,1.63258740
+Pigeonhole Sort,500,212,1.64830430
+Pigeonhole Sort,500,213,1.58881540
+Pigeonhole Sort,500,214,1.62133900
+Pigeonhole Sort,500,215,1.67948890
+Pigeonhole Sort,500,216,1.75681570
+Pigeonhole Sort,500,217,1.73420250
+Pigeonhole Sort,500,218,1.70251490
+Pigeonhole Sort,500,219,1.65212830
+Pigeonhole Sort,500,220,1.53953970
+Pigeonhole Sort,500,221,1.59499500
+Pigeonhole Sort,500,222,1.65672270
+Pigeonhole Sort,500,223,1.63624590
+Pigeonhole Sort,500,224,1.46078310
+Pigeonhole Sort,500,225,1.56554200
+Pigeonhole Sort,500,226,1.51940420
+Pigeonhole Sort,500,227,1.52637710
+Pigeonhole Sort,500,228,1.55699190
+Pigeonhole Sort,500,229,1.44240110
+Pigeonhole Sort,500,230,1.61973470
+Pigeonhole Sort,500,231,1.41596500
+Pigeonhole Sort,500,232,1.68401790
+Pigeonhole Sort,500,233,1.46010610
+Pigeonhole Sort,500,234,1.56698390
+Pigeonhole Sort,500,235,1.61629920
+Pigeonhole Sort,500,236,1.54184680
+Pigeonhole Sort,500,237,1.44072910
+Pigeonhole Sort,500,238,1.46562190
+Pigeonhole Sort,500,239,1.66159800
+Pigeonhole Sort,500,240,1.47557930
+Pigeonhole Sort,500,241,1.49169780
+Pigeonhole Sort,500,242,1.34310780
+Pigeonhole Sort,500,243,1.57960130
+Pigeonhole Sort,500,244,1.64207800
+Pigeonhole Sort,500,245,1.60901200
+Pigeonhole Sort,500,246,1.50491190
+Pigeonhole Sort,500,247,1.52710810
+Pigeonhole Sort,500,248,1.56862790
+Pigeonhole Sort,500,249,1.65584260
+Pigeonhole Sort,500,250,1.56669190
+Pigeonhole Sort,500,251,1.53428740
+Pigeonhole Sort,500,252,1.43328890
+Pigeonhole Sort,500,253,1.67343300
+Pigeonhole Sort,500,254,1.62173400
+Pigeonhole Sort,500,255,1.56483200
+Pigeonhole Sort,500,256,1.51786470
+Pigeonhole Sort,500,257,1.61563520
+Pigeonhole Sort,500,258,1.67620110
+Pigeonhole Sort,500,259,1.46356720
+Pigeonhole Sort,500,260,1.53512720
+Pigeonhole Sort,500,261,1.45101160
+Pigeonhole Sort,500,262,1.59872780
+Pigeonhole Sort,500,263,1.54032070
+Pigeonhole Sort,500,264,1.63562460
+Pigeonhole Sort,500,265,1.58448450
+Pigeonhole Sort,500,266,1.44979950
+Pigeonhole Sort,500,267,1.57604780
+Pigeonhole Sort,500,268,1.59082120
+Pigeonhole Sort,500,269,1.45686650
+Pigeonhole Sort,500,270,1.73550900
+Pigeonhole Sort,500,271,1.58451210
+Pigeonhole Sort,500,272,1.61807480
+Pigeonhole Sort,500,273,1.63512520
+Pigeonhole Sort,500,274,1.64645700
+Pigeonhole Sort,500,275,1.67385270
+Pigeonhole Sort,500,276,1.62604970
+Pigeonhole Sort,500,277,1.68425440
+Pigeonhole Sort,500,278,1.79861610
+Pigeonhole Sort,500,279,1.51491530
+Pigeonhole Sort,500,280,1.80135860
+Pigeonhole Sort,500,281,1.89756340
+Pigeonhole Sort,500,282,1.81458760
+Pigeonhole Sort,500,283,1.67089840
+Pigeonhole Sort,500,284,1.88322120
+Pigeonhole Sort,500,285,1.75441940
+Pigeonhole Sort,500,286,1.56205740
+Pigeonhole Sort,500,287,1.51654290
+Pigeonhole Sort,500,288,1.56914020
+Pigeonhole Sort,500,289,1.64160420
+Pigeonhole Sort,500,290,1.61076010
+Pigeonhole Sort,500,291,1.58671320
+Pigeonhole Sort,500,292,1.55726910
+Pigeonhole Sort,500,293,1.53696700
+Pigeonhole Sort,500,294,1.53610700
+Pigeonhole Sort,500,295,1.60828870
+Pigeonhole Sort,500,296,1.51309110
+Pigeonhole Sort,500,297,1.59973090
+Pigeonhole Sort,500,298,1.50060810
+Pigeonhole Sort,500,299,1.56632170
+Pigeonhole Sort,500,300,1.51444590
+Pigeonhole Sort,500,301,1.58594020
+Pigeonhole Sort,500,302,1.49310350
+Pigeonhole Sort,500,303,1.57943310
+Pigeonhole Sort,500,304,1.65417310
+Pigeonhole Sort,500,305,1.69088380
+Pigeonhole Sort,500,306,1.49809720
+Pigeonhole Sort,500,307,1.58511620
+Pigeonhole Sort,500,308,1.58134480
+Pigeonhole Sort,500,309,1.54471020
+Pigeonhole Sort,500,310,1.58465890
+Pigeonhole Sort,500,311,1.63369730
+Pigeonhole Sort,500,312,1.38248070
+Pigeonhole Sort,500,313,1.54884030
+Pigeonhole Sort,500,314,1.53768540
+Pigeonhole Sort,500,315,1.45935400
+Pigeonhole Sort,500,316,1.45754000
+Pigeonhole Sort,500,317,1.61886180
+Pigeonhole Sort,500,318,1.43276150
+Pigeonhole Sort,500,319,1.58563410
+Pigeonhole Sort,500,320,1.55716870
+Pigeonhole Sort,500,321,1.69875650
+Pigeonhole Sort,500,322,1.60999190
+Pigeonhole Sort,500,323,1.60800610
+Pigeonhole Sort,500,324,1.62363100
+Pigeonhole Sort,500,325,1.54841330
+Pigeonhole Sort,500,326,1.61557060
+Pigeonhole Sort,500,327,1.50315810
+Pigeonhole Sort,500,328,1.43855610
+Pigeonhole Sort,500,329,1.58586060
+Pigeonhole Sort,500,330,1.63187360
+Pigeonhole Sort,500,331,1.54519910
+Pigeonhole Sort,500,332,1.50998560
+Pigeonhole Sort,500,333,1.61639170
+Pigeonhole Sort,500,334,1.66509120
+Pigeonhole Sort,500,335,1.51784430
+Pigeonhole Sort,500,336,1.67025940
+Pigeonhole Sort,500,337,1.67391140
+Pigeonhole Sort,500,338,1.69146790
+Pigeonhole Sort,500,339,1.56406640
+Pigeonhole Sort,500,340,1.42205620
+Pigeonhole Sort,500,341,1.65012720
+Pigeonhole Sort,500,342,1.56468890
+Pigeonhole Sort,500,343,1.58104780
+Pigeonhole Sort,500,344,1.52893180
+Pigeonhole Sort,500,345,1.62086270
+Pigeonhole Sort,500,346,1.65945850
+Pigeonhole Sort,500,347,1.62992960
+Pigeonhole Sort,500,348,1.54927930
+Pigeonhole Sort,500,349,1.62752570
+Pigeonhole Sort,500,350,1.62309830
+Pigeonhole Sort,500,351,1.58133690
+Pigeonhole Sort,500,352,1.67552670
+Pigeonhole Sort,500,353,1.60902190
+Pigeonhole Sort,500,354,1.58618620
+Pigeonhole Sort,500,355,1.47153290
+Pigeonhole Sort,500,356,1.52903400
+Pigeonhole Sort,500,357,1.54614450
+Pigeonhole Sort,500,358,1.53214360
+Pigeonhole Sort,500,359,1.51999490
+Pigeonhole Sort,500,360,1.66621810
+Pigeonhole Sort,500,361,1.68466880
+Pigeonhole Sort,500,362,1.50565320
+Pigeonhole Sort,500,363,1.71433040
+Pigeonhole Sort,500,364,1.61527830
+Pigeonhole Sort,500,365,1.66169720
+Pigeonhole Sort,500,366,1.62840510
+Pigeonhole Sort,500,367,1.56527310
+Pigeonhole Sort,500,368,1.48496400
+Pigeonhole Sort,500,369,1.51130150
+Pigeonhole Sort,500,370,1.48405240
+Pigeonhole Sort,500,371,1.56114630
+Pigeonhole Sort,500,372,1.50195710
+Pigeonhole Sort,500,373,1.41837810
+Pigeonhole Sort,500,374,1.54989890
+Pigeonhole Sort,500,375,1.49599260
+Pigeonhole Sort,500,376,1.49410040
+Pigeonhole Sort,500,377,1.54475240
+Pigeonhole Sort,500,378,1.65649220
+Pigeonhole Sort,500,379,1.69801620
+Pigeonhole Sort,500,380,1.46213250
+Pigeonhole Sort,500,381,1.51650190
+Pigeonhole Sort,500,382,1.58963660
+Pigeonhole Sort,500,383,1.64812050
+Pigeonhole Sort,500,384,1.62962490
+Pigeonhole Sort,500,385,1.66493530
+Pigeonhole Sort,500,386,1.48028050
+Pigeonhole Sort,500,387,1.54824850
+Pigeonhole Sort,500,388,1.56293490
+Pigeonhole Sort,500,389,1.57787270
+Pigeonhole Sort,500,390,1.51372380
+Pigeonhole Sort,500,391,1.59946930
+Pigeonhole Sort,500,392,1.53004320
+Pigeonhole Sort,500,393,1.46331370
+Pigeonhole Sort,500,394,1.56378460
+Pigeonhole Sort,500,395,1.55414980
+Pigeonhole Sort,500,396,1.62333500
+Pigeonhole Sort,500,397,1.47151370
+Pigeonhole Sort,500,398,1.64105480
+Pigeonhole Sort,500,399,1.48252930
+Pigeonhole Sort,500,400,1.46640080
+Pigeonhole Sort,500,401,1.64618250
+Pigeonhole Sort,500,402,1.50344380
+Pigeonhole Sort,500,403,1.52428140
+Pigeonhole Sort,500,404,1.39013170
+Pigeonhole Sort,500,405,1.48655750
+Pigeonhole Sort,500,406,1.47560720
+Pigeonhole Sort,500,407,1.72609750
+Pigeonhole Sort,500,408,1.57131510
+Pigeonhole Sort,500,409,1.59467420
+Pigeonhole Sort,500,410,1.40623320
+Pigeonhole Sort,500,411,1.54713220
+Pigeonhole Sort,500,412,1.64313020
+Pigeonhole Sort,500,413,1.58991130
+Pigeonhole Sort,500,414,1.59364400
+Pigeonhole Sort,500,415,1.46077500
+Pigeonhole Sort,500,416,1.72783200
+Pigeonhole Sort,500,417,1.58741230
+Pigeonhole Sort,500,418,1.70884030
+Pigeonhole Sort,500,419,1.67877450
+Pigeonhole Sort,500,420,1.61106160
+Pigeonhole Sort,500,421,1.57602740
+Pigeonhole Sort,500,422,1.67140280
+Pigeonhole Sort,500,423,1.71697670
+Pigeonhole Sort,500,424,1.52430180
+Pigeonhole Sort,500,425,1.53316960
+Pigeonhole Sort,500,426,1.57740720
+Pigeonhole Sort,500,427,1.42292330
+Pigeonhole Sort,500,428,1.67955220
+Pigeonhole Sort,500,429,1.63752370
+Pigeonhole Sort,500,430,1.68223880
+Pigeonhole Sort,500,431,1.63430210
+Pigeonhole Sort,500,432,1.70374780
+Pigeonhole Sort,500,433,1.52742590
+Pigeonhole Sort,500,434,1.52803220
+Pigeonhole Sort,500,435,1.56065690
+Pigeonhole Sort,500,436,1.60194400
+Pigeonhole Sort,500,437,1.60325660
+Pigeonhole Sort,500,438,1.42935190
+Pigeonhole Sort,500,439,1.46407670
+Pigeonhole Sort,500,440,1.43677720
+Pigeonhole Sort,500,441,1.47920010
+Pigeonhole Sort,500,442,1.54843060
+Pigeonhole Sort,500,443,1.55885460
+Pigeonhole Sort,500,444,1.65616070
+Pigeonhole Sort,500,445,1.62071700
+Pigeonhole Sort,500,446,1.46551560
+Pigeonhole Sort,500,447,1.50226720
+Pigeonhole Sort,500,448,1.48815540
+Pigeonhole Sort,500,449,1.68869010
+Pigeonhole Sort,500,450,1.54924140
+Pigeonhole Sort,500,451,1.61029630
+Pigeonhole Sort,500,452,1.51651230
+Pigeonhole Sort,500,453,1.46502780
+Pigeonhole Sort,500,454,1.56434830
+Pigeonhole Sort,500,455,1.64504310
+Pigeonhole Sort,500,456,1.49802010
+Pigeonhole Sort,500,457,1.57121240
+Pigeonhole Sort,500,458,1.68532930
+Pigeonhole Sort,500,459,1.59987840
+Pigeonhole Sort,500,460,1.60964920
+Pigeonhole Sort,500,461,1.68104930
+Pigeonhole Sort,500,462,1.60570590
+Pigeonhole Sort,500,463,1.50953600
+Pigeonhole Sort,500,464,1.52887020
+Pigeonhole Sort,500,465,1.45712060
+Pigeonhole Sort,500,466,1.66136880
+Pigeonhole Sort,500,467,1.65337230
+Pigeonhole Sort,500,468,1.49829740
+Pigeonhole Sort,500,469,1.70037380
+Pigeonhole Sort,500,470,1.57443460
+Pigeonhole Sort,500,471,1.58548540
+Pigeonhole Sort,500,472,1.65344020
+Pigeonhole Sort,500,473,1.60323410
+Pigeonhole Sort,500,474,1.40838790
+Pigeonhole Sort,500,475,1.59652610
+Pigeonhole Sort,500,476,1.63404270
+Pigeonhole Sort,500,477,1.40078530
+Pigeonhole Sort,500,478,1.54465720
+Pigeonhole Sort,500,479,1.51428910
+Pigeonhole Sort,500,480,1.54653120
+Pigeonhole Sort,500,481,1.52870240
+Pigeonhole Sort,500,482,1.64565640
+Pigeonhole Sort,500,483,1.64775920
+Pigeonhole Sort,500,484,1.60788060
+Pigeonhole Sort,500,485,1.66474450
+Pigeonhole Sort,500,486,1.72081710
+Pigeonhole Sort,500,487,1.60525620
+Pigeonhole Sort,500,488,1.66331340
+Pigeonhole Sort,500,489,1.65556600
+Pigeonhole Sort,500,490,1.63446820
+Pigeonhole Sort,500,491,1.58817250
+Pigeonhole Sort,500,492,1.67277410
+Pigeonhole Sort,500,493,1.56977740
+Pigeonhole Sort,500,494,1.49113130
+Pigeonhole Sort,500,495,1.47624580
+Pigeonhole Sort,500,496,1.43448860
+Pigeonhole Sort,500,497,1.41597600
+Pigeonhole Sort,500,498,1.19746570
+Pigeonhole Sort,500,499,1.02986010
+Pigeonhole Sort,500,500,0.83250560
+Polyphase Merge Sort,500,1,0.00043810
+Polyphase Merge Sort,500,2,0.00045700
+Polyphase Merge Sort,500,3,0.00034550
+Polyphase Merge Sort,500,4,0.00040940
+Polyphase Merge Sort,500,5,0.00044680
+Polyphase Merge Sort,500,6,0.00042700
+Polyphase Merge Sort,500,7,0.00043720
+Polyphase Merge Sort,500,8,0.00040840
+Polyphase Merge Sort,500,9,0.00041370
+Polyphase Merge Sort,500,10,0.00047280
+Polyphase Merge Sort,500,11,0.00046160
+Polyphase Merge Sort,500,12,0.00041860
+Polyphase Merge Sort,500,13,0.00044660
+Polyphase Merge Sort,500,14,0.00047480
+Polyphase Merge Sort,500,15,0.00025960
+Polyphase Merge Sort,500,16,0.00026720
+Polyphase Merge Sort,500,17,0.00026070
+Polyphase Merge Sort,500,18,0.00025210
+Polyphase Merge Sort,500,19,0.00025020
+Polyphase Merge Sort,500,20,0.00048530
+Polyphase Merge Sort,500,21,0.00026580
+Polyphase Merge Sort,500,22,0.00025040
+Polyphase Merge Sort,500,23,0.00026220
+Polyphase Merge Sort,500,24,0.00027540
+Polyphase Merge Sort,500,25,0.00025810
+Polyphase Merge Sort,500,26,0.00027400
+Polyphase Merge Sort,500,27,0.00028180
+Polyphase Merge Sort,500,28,0.00033040
+Polyphase Merge Sort,500,29,0.00034490
+Polyphase Merge Sort,500,30,0.00036080
+Polyphase Merge Sort,500,31,0.00036090
+Polyphase Merge Sort,500,32,0.00032030
+Polyphase Merge Sort,500,33,0.00026830
+Polyphase Merge Sort,500,34,0.00031780
+Polyphase Merge Sort,500,35,0.00034440
+Polyphase Merge Sort,500,36,0.00047310
+Polyphase Merge Sort,500,37,0.00044490
+Polyphase Merge Sort,500,38,0.00044320
+Polyphase Merge Sort,500,39,0.00043640
+Polyphase Merge Sort,500,40,0.00044670
+Polyphase Merge Sort,500,41,0.00045860
+Polyphase Merge Sort,500,42,0.00047170
+Polyphase Merge Sort,500,43,0.00048100
+Polyphase Merge Sort,500,44,0.00041880
+Polyphase Merge Sort,500,45,0.00027840
+Polyphase Merge Sort,500,46,0.00026380
+Polyphase Merge Sort,500,47,0.00027090
+Polyphase Merge Sort,500,48,0.00030740
+Polyphase Merge Sort,500,49,0.00031220
+Polyphase Merge Sort,500,50,0.00047670
+Polyphase Merge Sort,500,51,0.00037420
+Polyphase Merge Sort,500,52,0.00038850
+Polyphase Merge Sort,500,53,0.00040540
+Polyphase Merge Sort,500,54,0.00038120
+Polyphase Merge Sort,500,55,0.00042840
+Polyphase Merge Sort,500,56,0.00041920
+Polyphase Merge Sort,500,57,0.00041230
+Polyphase Merge Sort,500,58,0.00044490
+Polyphase Merge Sort,500,59,0.00041250
+Polyphase Merge Sort,500,60,0.00035310
+Polyphase Merge Sort,500,61,0.00034550
+Polyphase Merge Sort,500,62,0.00038600
+Polyphase Merge Sort,500,63,0.00038560
+Polyphase Merge Sort,500,64,0.00037330
+Polyphase Merge Sort,500,65,0.00036270
+Polyphase Merge Sort,500,66,0.00037520
+Polyphase Merge Sort,500,67,0.00040880
+Polyphase Merge Sort,500,68,0.00038370
+Polyphase Merge Sort,500,69,0.00043500
+Polyphase Merge Sort,500,70,0.00047890
+Polyphase Merge Sort,500,71,0.00041730
+Polyphase Merge Sort,500,72,0.00044880
+Polyphase Merge Sort,500,73,0.00045960
+Polyphase Merge Sort,500,74,0.00046770
+Polyphase Merge Sort,500,75,0.00045200
+Polyphase Merge Sort,500,76,0.00044900
+Polyphase Merge Sort,500,77,0.00042830
+Polyphase Merge Sort,500,78,0.00038240
+Polyphase Merge Sort,500,79,0.00033920
+Polyphase Merge Sort,500,80,0.00030260
+Polyphase Merge Sort,500,81,0.00042530
+Polyphase Merge Sort,500,82,0.00042850
+Polyphase Merge Sort,500,83,0.00042910
+Polyphase Merge Sort,500,84,0.00042860
+Polyphase Merge Sort,500,85,0.00044660
+Polyphase Merge Sort,500,86,0.00047170
+Polyphase Merge Sort,500,87,0.00047480
+Polyphase Merge Sort,500,88,0.00047160
+Polyphase Merge Sort,500,89,0.00054700
+Polyphase Merge Sort,500,90,0.00050040
+Polyphase Merge Sort,500,91,0.00053520
+Polyphase Merge Sort,500,92,0.00029680
+Polyphase Merge Sort,500,93,0.00025890
+Polyphase Merge Sort,500,94,0.00039280
+Polyphase Merge Sort,500,95,0.00036890
+Polyphase Merge Sort,500,96,0.00036480
+Polyphase Merge Sort,500,97,0.00042430
+Polyphase Merge Sort,500,98,0.00046450
+Polyphase Merge Sort,500,99,0.00030410
+Polyphase Merge Sort,500,100,0.00025720
+Polyphase Merge Sort,500,101,0.00037130
+Polyphase Merge Sort,500,102,0.00039460
+Polyphase Merge Sort,500,103,0.00034950
+Polyphase Merge Sort,500,104,0.00036560
+Polyphase Merge Sort,500,105,0.00043610
+Polyphase Merge Sort,500,106,0.00031160
+Polyphase Merge Sort,500,107,0.00047420
+Polyphase Merge Sort,500,108,0.00044640
+Polyphase Merge Sort,500,109,0.00035530
+Polyphase Merge Sort,500,110,0.00039380
+Polyphase Merge Sort,500,111,0.00037450
+Polyphase Merge Sort,500,112,0.00038300
+Polyphase Merge Sort,500,113,0.00038320
+Polyphase Merge Sort,500,114,0.00052510
+Polyphase Merge Sort,500,115,0.00028870
+Polyphase Merge Sort,500,116,0.00040880
+Polyphase Merge Sort,500,117,0.00058700
+Polyphase Merge Sort,500,118,0.00041300
+Polyphase Merge Sort,500,119,0.00050260
+Polyphase Merge Sort,500,120,0.00038150
+Polyphase Merge Sort,500,121,0.00040570
+Polyphase Merge Sort,500,122,0.00037150
+Polyphase Merge Sort,500,123,0.00038440
+Polyphase Merge Sort,500,124,0.00038780
+Polyphase Merge Sort,500,125,0.00038260
+Polyphase Merge Sort,500,126,0.00044360
+Polyphase Merge Sort,500,127,0.00045030
+Polyphase Merge Sort,500,128,0.00026430
+Polyphase Merge Sort,500,129,0.00053580
+Polyphase Merge Sort,500,130,0.00044370
+Polyphase Merge Sort,500,131,0.00039500
+Polyphase Merge Sort,500,132,0.00042170
+Polyphase Merge Sort,500,133,0.00037770
+Polyphase Merge Sort,500,134,0.00036020
+Polyphase Merge Sort,500,135,0.00036600
+Polyphase Merge Sort,500,136,0.00037840
+Polyphase Merge Sort,500,137,0.00036680
+Polyphase Merge Sort,500,138,0.00036510
+Polyphase Merge Sort,500,139,0.00042370
+Polyphase Merge Sort,500,140,0.00040360
+Polyphase Merge Sort,500,141,0.00032310
+Polyphase Merge Sort,500,142,0.00037750
+Polyphase Merge Sort,500,143,0.00025900
+Polyphase Merge Sort,500,144,0.00027510
+Polyphase Merge Sort,500,145,0.00042640
+Polyphase Merge Sort,500,146,0.00037120
+Polyphase Merge Sort,500,147,0.00037140
+Polyphase Merge Sort,500,148,0.00038560
+Polyphase Merge Sort,500,149,0.00037100
+Polyphase Merge Sort,500,150,0.00047370
+Polyphase Merge Sort,500,151,0.00045460
+Polyphase Merge Sort,500,152,0.00055700
+Polyphase Merge Sort,500,153,0.00039870
+Polyphase Merge Sort,500,154,0.00036950
+Polyphase Merge Sort,500,155,0.00036140
+Polyphase Merge Sort,500,156,0.00047510
+Polyphase Merge Sort,500,157,0.00037640
+Polyphase Merge Sort,500,158,0.00046800
+Polyphase Merge Sort,500,159,0.00046330
+Polyphase Merge Sort,500,160,0.00043760
+Polyphase Merge Sort,500,161,0.00026510
+Polyphase Merge Sort,500,162,0.00045960
+Polyphase Merge Sort,500,163,0.00046640
+Polyphase Merge Sort,500,164,0.00042280
+Polyphase Merge Sort,500,165,0.00042190
+Polyphase Merge Sort,500,166,0.00052520
+Polyphase Merge Sort,500,167,0.00048340
+Polyphase Merge Sort,500,168,0.00062180
+Polyphase Merge Sort,500,169,0.00058830
+Polyphase Merge Sort,500,170,0.00060350
+Polyphase Merge Sort,500,171,0.00030650
+Polyphase Merge Sort,500,172,0.00062810
+Polyphase Merge Sort,500,173,0.00052520
+Polyphase Merge Sort,500,174,0.00048320
+Polyphase Merge Sort,500,175,0.00063530
+Polyphase Merge Sort,500,176,0.00041960
+Polyphase Merge Sort,500,177,0.00038740
+Polyphase Merge Sort,500,178,0.00042610
+Polyphase Merge Sort,500,179,0.00037590
+Polyphase Merge Sort,500,180,0.00039500
+Polyphase Merge Sort,500,181,0.00034290
+Polyphase Merge Sort,500,182,0.00038530
+Polyphase Merge Sort,500,183,0.00034560
+Polyphase Merge Sort,500,184,0.00041250
+Polyphase Merge Sort,500,185,0.00044270
+Polyphase Merge Sort,500,186,0.00033930
+Polyphase Merge Sort,500,187,0.00045180
+Polyphase Merge Sort,500,188,0.00026980
+Polyphase Merge Sort,500,189,0.00049200
+Polyphase Merge Sort,500,190,0.00028740
+Polyphase Merge Sort,500,191,0.00048190
+Polyphase Merge Sort,500,192,0.00030660
+Polyphase Merge Sort,500,193,0.00026960
+Polyphase Merge Sort,500,194,0.00044940
+Polyphase Merge Sort,500,195,0.00045970
+Polyphase Merge Sort,500,196,0.00047220
+Polyphase Merge Sort,500,197,0.00046090
+Polyphase Merge Sort,500,198,0.00047330
+Polyphase Merge Sort,500,199,0.00029410
+Polyphase Merge Sort,500,200,0.00028060
+Polyphase Merge Sort,500,201,0.00026710
+Polyphase Merge Sort,500,202,0.00036440
+Polyphase Merge Sort,500,203,0.00042580
+Polyphase Merge Sort,500,204,0.00041610
+Polyphase Merge Sort,500,205,0.00040620
+Polyphase Merge Sort,500,206,0.00025510
+Polyphase Merge Sort,500,207,0.00042010
+Polyphase Merge Sort,500,208,0.00040080
+Polyphase Merge Sort,500,209,0.00043010
+Polyphase Merge Sort,500,210,0.00033830
+Polyphase Merge Sort,500,211,0.00051300
+Polyphase Merge Sort,500,212,0.00034840
+Polyphase Merge Sort,500,213,0.00049510
+Polyphase Merge Sort,500,214,0.00050440
+Polyphase Merge Sort,500,215,0.00056950
+Polyphase Merge Sort,500,216,0.00065960
+Polyphase Merge Sort,500,217,0.00043190
+Polyphase Merge Sort,500,218,0.00036990
+Polyphase Merge Sort,500,219,0.00040300
+Polyphase Merge Sort,500,220,0.00043740
+Polyphase Merge Sort,500,221,0.00042390
+Polyphase Merge Sort,500,222,0.00026080
+Polyphase Merge Sort,500,223,0.00041980
+Polyphase Merge Sort,500,224,0.00040830
+Polyphase Merge Sort,500,225,0.00039370
+Polyphase Merge Sort,500,226,0.00028560
+Polyphase Merge Sort,500,227,0.00025110
+Polyphase Merge Sort,500,228,0.00038010
+Polyphase Merge Sort,500,229,0.00031680
+Polyphase Merge Sort,500,230,0.00037260
+Polyphase Merge Sort,500,231,0.00040340
+Polyphase Merge Sort,500,232,0.00038160
+Polyphase Merge Sort,500,233,0.00039400
+Polyphase Merge Sort,500,234,0.00037430
+Polyphase Merge Sort,500,235,0.00025070
+Polyphase Merge Sort,500,236,0.00034290
+Polyphase Merge Sort,500,237,0.00030190
+Polyphase Merge Sort,500,238,0.00025480
+Polyphase Merge Sort,500,239,0.00025790
+Polyphase Merge Sort,500,240,0.00048820
+Polyphase Merge Sort,500,241,0.00045760
+Polyphase Merge Sort,500,242,0.00042760
+Polyphase Merge Sort,500,243,0.00040450
+Polyphase Merge Sort,500,244,0.00044430
+Polyphase Merge Sort,500,245,0.00044830
+Polyphase Merge Sort,500,246,0.00040830
+Polyphase Merge Sort,500,247,0.00045620
+Polyphase Merge Sort,500,248,0.00042950
+Polyphase Merge Sort,500,249,0.00045570
+Polyphase Merge Sort,500,250,0.00032880
+Polyphase Merge Sort,500,251,0.00044300
+Polyphase Merge Sort,500,252,0.00032710
+Polyphase Merge Sort,500,253,0.00042960
+Polyphase Merge Sort,500,254,0.00033120
+Polyphase Merge Sort,500,255,0.00035180
+Polyphase Merge Sort,500,256,0.00040210
+Polyphase Merge Sort,500,257,0.00028770
+Polyphase Merge Sort,500,258,0.00038890
+Polyphase Merge Sort,500,259,0.00055390
+Polyphase Merge Sort,500,260,0.00051450
+Polyphase Merge Sort,500,261,0.00030310
+Polyphase Merge Sort,500,262,0.00027570
+Polyphase Merge Sort,500,263,0.00025580
+Polyphase Merge Sort,500,264,0.00026300
+Polyphase Merge Sort,500,265,0.00048190
+Polyphase Merge Sort,500,266,0.00038110
+Polyphase Merge Sort,500,267,0.00045250
+Polyphase Merge Sort,500,268,0.00043490
+Polyphase Merge Sort,500,269,0.00037550
+Polyphase Merge Sort,500,270,0.00040600
+Polyphase Merge Sort,500,271,0.00025470
+Polyphase Merge Sort,500,272,0.00041360
+Polyphase Merge Sort,500,273,0.00047370
+Polyphase Merge Sort,500,274,0.00047140
+Polyphase Merge Sort,500,275,0.00047200
+Polyphase Merge Sort,500,276,0.00042190
+Polyphase Merge Sort,500,277,0.00040140
+Polyphase Merge Sort,500,278,0.00040950
+Polyphase Merge Sort,500,279,0.00051390
+Polyphase Merge Sort,500,280,0.00035820
+Polyphase Merge Sort,500,281,0.00049270
+Polyphase Merge Sort,500,282,0.00042710
+Polyphase Merge Sort,500,283,0.00036800
+Polyphase Merge Sort,500,284,0.00042900
+Polyphase Merge Sort,500,285,0.00035500
+Polyphase Merge Sort,500,286,0.00045460
+Polyphase Merge Sort,500,287,0.00035100
+Polyphase Merge Sort,500,288,0.00045710
+Polyphase Merge Sort,500,289,0.00036660
+Polyphase Merge Sort,500,290,0.00042430
+Polyphase Merge Sort,500,291,0.00037880
+Polyphase Merge Sort,500,292,0.00037550
+Polyphase Merge Sort,500,293,0.00036730
+Polyphase Merge Sort,500,294,0.00043520
+Polyphase Merge Sort,500,295,0.00036250
+Polyphase Merge Sort,500,296,0.00034620
+Polyphase Merge Sort,500,297,0.00025820
+Polyphase Merge Sort,500,298,0.00040660
+Polyphase Merge Sort,500,299,0.00034910
+Polyphase Merge Sort,500,300,0.00036680
+Polyphase Merge Sort,500,301,0.00042390
+Polyphase Merge Sort,500,302,0.00041710
+Polyphase Merge Sort,500,303,0.00047430
+Polyphase Merge Sort,500,304,0.00040240
+Polyphase Merge Sort,500,305,0.00051350
+Polyphase Merge Sort,500,306,0.00047410
+Polyphase Merge Sort,500,307,0.00032940
+Polyphase Merge Sort,500,308,0.00034660
+Polyphase Merge Sort,500,309,0.00039370
+Polyphase Merge Sort,500,310,0.00039700
+Polyphase Merge Sort,500,311,0.00038450
+Polyphase Merge Sort,500,312,0.00040050
+Polyphase Merge Sort,500,313,0.00039320
+Polyphase Merge Sort,500,314,0.00038380
+Polyphase Merge Sort,500,315,0.00049560
+Polyphase Merge Sort,500,316,0.00039820
+Polyphase Merge Sort,500,317,0.00047180
+Polyphase Merge Sort,500,318,0.00039730
+Polyphase Merge Sort,500,319,0.00044280
+Polyphase Merge Sort,500,320,0.00035990
+Polyphase Merge Sort,500,321,0.00045860
+Polyphase Merge Sort,500,322,0.00028000
+Polyphase Merge Sort,500,323,0.00051560
+Polyphase Merge Sort,500,324,0.00056280
+Polyphase Merge Sort,500,325,0.00039000
+Polyphase Merge Sort,500,326,0.00051270
+Polyphase Merge Sort,500,327,0.00050510
+Polyphase Merge Sort,500,328,0.00037550
+Polyphase Merge Sort,500,329,0.00040250
+Polyphase Merge Sort,500,330,0.00043980
+Polyphase Merge Sort,500,331,0.00038510
+Polyphase Merge Sort,500,332,0.00038780
+Polyphase Merge Sort,500,333,0.00040420
+Polyphase Merge Sort,500,334,0.00040460
+Polyphase Merge Sort,500,335,0.00039930
+Polyphase Merge Sort,500,336,0.00037900
+Polyphase Merge Sort,500,337,0.00041670
+Polyphase Merge Sort,500,338,0.00034470
+Polyphase Merge Sort,500,339,0.00034250
+Polyphase Merge Sort,500,340,0.00037220
+Polyphase Merge Sort,500,341,0.00039230
+Polyphase Merge Sort,500,342,0.00043440
+Polyphase Merge Sort,500,343,0.00036870
+Polyphase Merge Sort,500,344,0.00039280
+Polyphase Merge Sort,500,345,0.00025720
+Polyphase Merge Sort,500,346,0.00028090
+Polyphase Merge Sort,500,347,0.00031950
+Polyphase Merge Sort,500,348,0.00025500
+Polyphase Merge Sort,500,349,0.00035450
+Polyphase Merge Sort,500,350,0.00025810
+Polyphase Merge Sort,500,351,0.00025330
+Polyphase Merge Sort,500,352,0.00025440
+Polyphase Merge Sort,500,353,0.00030880
+Polyphase Merge Sort,500,354,0.00047720
+Polyphase Merge Sort,500,355,0.00027710
+Polyphase Merge Sort,500,356,0.00045830
+Polyphase Merge Sort,500,357,0.00043650
+Polyphase Merge Sort,500,358,0.00049430
+Polyphase Merge Sort,500,359,0.00039010
+Polyphase Merge Sort,500,360,0.00028460
+Polyphase Merge Sort,500,361,0.00041340
+Polyphase Merge Sort,500,362,0.00038540
+Polyphase Merge Sort,500,363,0.00024500
+Polyphase Merge Sort,500,364,0.00038950
+Polyphase Merge Sort,500,365,0.00043310
+Polyphase Merge Sort,500,366,0.00043900
+Polyphase Merge Sort,500,367,0.00044000
+Polyphase Merge Sort,500,368,0.00040070
+Polyphase Merge Sort,500,369,0.00039040
+Polyphase Merge Sort,500,370,0.00038240
+Polyphase Merge Sort,500,371,0.00044570
+Polyphase Merge Sort,500,372,0.00039750
+Polyphase Merge Sort,500,373,0.00048470
+Polyphase Merge Sort,500,374,0.00039970
+Polyphase Merge Sort,500,375,0.00048390
+Polyphase Merge Sort,500,376,0.00035440
+Polyphase Merge Sort,500,377,0.00058210
+Polyphase Merge Sort,500,378,0.00035560
+Polyphase Merge Sort,500,379,0.00045590
+Polyphase Merge Sort,500,380,0.00046320
+Polyphase Merge Sort,500,381,0.00043570
+Polyphase Merge Sort,500,382,0.00045790
+Polyphase Merge Sort,500,383,0.00045500
+Polyphase Merge Sort,500,384,0.00043250
+Polyphase Merge Sort,500,385,0.00045770
+Polyphase Merge Sort,500,386,0.00045740
+Polyphase Merge Sort,500,387,0.00028280
+Polyphase Merge Sort,500,388,0.00046700
+Polyphase Merge Sort,500,389,0.00041780
+Polyphase Merge Sort,500,390,0.00046400
+Polyphase Merge Sort,500,391,0.00041560
+Polyphase Merge Sort,500,392,0.00033890
+Polyphase Merge Sort,500,393,0.00044360
+Polyphase Merge Sort,500,394,0.00035260
+Polyphase Merge Sort,500,395,0.00039900
+Polyphase Merge Sort,500,396,0.00030220
+Polyphase Merge Sort,500,397,0.00025570
+Polyphase Merge Sort,500,398,0.00039460
+Polyphase Merge Sort,500,399,0.00058120
+Polyphase Merge Sort,500,400,0.00033070
+Polyphase Merge Sort,500,401,0.00034820
+Polyphase Merge Sort,500,402,0.00024690
+Polyphase Merge Sort,500,403,0.00047670
+Polyphase Merge Sort,500,404,0.00033490
+Polyphase Merge Sort,500,405,0.00045530
+Polyphase Merge Sort,500,406,0.00041840
+Polyphase Merge Sort,500,407,0.00027720
+Polyphase Merge Sort,500,408,0.00043350
+Polyphase Merge Sort,500,409,0.00045190
+Polyphase Merge Sort,500,410,0.00040430
+Polyphase Merge Sort,500,411,0.00043930
+Polyphase Merge Sort,500,412,0.00041480
+Polyphase Merge Sort,500,413,0.00059180
+Polyphase Merge Sort,500,414,0.00045680
+Polyphase Merge Sort,500,415,0.00048550
+Polyphase Merge Sort,500,416,0.00049890
+Polyphase Merge Sort,500,417,0.00052480
+Polyphase Merge Sort,500,418,0.00043220
+Polyphase Merge Sort,500,419,0.00039440
+Polyphase Merge Sort,500,420,0.00026850
+Polyphase Merge Sort,500,421,0.00027080
+Polyphase Merge Sort,500,422,0.00041550
+Polyphase Merge Sort,500,423,0.00044910
+Polyphase Merge Sort,500,424,0.00025010
+Polyphase Merge Sort,500,425,0.00035780
+Polyphase Merge Sort,500,426,0.00043650
+Polyphase Merge Sort,500,427,0.00026360
+Polyphase Merge Sort,500,428,0.00043220
+Polyphase Merge Sort,500,429,0.00025380
+Polyphase Merge Sort,500,430,0.00045070
+Polyphase Merge Sort,500,431,0.00028830
+Polyphase Merge Sort,500,432,0.00044570
+Polyphase Merge Sort,500,433,0.00046090
+Polyphase Merge Sort,500,434,0.00049300
+Polyphase Merge Sort,500,435,0.00038960
+Polyphase Merge Sort,500,436,0.00053150
+Polyphase Merge Sort,500,437,0.00026400
+Polyphase Merge Sort,500,438,0.00042660
+Polyphase Merge Sort,500,439,0.00026410
+Polyphase Merge Sort,500,440,0.00053090
+Polyphase Merge Sort,500,441,0.00042690
+Polyphase Merge Sort,500,442,0.00025260
+Polyphase Merge Sort,500,443,0.00045340
+Polyphase Merge Sort,500,444,0.00044550
+Polyphase Merge Sort,500,445,0.00040920
+Polyphase Merge Sort,500,446,0.00045920
+Polyphase Merge Sort,500,447,0.00054150
+Polyphase Merge Sort,500,448,0.00046120
+Polyphase Merge Sort,500,449,0.00046430
+Polyphase Merge Sort,500,450,0.00045790
+Polyphase Merge Sort,500,451,0.00039930
+Polyphase Merge Sort,500,452,0.00046350
+Polyphase Merge Sort,500,453,0.00040610
+Polyphase Merge Sort,500,454,0.00045960
+Polyphase Merge Sort,500,455,0.00037960
+Polyphase Merge Sort,500,456,0.00041600
+Polyphase Merge Sort,500,457,0.00046230
+Polyphase Merge Sort,500,458,0.00037000
+Polyphase Merge Sort,500,459,0.00039680
+Polyphase Merge Sort,500,460,0.00036680
+Polyphase Merge Sort,500,461,0.00040860
+Polyphase Merge Sort,500,462,0.00040800
+Polyphase Merge Sort,500,463,0.00030080
+Polyphase Merge Sort,500,464,0.00039500
+Polyphase Merge Sort,500,465,0.00031520
+Polyphase Merge Sort,500,466,0.00040640
+Polyphase Merge Sort,500,467,0.00038240
+Polyphase Merge Sort,500,468,0.00046420
+Polyphase Merge Sort,500,469,0.00040260
+Polyphase Merge Sort,500,470,0.00046740
+Polyphase Merge Sort,500,471,0.00040190
+Polyphase Merge Sort,500,472,0.00047520
+Polyphase Merge Sort,500,473,0.00046610
+Polyphase Merge Sort,500,474,0.00036210
+Polyphase Merge Sort,500,475,0.00049300
+Polyphase Merge Sort,500,476,0.00053360
+Polyphase Merge Sort,500,477,0.00047290
+Polyphase Merge Sort,500,478,0.00043350
+Polyphase Merge Sort,500,479,0.00046870
+Polyphase Merge Sort,500,480,0.00045760
+Polyphase Merge Sort,500,481,0.00043710
+Polyphase Merge Sort,500,482,0.00036580
+Polyphase Merge Sort,500,483,0.00042540
+Polyphase Merge Sort,500,484,0.00052310
+Polyphase Merge Sort,500,485,0.00044060
+Polyphase Merge Sort,500,486,0.00043520
+Polyphase Merge Sort,500,487,0.00051620
+Polyphase Merge Sort,500,488,0.00046040
+Polyphase Merge Sort,500,489,0.00044260
+Polyphase Merge Sort,500,490,0.00039710
+Polyphase Merge Sort,500,491,0.00045380
+Polyphase Merge Sort,500,492,0.00043820
+Polyphase Merge Sort,500,493,0.00044430
+Polyphase Merge Sort,500,494,0.00044240
+Polyphase Merge Sort,500,495,0.00043730
+Polyphase Merge Sort,500,496,0.00037460
+Polyphase Merge Sort,500,497,0.00043590
+Polyphase Merge Sort,500,498,0.00042810
+Polyphase Merge Sort,500,499,0.00040540
+Polyphase Merge Sort,500,500,0.00037480
+Postman Sort,500,1,0.00085890
+Postman Sort,500,2,0.00106740
+Postman Sort,500,3,0.00113390
+Postman Sort,500,4,0.00095680
+Postman Sort,500,5,0.00102520
+Postman Sort,500,6,0.00093400
+Postman Sort,500,7,0.00089480
+Postman Sort,500,8,0.00095260
+Postman Sort,500,9,0.00088350
+Postman Sort,500,10,0.00094400
+Postman Sort,500,11,0.00110540
+Postman Sort,500,12,0.00102860
+Postman Sort,500,13,0.00095320
+Postman Sort,500,14,0.00090180
+Postman Sort,500,15,0.00094130
+Postman Sort,500,16,0.00105010
+Postman Sort,500,17,0.00119990
+Postman Sort,500,18,0.00087600
+Postman Sort,500,19,0.00117130
+Postman Sort,500,20,0.00093500
+Postman Sort,500,21,0.00087810
+Postman Sort,500,22,0.00092210
+Postman Sort,500,23,0.00089090
+Postman Sort,500,24,0.00088810
+Postman Sort,500,25,0.00097590
+Postman Sort,500,26,0.00105140
+Postman Sort,500,27,0.00096620
+Postman Sort,500,28,0.00107470
+Postman Sort,500,29,0.00099020
+Postman Sort,500,30,0.00136980
+Postman Sort,500,31,0.00106390
+Postman Sort,500,32,0.00102970
+Postman Sort,500,33,0.00112380
+Postman Sort,500,34,0.00121660
+Postman Sort,500,35,0.00088530
+Postman Sort,500,36,0.00106880
+Postman Sort,500,37,0.00095580
+Postman Sort,500,38,0.00090850
+Postman Sort,500,39,0.00125110
+Postman Sort,500,40,0.00123930
+Postman Sort,500,41,0.00094700
+Postman Sort,500,42,0.00115900
+Postman Sort,500,43,0.00091610
+Postman Sort,500,44,0.00105770
+Postman Sort,500,45,0.00105530
+Postman Sort,500,46,0.00108100
+Postman Sort,500,47,0.00098880
+Postman Sort,500,48,0.00113080
+Postman Sort,500,49,0.00100730
+Postman Sort,500,50,0.00088990
+Postman Sort,500,51,0.00104520
+Postman Sort,500,52,0.00098570
+Postman Sort,500,53,0.00065690
+Postman Sort,500,54,0.00105660
+Postman Sort,500,55,0.00103780
+Postman Sort,500,56,0.00099940
+Postman Sort,500,57,0.00069720
+Postman Sort,500,58,0.00099220
+Postman Sort,500,59,0.00106780
+Postman Sort,500,60,0.00067410
+Postman Sort,500,61,0.00100390
+Postman Sort,500,62,0.00105390
+Postman Sort,500,63,0.00091910
+Postman Sort,500,64,0.00094710
+Postman Sort,500,65,0.00087130
+Postman Sort,500,66,0.00105720
+Postman Sort,500,67,0.00075680
+Postman Sort,500,68,0.00108320
+Postman Sort,500,69,0.00096180
+Postman Sort,500,70,0.00087370
+Postman Sort,500,71,0.00081810
+Postman Sort,500,72,0.00095460
+Postman Sort,500,73,0.00100110
+Postman Sort,500,74,0.00095420
+Postman Sort,500,75,0.00087660
+Postman Sort,500,76,0.00089800
+Postman Sort,500,77,0.00102380
+Postman Sort,500,78,0.00080390
+Postman Sort,500,79,0.00102490
+Postman Sort,500,80,0.00089670
+Postman Sort,500,81,0.00114630
+Postman Sort,500,82,0.00108250
+Postman Sort,500,83,0.00120980
+Postman Sort,500,84,0.00114360
+Postman Sort,500,85,0.00109450
+Postman Sort,500,86,0.00119980
+Postman Sort,500,87,0.00126350
+Postman Sort,500,88,0.00109750
+Postman Sort,500,89,0.00108930
+Postman Sort,500,90,0.00120180
+Postman Sort,500,91,0.00095860
+Postman Sort,500,92,0.00091990
+Postman Sort,500,93,0.00116430
+Postman Sort,500,94,0.00105570
+Postman Sort,500,95,0.00114870
+Postman Sort,500,96,0.00098920
+Postman Sort,500,97,0.00111240
+Postman Sort,500,98,0.00064150
+Postman Sort,500,99,0.00064260
+Postman Sort,500,100,0.00103430
+Postman Sort,500,101,0.00115390
+Postman Sort,500,102,0.00098590
+Postman Sort,500,103,0.00099780
+Postman Sort,500,104,0.00090860
+Postman Sort,500,105,0.00106150
+Postman Sort,500,106,0.00097040
+Postman Sort,500,107,0.00094620
+Postman Sort,500,108,0.00115080
+Postman Sort,500,109,0.00109330
+Postman Sort,500,110,0.00107130
+Postman Sort,500,111,0.00094420
+Postman Sort,500,112,0.00096790
+Postman Sort,500,113,0.00126510
+Postman Sort,500,114,0.00095500
+Postman Sort,500,115,0.00123580
+Postman Sort,500,116,0.00126560
+Postman Sort,500,117,0.00112170
+Postman Sort,500,118,0.00125800
+Postman Sort,500,119,0.00100410
+Postman Sort,500,120,0.00107900
+Postman Sort,500,121,0.00070590
+Postman Sort,500,122,0.00115570
+Postman Sort,500,123,0.00127210
+Postman Sort,500,124,0.00091180
+Postman Sort,500,125,0.00097080
+Postman Sort,500,126,0.00108700
+Postman Sort,500,127,0.00106800
+Postman Sort,500,128,0.00105490
+Postman Sort,500,129,0.00114540
+Postman Sort,500,130,0.00114340
+Postman Sort,500,131,0.00104680
+Postman Sort,500,132,0.00100160
+Postman Sort,500,133,0.00115660
+Postman Sort,500,134,0.00115190
+Postman Sort,500,135,0.00099930
+Postman Sort,500,136,0.00114470
+Postman Sort,500,137,0.00102010
+Postman Sort,500,138,0.00107330
+Postman Sort,500,139,0.00104990
+Postman Sort,500,140,0.00111070
+Postman Sort,500,141,0.00100620
+Postman Sort,500,142,0.00069140
+Postman Sort,500,143,0.00072160
+Postman Sort,500,144,0.00119130
+Postman Sort,500,145,0.00143620
+Postman Sort,500,146,0.00114650
+Postman Sort,500,147,0.00097320
+Postman Sort,500,148,0.00088280
+Postman Sort,500,149,0.00111690
+Postman Sort,500,150,0.00094350
+Postman Sort,500,151,0.00103120
+Postman Sort,500,152,0.00085080
+Postman Sort,500,153,0.00110040
+Postman Sort,500,154,0.00097350
+Postman Sort,500,155,0.00109050
+Postman Sort,500,156,0.00112780
+Postman Sort,500,157,0.00098520
+Postman Sort,500,158,0.00114720
+Postman Sort,500,159,0.00071880
+Postman Sort,500,160,0.00099500
+Postman Sort,500,161,0.00083390
+Postman Sort,500,162,0.00064880
+Postman Sort,500,163,0.00080470
+Postman Sort,500,164,0.00066900
+Postman Sort,500,165,0.00064800
+Postman Sort,500,166,0.00074140
+Postman Sort,500,167,0.00097750
+Postman Sort,500,168,0.00070840
+Postman Sort,500,169,0.00105330
+Postman Sort,500,170,0.00064480
+Postman Sort,500,171,0.00103370
+Postman Sort,500,172,0.00069910
+Postman Sort,500,173,0.00103520
+Postman Sort,500,174,0.00100120
+Postman Sort,500,175,0.00070960
+Postman Sort,500,176,0.00083820
+Postman Sort,500,177,0.00075590
+Postman Sort,500,178,0.00097430
+Postman Sort,500,179,0.00098030
+Postman Sort,500,180,0.00063120
+Postman Sort,500,181,0.00094030
+Postman Sort,500,182,0.00105530
+Postman Sort,500,183,0.00103760
+Postman Sort,500,184,0.00083920
+Postman Sort,500,185,0.00103940
+Postman Sort,500,186,0.00094970
+Postman Sort,500,187,0.00116330
+Postman Sort,500,188,0.00097790
+Postman Sort,500,189,0.00096610
+Postman Sort,500,190,0.00103340
+Postman Sort,500,191,0.00074970
+Postman Sort,500,192,0.00097840
+Postman Sort,500,193,0.00104490
+Postman Sort,500,194,0.00077640
+Postman Sort,500,195,0.00105810
+Postman Sort,500,196,0.00090640
+Postman Sort,500,197,0.00102450
+Postman Sort,500,198,0.00103590
+Postman Sort,500,199,0.00077310
+Postman Sort,500,200,0.00110710
+Postman Sort,500,201,0.00114070
+Postman Sort,500,202,0.00118270
+Postman Sort,500,203,0.00104730
+Postman Sort,500,204,0.00109450
+Postman Sort,500,205,0.00108590
+Postman Sort,500,206,0.00101090
+Postman Sort,500,207,0.00114610
+Postman Sort,500,208,0.00108160
+Postman Sort,500,209,0.00092900
+Postman Sort,500,210,0.00094360
+Postman Sort,500,211,0.00103260
+Postman Sort,500,212,0.00081670
+Postman Sort,500,213,0.00080840
+Postman Sort,500,214,0.00113050
+Postman Sort,500,215,0.00109790
+Postman Sort,500,216,0.00093140
+Postman Sort,500,217,0.00089240
+Postman Sort,500,218,0.00101710
+Postman Sort,500,219,0.00081440
+Postman Sort,500,220,0.00088780
+Postman Sort,500,221,0.00100650
+Postman Sort,500,222,0.00114520
+Postman Sort,500,223,0.00089500
+Postman Sort,500,224,0.00075980
+Postman Sort,500,225,0.00088720
+Postman Sort,500,226,0.00098020
+Postman Sort,500,227,0.00093540
+Postman Sort,500,228,0.00094700
+Postman Sort,500,229,0.00116220
+Postman Sort,500,230,0.00063290
+Postman Sort,500,231,0.00102180
+Postman Sort,500,232,0.00102690
+Postman Sort,500,233,0.00074170
+Postman Sort,500,234,0.00109000
+Postman Sort,500,235,0.00109330
+Postman Sort,500,236,0.00099490
+Postman Sort,500,237,0.00119150
+Postman Sort,500,238,0.00107670
+Postman Sort,500,239,0.00108340
+Postman Sort,500,240,0.00093180
+Postman Sort,500,241,0.00120450
+Postman Sort,500,242,0.00101150
+Postman Sort,500,243,0.00120230
+Postman Sort,500,244,0.00075560
+Postman Sort,500,245,0.00094410
+Postman Sort,500,246,0.00114700
+Postman Sort,500,247,0.00097650
+Postman Sort,500,248,0.00106480
+Postman Sort,500,249,0.00090960
+Postman Sort,500,250,0.00109770
+Postman Sort,500,251,0.00070100
+Postman Sort,500,252,0.00110130
+Postman Sort,500,253,0.00118450
+Postman Sort,500,254,0.00088470
+Postman Sort,500,255,0.00094690
+Postman Sort,500,256,0.00062250
+Postman Sort,500,257,0.00095350
+Postman Sort,500,258,0.00096930
+Postman Sort,500,259,0.00100340
+Postman Sort,500,260,0.00063770
+Postman Sort,500,261,0.00094290
+Postman Sort,500,262,0.00072420
+Postman Sort,500,263,0.00065750
+Postman Sort,500,264,0.00096800
+Postman Sort,500,265,0.00068080
+Postman Sort,500,266,0.00088190
+Postman Sort,500,267,0.00106000
+Postman Sort,500,268,0.00095290
+Postman Sort,500,269,0.00079800
+Postman Sort,500,270,0.00073880
+Postman Sort,500,271,0.00115570
+Postman Sort,500,272,0.00115380
+Postman Sort,500,273,0.00072900
+Postman Sort,500,274,0.00110960
+Postman Sort,500,275,0.00112380
+Postman Sort,500,276,0.00107220
+Postman Sort,500,277,0.00065500
+Postman Sort,500,278,0.00111400
+Postman Sort,500,279,0.00112190
+Postman Sort,500,280,0.00064390
+Postman Sort,500,281,0.00117920
+Postman Sort,500,282,0.00123270
+Postman Sort,500,283,0.00103690
+Postman Sort,500,284,0.00076940
+Postman Sort,500,285,0.00085210
+Postman Sort,500,286,0.00069960
+Postman Sort,500,287,0.00088570
+Postman Sort,500,288,0.00080390
+Postman Sort,500,289,0.00062430
+Postman Sort,500,290,0.00065640
+Postman Sort,500,291,0.00101000
+Postman Sort,500,292,0.00063910
+Postman Sort,500,293,0.00081330
+Postman Sort,500,294,0.00084670
+Postman Sort,500,295,0.00103690
+Postman Sort,500,296,0.00110070
+Postman Sort,500,297,0.00113260
+Postman Sort,500,298,0.00076180
+Postman Sort,500,299,0.00098820
+Postman Sort,500,300,0.00075680
+Postman Sort,500,301,0.00096030
+Postman Sort,500,302,0.00117010
+Postman Sort,500,303,0.00110770
+Postman Sort,500,304,0.00093150
+Postman Sort,500,305,0.00113110
+Postman Sort,500,306,0.00116020
+Postman Sort,500,307,0.00075970
+Postman Sort,500,308,0.00150610
+Postman Sort,500,309,0.00109170
+Postman Sort,500,310,0.00076040
+Postman Sort,500,311,0.00107620
+Postman Sort,500,312,0.00145810
+Postman Sort,500,313,0.00114120
+Postman Sort,500,314,0.00114730
+Postman Sort,500,315,0.00119070
+Postman Sort,500,316,0.00108360
+Postman Sort,500,317,0.00103470
+Postman Sort,500,318,0.00107820
+Postman Sort,500,319,0.00076650
+Postman Sort,500,320,0.00091030
+Postman Sort,500,321,0.00117350
+Postman Sort,500,322,0.00114500
+Postman Sort,500,323,0.00094830
+Postman Sort,500,324,0.00102730
+Postman Sort,500,325,0.00106440
+Postman Sort,500,326,0.00080140
+Postman Sort,500,327,0.00118720
+Postman Sort,500,328,0.00104260
+Postman Sort,500,329,0.00110580
+Postman Sort,500,330,0.00097780
+Postman Sort,500,331,0.00124550
+Postman Sort,500,332,0.00123860
+Postman Sort,500,333,0.00111100
+Postman Sort,500,334,0.00066280
+Postman Sort,500,335,0.00111040
+Postman Sort,500,336,0.00098020
+Postman Sort,500,337,0.00063790
+Postman Sort,500,338,0.00104500
+Postman Sort,500,339,0.00112770
+Postman Sort,500,340,0.00113260
+Postman Sort,500,341,0.00138490
+Postman Sort,500,342,0.00121950
+Postman Sort,500,343,0.00113220
+Postman Sort,500,344,0.00128330
+Postman Sort,500,345,0.00118390
+Postman Sort,500,346,0.00115640
+Postman Sort,500,347,0.00103260
+Postman Sort,500,348,0.00100060
+Postman Sort,500,349,0.00112080
+Postman Sort,500,350,0.00088100
+Postman Sort,500,351,0.00112390
+Postman Sort,500,352,0.00114030
+Postman Sort,500,353,0.00091480
+Postman Sort,500,354,0.00108860
+Postman Sort,500,355,0.00101610
+Postman Sort,500,356,0.00102520
+Postman Sort,500,357,0.00092520
+Postman Sort,500,358,0.00097050
+Postman Sort,500,359,0.00097900
+Postman Sort,500,360,0.00104130
+Postman Sort,500,361,0.00119510
+Postman Sort,500,362,0.00097340
+Postman Sort,500,363,0.00063960
+Postman Sort,500,364,0.00107440
+Postman Sort,500,365,0.00106770
+Postman Sort,500,366,0.00098070
+Postman Sort,500,367,0.00070740
+Postman Sort,500,368,0.00064150
+Postman Sort,500,369,0.00089760
+Postman Sort,500,370,0.00085980
+Postman Sort,500,371,0.00067190
+Postman Sort,500,372,0.00102440
+Postman Sort,500,373,0.00065630
+Postman Sort,500,374,0.00092870
+Postman Sort,500,375,0.00080230
+Postman Sort,500,376,0.00068990
+Postman Sort,500,377,0.00089370
+Postman Sort,500,378,0.00094510
+Postman Sort,500,379,0.00094250
+Postman Sort,500,380,0.00064570
+Postman Sort,500,381,0.00079250
+Postman Sort,500,382,0.00100910
+Postman Sort,500,383,0.00099660
+Postman Sort,500,384,0.00088290
+Postman Sort,500,385,0.00114760
+Postman Sort,500,386,0.00112050
+Postman Sort,500,387,0.00114130
+Postman Sort,500,388,0.00097510
+Postman Sort,500,389,0.00107280
+Postman Sort,500,390,0.00079200
+Postman Sort,500,391,0.00121580
+Postman Sort,500,392,0.00085620
+Postman Sort,500,393,0.00104940
+Postman Sort,500,394,0.00104360
+Postman Sort,500,395,0.00099980
+Postman Sort,500,396,0.00115250
+Postman Sort,500,397,0.00093300
+Postman Sort,500,398,0.00093900
+Postman Sort,500,399,0.00078650
+Postman Sort,500,400,0.00116990
+Postman Sort,500,401,0.00111650
+Postman Sort,500,402,0.00075740
+Postman Sort,500,403,0.00065120
+Postman Sort,500,404,0.00103140
+Postman Sort,500,405,0.00101150
+Postman Sort,500,406,0.00094280
+Postman Sort,500,407,0.00098420
+Postman Sort,500,408,0.00097240
+Postman Sort,500,409,0.00091560
+Postman Sort,500,410,0.00068360
+Postman Sort,500,411,0.00083510
+Postman Sort,500,412,0.00100070
+Postman Sort,500,413,0.00102300
+Postman Sort,500,414,0.00086520
+Postman Sort,500,415,0.00112750
+Postman Sort,500,416,0.00111580
+Postman Sort,500,417,0.00087720
+Postman Sort,500,418,0.00066810
+Postman Sort,500,419,0.00110610
+Postman Sort,500,420,0.00091350
+Postman Sort,500,421,0.00110790
+Postman Sort,500,422,0.00106550
+Postman Sort,500,423,0.00115900
+Postman Sort,500,424,0.00090960
+Postman Sort,500,425,0.00104120
+Postman Sort,500,426,0.00112790
+Postman Sort,500,427,0.00101190
+Postman Sort,500,428,0.00106520
+Postman Sort,500,429,0.00111300
+Postman Sort,500,430,0.00086920
+Postman Sort,500,431,0.00112210
+Postman Sort,500,432,0.00092160
+Postman Sort,500,433,0.00119360
+Postman Sort,500,434,0.00091270
+Postman Sort,500,435,0.00090770
+Postman Sort,500,436,0.00096070
+Postman Sort,500,437,0.00079500
+Postman Sort,500,438,0.00130270
+Postman Sort,500,439,0.00074350
+Postman Sort,500,440,0.00095940
+Postman Sort,500,441,0.00086900
+Postman Sort,500,442,0.00074010
+Postman Sort,500,443,0.00095610
+Postman Sort,500,444,0.00128720
+Postman Sort,500,445,0.00111980
+Postman Sort,500,446,0.00098390
+Postman Sort,500,447,0.00071360
+Postman Sort,500,448,0.00098410
+Postman Sort,500,449,0.00094910
+Postman Sort,500,450,0.00104010
+Postman Sort,500,451,0.00067660
+Postman Sort,500,452,0.00112550
+Postman Sort,500,453,0.00110280
+Postman Sort,500,454,0.00129720
+Postman Sort,500,455,0.00106370
+Postman Sort,500,456,0.00100660
+Postman Sort,500,457,0.00111220
+Postman Sort,500,458,0.00106910
+Postman Sort,500,459,0.00106330
+Postman Sort,500,460,0.00094430
+Postman Sort,500,461,0.00062610
+Postman Sort,500,462,0.00064800
+Postman Sort,500,463,0.00108660
+Postman Sort,500,464,0.00134260
+Postman Sort,500,465,0.00089920
+Postman Sort,500,466,0.00103650
+Postman Sort,500,467,0.00077810
+Postman Sort,500,468,0.00087640
+Postman Sort,500,469,0.00079980
+Postman Sort,500,470,0.00104120
+Postman Sort,500,471,0.00110230
+Postman Sort,500,472,0.00092510
+Postman Sort,500,473,0.00076730
+Postman Sort,500,474,0.00072140
+Postman Sort,500,475,0.00108250
+Postman Sort,500,476,0.00101600
+Postman Sort,500,477,0.00090530
+Postman Sort,500,478,0.00065610
+Postman Sort,500,479,0.00106110
+Postman Sort,500,480,0.00088210
+Postman Sort,500,481,0.00097780
+Postman Sort,500,482,0.00064510
+Postman Sort,500,483,0.00066230
+Postman Sort,500,484,0.00087510
+Postman Sort,500,485,0.00071970
+Postman Sort,500,486,0.00099690
+Postman Sort,500,487,0.00097580
+Postman Sort,500,488,0.00084050
+Postman Sort,500,489,0.00094070
+Postman Sort,500,490,0.00093070
+Postman Sort,500,491,0.00098710
+Postman Sort,500,492,0.00069620
+Postman Sort,500,493,0.00107720
+Postman Sort,500,494,0.00095700
+Postman Sort,500,495,0.00066950
+Postman Sort,500,496,0.00102200
+Postman Sort,500,497,0.00116500
+Postman Sort,500,498,0.00092800
+Postman Sort,500,499,0.00094460
+Postman Sort,500,500,0.00079740
+Quick Sort,500,1,0.00112270
+Quick Sort,500,2,0.00105310
+Quick Sort,500,3,0.00094800
+Quick Sort,500,4,0.00068550
+Quick Sort,500,5,0.00095170
+Quick Sort,500,6,0.00097070
+Quick Sort,500,7,0.00118950
+Quick Sort,500,8,0.00074640
+Quick Sort,500,9,0.00089290
+Quick Sort,500,10,0.00091490
+Quick Sort,500,11,0.00098680
+Quick Sort,500,12,0.00099170
+Quick Sort,500,13,0.00089200
+Quick Sort,500,14,0.00096550
+Quick Sort,500,15,0.00109880
+Quick Sort,500,16,0.00099560
+Quick Sort,500,17,0.00086880
+Quick Sort,500,18,0.00092420
+Quick Sort,500,19,0.00103660
+Quick Sort,500,20,0.00113060
+Quick Sort,500,21,0.00101920
+Quick Sort,500,22,0.00089580
+Quick Sort,500,23,0.00099760
+Quick Sort,500,24,0.00106350
+Quick Sort,500,25,0.00075480
+Quick Sort,500,26,0.00087750
+Quick Sort,500,27,0.00105980
+Quick Sort,500,28,0.00130470
+Quick Sort,500,29,0.00113790
+Quick Sort,500,30,0.00090600
+Quick Sort,500,31,0.00106070
+Quick Sort,500,32,0.00098410
+Quick Sort,500,33,0.00089810
+Quick Sort,500,34,0.00103680
+Quick Sort,500,35,0.00100590
+Quick Sort,500,36,0.00091730
+Quick Sort,500,37,0.00094910
+Quick Sort,500,38,0.00096790
+Quick Sort,500,39,0.00110360
+Quick Sort,500,40,0.00094960
+Quick Sort,500,41,0.00092590
+Quick Sort,500,42,0.00066690
+Quick Sort,500,43,0.00102630
+Quick Sort,500,44,0.00091240
+Quick Sort,500,45,0.00095880
+Quick Sort,500,46,0.00096590
+Quick Sort,500,47,0.00106010
+Quick Sort,500,48,0.00116400
+Quick Sort,500,49,0.00106670
+Quick Sort,500,50,0.00096300
+Quick Sort,500,51,0.00073190
+Quick Sort,500,52,0.00085900
+Quick Sort,500,53,0.00072850
+Quick Sort,500,54,0.00090690
+Quick Sort,500,55,0.00061100
+Quick Sort,500,56,0.00085990
+Quick Sort,500,57,0.00061970
+Quick Sort,500,58,0.00093500
+Quick Sort,500,59,0.00075420
+Quick Sort,500,60,0.00086690
+Quick Sort,500,61,0.00094220
+Quick Sort,500,62,0.00100270
+Quick Sort,500,63,0.00101480
+Quick Sort,500,64,0.00099190
+Quick Sort,500,65,0.00092390
+Quick Sort,500,66,0.00083920
+Quick Sort,500,67,0.00080310
+Quick Sort,500,68,0.00088760
+Quick Sort,500,69,0.00089110
+Quick Sort,500,70,0.00100370
+Quick Sort,500,71,0.00092000
+Quick Sort,500,72,0.00091140
+Quick Sort,500,73,0.00090790
+Quick Sort,500,74,0.00085990
+Quick Sort,500,75,0.00079770
+Quick Sort,500,76,0.00074790
+Quick Sort,500,77,0.00090960
+Quick Sort,500,78,0.00083760
+Quick Sort,500,79,0.00086010
+Quick Sort,500,80,0.00061390
+Quick Sort,500,81,0.00083810
+Quick Sort,500,82,0.00068730
+Quick Sort,500,83,0.00085540
+Quick Sort,500,84,0.00101410
+Quick Sort,500,85,0.00091870
+Quick Sort,500,86,0.00101710
+Quick Sort,500,87,0.00059750
+Quick Sort,500,88,0.00100070
+Quick Sort,500,89,0.00064900
+Quick Sort,500,90,0.00094780
+Quick Sort,500,91,0.00098190
+Quick Sort,500,92,0.00109050
+Quick Sort,500,93,0.00071030
+Quick Sort,500,94,0.00103920
+Quick Sort,500,95,0.00103050
+Quick Sort,500,96,0.00099820
+Quick Sort,500,97,0.00103190
+Quick Sort,500,98,0.00090020
+Quick Sort,500,99,0.00061890
+Quick Sort,500,100,0.00070880
+Quick Sort,500,101,0.00096810
+Quick Sort,500,102,0.00067500
+Quick Sort,500,103,0.00067240
+Quick Sort,500,104,0.00071930
+Quick Sort,500,105,0.00089530
+Quick Sort,500,106,0.00080260
+Quick Sort,500,107,0.00078850
+Quick Sort,500,108,0.00089730
+Quick Sort,500,109,0.00108970
+Quick Sort,500,110,0.00076830
+Quick Sort,500,111,0.00067870
+Quick Sort,500,112,0.00060350
+Quick Sort,500,113,0.00065110
+Quick Sort,500,114,0.00065840
+Quick Sort,500,115,0.00105910
+Quick Sort,500,116,0.00092710
+Quick Sort,500,117,0.00073230
+Quick Sort,500,118,0.00092440
+Quick Sort,500,119,0.00104020
+Quick Sort,500,120,0.00098170
+Quick Sort,500,121,0.00096860
+Quick Sort,500,122,0.00092520
+Quick Sort,500,123,0.00091250
+Quick Sort,500,124,0.00097560
+Quick Sort,500,125,0.00076540
+Quick Sort,500,126,0.00082980
+Quick Sort,500,127,0.00095920
+Quick Sort,500,128,0.00115430
+Quick Sort,500,129,0.00109360
+Quick Sort,500,130,0.00094000
+Quick Sort,500,131,0.00099370
+Quick Sort,500,132,0.00091580
+Quick Sort,500,133,0.00089360
+Quick Sort,500,134,0.00078730
+Quick Sort,500,135,0.00087300
+Quick Sort,500,136,0.00109230
+Quick Sort,500,137,0.00070280
+Quick Sort,500,138,0.00079000
+Quick Sort,500,139,0.00099670
+Quick Sort,500,140,0.00100020
+Quick Sort,500,141,0.00101170
+Quick Sort,500,142,0.00085590
+Quick Sort,500,143,0.00076000
+Quick Sort,500,144,0.00098090
+Quick Sort,500,145,0.00100110
+Quick Sort,500,146,0.00099370
+Quick Sort,500,147,0.00093080
+Quick Sort,500,148,0.00097100
+Quick Sort,500,149,0.00099960
+Quick Sort,500,150,0.00112980
+Quick Sort,500,151,0.00091830
+Quick Sort,500,152,0.00102770
+Quick Sort,500,153,0.00104140
+Quick Sort,500,154,0.00094740
+Quick Sort,500,155,0.00084670
+Quick Sort,500,156,0.00104480
+Quick Sort,500,157,0.00101950
+Quick Sort,500,158,0.00106210
+Quick Sort,500,159,0.00100890
+Quick Sort,500,160,0.00094840
+Quick Sort,500,161,0.00094080
+Quick Sort,500,162,0.00108960
+Quick Sort,500,163,0.00114500
+Quick Sort,500,164,0.00079780
+Quick Sort,500,165,0.00097700
+Quick Sort,500,166,0.00092800
+Quick Sort,500,167,0.00097140
+Quick Sort,500,168,0.00106950
+Quick Sort,500,169,0.00083980
+Quick Sort,500,170,0.00107980
+Quick Sort,500,171,0.00097640
+Quick Sort,500,172,0.00064020
+Quick Sort,500,173,0.00096180
+Quick Sort,500,174,0.00084100
+Quick Sort,500,175,0.00103020
+Quick Sort,500,176,0.00159000
+Quick Sort,500,177,0.00073790
+Quick Sort,500,178,0.00097600
+Quick Sort,500,179,0.00118970
+Quick Sort,500,180,0.00074460
+Quick Sort,500,181,0.00098700
+Quick Sort,500,182,0.00073230
+Quick Sort,500,183,0.00090000
+Quick Sort,500,184,0.00100080
+Quick Sort,500,185,0.00094570
+Quick Sort,500,186,0.00096550
+Quick Sort,500,187,0.00072210
+Quick Sort,500,188,0.00101100
+Quick Sort,500,189,0.00097590
+Quick Sort,500,190,0.00081410
+Quick Sort,500,191,0.00080520
+Quick Sort,500,192,0.00102320
+Quick Sort,500,193,0.00101290
+Quick Sort,500,194,0.00077460
+Quick Sort,500,195,0.00087270
+Quick Sort,500,196,0.00096500
+Quick Sort,500,197,0.00062280
+Quick Sort,500,198,0.00094010
+Quick Sort,500,199,0.00098870
+Quick Sort,500,200,0.00086120
+Quick Sort,500,201,0.00098220
+Quick Sort,500,202,0.00104440
+Quick Sort,500,203,0.00102880
+Quick Sort,500,204,0.00098700
+Quick Sort,500,205,0.00091870
+Quick Sort,500,206,0.00098340
+Quick Sort,500,207,0.00102420
+Quick Sort,500,208,0.00116190
+Quick Sort,500,209,0.00135880
+Quick Sort,500,210,0.00090470
+Quick Sort,500,211,0.00106000
+Quick Sort,500,212,0.00095260
+Quick Sort,500,213,0.00084130
+Quick Sort,500,214,0.00103230
+Quick Sort,500,215,0.00098360
+Quick Sort,500,216,0.00104920
+Quick Sort,500,217,0.00100610
+Quick Sort,500,218,0.00096340
+Quick Sort,500,219,0.00093470
+Quick Sort,500,220,0.00104990
+Quick Sort,500,221,0.00097760
+Quick Sort,500,222,0.00098020
+Quick Sort,500,223,0.00093350
+Quick Sort,500,224,0.00104950
+Quick Sort,500,225,0.00094910
+Quick Sort,500,226,0.00100930
+Quick Sort,500,227,0.00095260
+Quick Sort,500,228,0.00106710
+Quick Sort,500,229,0.00106240
+Quick Sort,500,230,0.00078790
+Quick Sort,500,231,0.00094000
+Quick Sort,500,232,0.00105360
+Quick Sort,500,233,0.00108890
+Quick Sort,500,234,0.00112960
+Quick Sort,500,235,0.00113070
+Quick Sort,500,236,0.00073160
+Quick Sort,500,237,0.00070200
+Quick Sort,500,238,0.00098900
+Quick Sort,500,239,0.00083250
+Quick Sort,500,240,0.00108090
+Quick Sort,500,241,0.00099040
+Quick Sort,500,242,0.00100270
+Quick Sort,500,243,0.00102260
+Quick Sort,500,244,0.00103060
+Quick Sort,500,245,0.00088310
+Quick Sort,500,246,0.00113730
+Quick Sort,500,247,0.00101300
+Quick Sort,500,248,0.00076600
+Quick Sort,500,249,0.00097860
+Quick Sort,500,250,0.00084650
+Quick Sort,500,251,0.00098380
+Quick Sort,500,252,0.00092930
+Quick Sort,500,253,0.00059870
+Quick Sort,500,254,0.00062750
+Quick Sort,500,255,0.00083370
+Quick Sort,500,256,0.00096930
+Quick Sort,500,257,0.00103250
+Quick Sort,500,258,0.00068260
+Quick Sort,500,259,0.00064390
+Quick Sort,500,260,0.00104150
+Quick Sort,500,261,0.00106960
+Quick Sort,500,262,0.00101860
+Quick Sort,500,263,0.00101800
+Quick Sort,500,264,0.00116680
+Quick Sort,500,265,0.00099540
+Quick Sort,500,266,0.00094390
+Quick Sort,500,267,0.00099950
+Quick Sort,500,268,0.00101100
+Quick Sort,500,269,0.00128630
+Quick Sort,500,270,0.00109040
+Quick Sort,500,271,0.00074170
+Quick Sort,500,272,0.00124550
+Quick Sort,500,273,0.00104530
+Quick Sort,500,274,0.00102820
+Quick Sort,500,275,0.00105050
+Quick Sort,500,276,0.00072900
+Quick Sort,500,277,0.00100890
+Quick Sort,500,278,0.00109900
+Quick Sort,500,279,0.00101510
+Quick Sort,500,280,0.00080300
+Quick Sort,500,281,0.00090510
+Quick Sort,500,282,0.00092510
+Quick Sort,500,283,0.00098080
+Quick Sort,500,284,0.00093170
+Quick Sort,500,285,0.00089370
+Quick Sort,500,286,0.00099470
+Quick Sort,500,287,0.00092310
+Quick Sort,500,288,0.00072510
+Quick Sort,500,289,0.00098460
+Quick Sort,500,290,0.00096810
+Quick Sort,500,291,0.00083770
+Quick Sort,500,292,0.00112850
+Quick Sort,500,293,0.00081910
+Quick Sort,500,294,0.00100170
+Quick Sort,500,295,0.00070860
+Quick Sort,500,296,0.00095610
+Quick Sort,500,297,0.00103900
+Quick Sort,500,298,0.00087120
+Quick Sort,500,299,0.00110340
+Quick Sort,500,300,0.00101690
+Quick Sort,500,301,0.00079820
+Quick Sort,500,302,0.00069460
+Quick Sort,500,303,0.00144650
+Quick Sort,500,304,0.00092300
+Quick Sort,500,305,0.00090960
+Quick Sort,500,306,0.00086890
+Quick Sort,500,307,0.00082780
+Quick Sort,500,308,0.00063240
+Quick Sort,500,309,0.00080140
+Quick Sort,500,310,0.00112910
+Quick Sort,500,311,0.00105180
+Quick Sort,500,312,0.00105480
+Quick Sort,500,313,0.00125420
+Quick Sort,500,314,0.00099610
+Quick Sort,500,315,0.00099960
+Quick Sort,500,316,0.00073220
+Quick Sort,500,317,0.00075730
+Quick Sort,500,318,0.00100840
+Quick Sort,500,319,0.00101470
+Quick Sort,500,320,0.00067640
+Quick Sort,500,321,0.00065470
+Quick Sort,500,322,0.00101870
+Quick Sort,500,323,0.00080180
+Quick Sort,500,324,0.00097490
+Quick Sort,500,325,0.00100760
+Quick Sort,500,326,0.00098360
+Quick Sort,500,327,0.00090310
+Quick Sort,500,328,0.00065860
+Quick Sort,500,329,0.00101270
+Quick Sort,500,330,0.00075060
+Quick Sort,500,331,0.00093900
+Quick Sort,500,332,0.00090440
+Quick Sort,500,333,0.00067550
+Quick Sort,500,334,0.00075460
+Quick Sort,500,335,0.00093390
+Quick Sort,500,336,0.00099470
+Quick Sort,500,337,0.00081620
+Quick Sort,500,338,0.00100960
+Quick Sort,500,339,0.00097000
+Quick Sort,500,340,0.00094990
+Quick Sort,500,341,0.00091850
+Quick Sort,500,342,0.00107860
+Quick Sort,500,343,0.00097290
+Quick Sort,500,344,0.00091900
+Quick Sort,500,345,0.00102350
+Quick Sort,500,346,0.00106610
+Quick Sort,500,347,0.00098390
+Quick Sort,500,348,0.00106370
+Quick Sort,500,349,0.00094860
+Quick Sort,500,350,0.00093510
+Quick Sort,500,351,0.00104040
+Quick Sort,500,352,0.00073920
+Quick Sort,500,353,0.00059290
+Quick Sort,500,354,0.00090300
+Quick Sort,500,355,0.00107070
+Quick Sort,500,356,0.00094700
+Quick Sort,500,357,0.00096540
+Quick Sort,500,358,0.00098880
+Quick Sort,500,359,0.00096860
+Quick Sort,500,360,0.00064350
+Quick Sort,500,361,0.00105510
+Quick Sort,500,362,0.00075000
+Quick Sort,500,363,0.00093450
+Quick Sort,500,364,0.00084610
+Quick Sort,500,365,0.00086640
+Quick Sort,500,366,0.00098120
+Quick Sort,500,367,0.00113830
+Quick Sort,500,368,0.00097240
+Quick Sort,500,369,0.00098900
+Quick Sort,500,370,0.00080330
+Quick Sort,500,371,0.00061580
+Quick Sort,500,372,0.00060230
+Quick Sort,500,373,0.00104100
+Quick Sort,500,374,0.00096220
+Quick Sort,500,375,0.00107050
+Quick Sort,500,376,0.00091640
+Quick Sort,500,377,0.00116980
+Quick Sort,500,378,0.00085960
+Quick Sort,500,379,0.00093900
+Quick Sort,500,380,0.00073620
+Quick Sort,500,381,0.00076730
+Quick Sort,500,382,0.00099590
+Quick Sort,500,383,0.00102120
+Quick Sort,500,384,0.00087980
+Quick Sort,500,385,0.00078390
+Quick Sort,500,386,0.00065370
+Quick Sort,500,387,0.00063140
+Quick Sort,500,388,0.00087300
+Quick Sort,500,389,0.00066900
+Quick Sort,500,390,0.00087410
+Quick Sort,500,391,0.00117980
+Quick Sort,500,392,0.00100380
+Quick Sort,500,393,0.00085940
+Quick Sort,500,394,0.00124360
+Quick Sort,500,395,0.00097060
+Quick Sort,500,396,0.00097470
+Quick Sort,500,397,0.00094530
+Quick Sort,500,398,0.00098410
+Quick Sort,500,399,0.00092140
+Quick Sort,500,400,0.00099490
+Quick Sort,500,401,0.00089860
+Quick Sort,500,402,0.00094930
+Quick Sort,500,403,0.00091620
+Quick Sort,500,404,0.00100160
+Quick Sort,500,405,0.00120290
+Quick Sort,500,406,0.00099600
+Quick Sort,500,407,0.00086620
+Quick Sort,500,408,0.00093570
+Quick Sort,500,409,0.00082250
+Quick Sort,500,410,0.00100690
+Quick Sort,500,411,0.00093930
+Quick Sort,500,412,0.00094090
+Quick Sort,500,413,0.00087120
+Quick Sort,500,414,0.00092700
+Quick Sort,500,415,0.00091960
+Quick Sort,500,416,0.00083530
+Quick Sort,500,417,0.00104440
+Quick Sort,500,418,0.00087080
+Quick Sort,500,419,0.00102370
+Quick Sort,500,420,0.00078550
+Quick Sort,500,421,0.00100320
+Quick Sort,500,422,0.00079620
+Quick Sort,500,423,0.00089350
+Quick Sort,500,424,0.00087880
+Quick Sort,500,425,0.00067960
+Quick Sort,500,426,0.00081510
+Quick Sort,500,427,0.00104350
+Quick Sort,500,428,0.00091490
+Quick Sort,500,429,0.00094460
+Quick Sort,500,430,0.00064380
+Quick Sort,500,431,0.00089770
+Quick Sort,500,432,0.00121730
+Quick Sort,500,433,0.00114900
+Quick Sort,500,434,0.00103890
+Quick Sort,500,435,0.00088770
+Quick Sort,500,436,0.00088890
+Quick Sort,500,437,0.00102440
+Quick Sort,500,438,0.00099050
+Quick Sort,500,439,0.00097440
+Quick Sort,500,440,0.00091250
+Quick Sort,500,441,0.00087140
+Quick Sort,500,442,0.00110900
+Quick Sort,500,443,0.00088750
+Quick Sort,500,444,0.00095980
+Quick Sort,500,445,0.00101930
+Quick Sort,500,446,0.00086050
+Quick Sort,500,447,0.00101710
+Quick Sort,500,448,0.00092990
+Quick Sort,500,449,0.00084200
+Quick Sort,500,450,0.00088950
+Quick Sort,500,451,0.00098510
+Quick Sort,500,452,0.00085940
+Quick Sort,500,453,0.00096180
+Quick Sort,500,454,0.00096090
+Quick Sort,500,455,0.00079890
+Quick Sort,500,456,0.00098010
+Quick Sort,500,457,0.00090070
+Quick Sort,500,458,0.00099910
+Quick Sort,500,459,0.00085690
+Quick Sort,500,460,0.00064320
+Quick Sort,500,461,0.00075270
+Quick Sort,500,462,0.00057460
+Quick Sort,500,463,0.00059000
+Quick Sort,500,464,0.00088680
+Quick Sort,500,465,0.00077390
+Quick Sort,500,466,0.00068230
+Quick Sort,500,467,0.00066240
+Quick Sort,500,468,0.00079070
+Quick Sort,500,469,0.00100030
+Quick Sort,500,470,0.00070150
+Quick Sort,500,471,0.00075060
+Quick Sort,500,472,0.00102630
+Quick Sort,500,473,0.00067400
+Quick Sort,500,474,0.00088200
+Quick Sort,500,475,0.00100540
+Quick Sort,500,476,0.00100240
+Quick Sort,500,477,0.00091230
+Quick Sort,500,478,0.00096030
+Quick Sort,500,479,0.00093060
+Quick Sort,500,480,0.00097130
+Quick Sort,500,481,0.00092730
+Quick Sort,500,482,0.00091150
+Quick Sort,500,483,0.00096920
+Quick Sort,500,484,0.00096260
+Quick Sort,500,485,0.00096440
+Quick Sort,500,486,0.00117190
+Quick Sort,500,487,0.00083780
+Quick Sort,500,488,0.00094830
+Quick Sort,500,489,0.00082700
+Quick Sort,500,490,0.00092820
+Quick Sort,500,491,0.00096010
+Quick Sort,500,492,0.00103080
+Quick Sort,500,493,0.00100550
+Quick Sort,500,494,0.00070580
+Quick Sort,500,495,0.00108580
+Quick Sort,500,496,0.00103410
+Quick Sort,500,497,0.00092440
+Quick Sort,500,498,0.00098100
+Quick Sort,500,499,0.00099470
+Quick Sort,500,500,0.00100230
+Radix Sort,500,1,0.00101470
+Radix Sort,500,2,0.00068120
+Radix Sort,500,3,0.00112450
+Radix Sort,500,4,0.00117790
+Radix Sort,500,5,0.00074200
+Radix Sort,500,6,0.00094140
+Radix Sort,500,7,0.00077890
+Radix Sort,500,8,0.00116710
+Radix Sort,500,9,0.00114820
+Radix Sort,500,10,0.00085220
+Radix Sort,500,11,0.00079600
+Radix Sort,500,12,0.00105070
+Radix Sort,500,13,0.00113170
+Radix Sort,500,14,0.00087060
+Radix Sort,500,15,0.00113180
+Radix Sort,500,16,0.00073660
+Radix Sort,500,17,0.00066800
+Radix Sort,500,18,0.00091540
+Radix Sort,500,19,0.00084120
+Radix Sort,500,20,0.00068630
+Radix Sort,500,21,0.00065950
+Radix Sort,500,22,0.00112910
+Radix Sort,500,23,0.00084890
+Radix Sort,500,24,0.00067850
+Radix Sort,500,25,0.00066260
+Radix Sort,500,26,0.00113160
+Radix Sort,500,27,0.00109390
+Radix Sort,500,28,0.00074570
+Radix Sort,500,29,0.00096620
+Radix Sort,500,30,0.00110210
+Radix Sort,500,31,0.00116550
+Radix Sort,500,32,0.00071220
+Radix Sort,500,33,0.00118280
+Radix Sort,500,34,0.00079980
+Radix Sort,500,35,0.00117140
+Radix Sort,500,36,0.00066440
+Radix Sort,500,37,0.00115940
+Radix Sort,500,38,0.00078950
+Radix Sort,500,39,0.00118940
+Radix Sort,500,40,0.00068200
+Radix Sort,500,41,0.00118290
+Radix Sort,500,42,0.00073250
+Radix Sort,500,43,0.00116470
+Radix Sort,500,44,0.00068790
+Radix Sort,500,45,0.00142670
+Radix Sort,500,46,0.00068440
+Radix Sort,500,47,0.00070320
+Radix Sort,500,48,0.00118430
+Radix Sort,500,49,0.00128690
+Radix Sort,500,50,0.00111070
+Radix Sort,500,51,0.00076510
+Radix Sort,500,52,0.00119300
+Radix Sort,500,53,0.00099090
+Radix Sort,500,54,0.00111420
+Radix Sort,500,55,0.00114860
+Radix Sort,500,56,0.00116190
+Radix Sort,500,57,0.00114270
+Radix Sort,500,58,0.00119370
+Radix Sort,500,59,0.00103370
+Radix Sort,500,60,0.00110010
+Radix Sort,500,61,0.00112360
+Radix Sort,500,62,0.00115680
+Radix Sort,500,63,0.00123790
+Radix Sort,500,64,0.00101530
+Radix Sort,500,65,0.00115110
+Radix Sort,500,66,0.00085830
+Radix Sort,500,67,0.00075220
+Radix Sort,500,68,0.00123880
+Radix Sort,500,69,0.00096940
+Radix Sort,500,70,0.00077180
+Radix Sort,500,71,0.00098180
+Radix Sort,500,72,0.00070580
+Radix Sort,500,73,0.00108830
+Radix Sort,500,74,0.00098260
+Radix Sort,500,75,0.00089970
+Radix Sort,500,76,0.00074560
+Radix Sort,500,77,0.00066630
+Radix Sort,500,78,0.00091980
+Radix Sort,500,79,0.00098170
+Radix Sort,500,80,0.00107480
+Radix Sort,500,81,0.00108680
+Radix Sort,500,82,0.00124260
+Radix Sort,500,83,0.00116430
+Radix Sort,500,84,0.00077670
+Radix Sort,500,85,0.00093060
+Radix Sort,500,86,0.00069410
+Radix Sort,500,87,0.00116290
+Radix Sort,500,88,0.00083060
+Radix Sort,500,89,0.00070050
+Radix Sort,500,90,0.00117190
+Radix Sort,500,91,0.00101720
+Radix Sort,500,92,0.00117300
+Radix Sort,500,93,0.00101790
+Radix Sort,500,94,0.00112680
+Radix Sort,500,95,0.00098720
+Radix Sort,500,96,0.00107570
+Radix Sort,500,97,0.00091130
+Radix Sort,500,98,0.00103080
+Radix Sort,500,99,0.00086450
+Radix Sort,500,100,0.00067510
+Radix Sort,500,101,0.00106160
+Radix Sort,500,102,0.00082200
+Radix Sort,500,103,0.00077640
+Radix Sort,500,104,0.00123230
+Radix Sort,500,105,0.00133300
+Radix Sort,500,106,0.00120090
+Radix Sort,500,107,0.00114980
+Radix Sort,500,108,0.00119030
+Radix Sort,500,109,0.00114010
+Radix Sort,500,110,0.00118050
+Radix Sort,500,111,0.00126000
+Radix Sort,500,112,0.00112270
+Radix Sort,500,113,0.00121480
+Radix Sort,500,114,0.00116430
+Radix Sort,500,115,0.00155280
+Radix Sort,500,116,0.00125070
+Radix Sort,500,117,0.00144490
+Radix Sort,500,118,0.00134930
+Radix Sort,500,119,0.00105800
+Radix Sort,500,120,0.00134510
+Radix Sort,500,121,0.00096390
+Radix Sort,500,122,0.00155270
+Radix Sort,500,123,0.00115060
+Radix Sort,500,124,0.00111370
+Radix Sort,500,125,0.00113010
+Radix Sort,500,126,0.00128840
+Radix Sort,500,127,0.00111570
+Radix Sort,500,128,0.00094080
+Radix Sort,500,129,0.00116020
+Radix Sort,500,130,0.00089070
+Radix Sort,500,131,0.00116240
+Radix Sort,500,132,0.00088770
+Radix Sort,500,133,0.00116260
+Radix Sort,500,134,0.00072300
+Radix Sort,500,135,0.00116570
+Radix Sort,500,136,0.00121270
+Radix Sort,500,137,0.00122640
+Radix Sort,500,138,0.00114350
+Radix Sort,500,139,0.00096750
+Radix Sort,500,140,0.00114410
+Radix Sort,500,141,0.00105040
+Radix Sort,500,142,0.00114830
+Radix Sort,500,143,0.00078960
+Radix Sort,500,144,0.00107900
+Radix Sort,500,145,0.00119030
+Radix Sort,500,146,0.00096760
+Radix Sort,500,147,0.00104480
+Radix Sort,500,148,0.00132420
+Radix Sort,500,149,0.00120510
+Radix Sort,500,150,0.00091440
+Radix Sort,500,151,0.00115530
+Radix Sort,500,152,0.00114940
+Radix Sort,500,153,0.00117170
+Radix Sort,500,154,0.00121090
+Radix Sort,500,155,0.00115850
+Radix Sort,500,156,0.00117600
+Radix Sort,500,157,0.00111890
+Radix Sort,500,158,0.00099990
+Radix Sort,500,159,0.00127490
+Radix Sort,500,160,0.00114610
+Radix Sort,500,161,0.00130850
+Radix Sort,500,162,0.00104580
+Radix Sort,500,163,0.00108500
+Radix Sort,500,164,0.00119610
+Radix Sort,500,165,0.00121670
+Radix Sort,500,166,0.00114870
+Radix Sort,500,167,0.00116880
+Radix Sort,500,168,0.00119850
+Radix Sort,500,169,0.00119350
+Radix Sort,500,170,0.00107220
+Radix Sort,500,171,0.00116330
+Radix Sort,500,172,0.00108630
+Radix Sort,500,173,0.00110590
+Radix Sort,500,174,0.00108620
+Radix Sort,500,175,0.00119730
+Radix Sort,500,176,0.00096850
+Radix Sort,500,177,0.00107920
+Radix Sort,500,178,0.00106930
+Radix Sort,500,179,0.00120830
+Radix Sort,500,180,0.00121400
+Radix Sort,500,181,0.00120410
+Radix Sort,500,182,0.00117020
+Radix Sort,500,183,0.00130370
+Radix Sort,500,184,0.00115900
+Radix Sort,500,185,0.00116630
+Radix Sort,500,186,0.00113470
+Radix Sort,500,187,0.00110100
+Radix Sort,500,188,0.00125760
+Radix Sort,500,189,0.00115160
+Radix Sort,500,190,0.00114900
+Radix Sort,500,191,0.00114080
+Radix Sort,500,192,0.00067480
+Radix Sort,500,193,0.00112220
+Radix Sort,500,194,0.00113890
+Radix Sort,500,195,0.00109900
+Radix Sort,500,196,0.00113240
+Radix Sort,500,197,0.00114910
+Radix Sort,500,198,0.00073360
+Radix Sort,500,199,0.00092030
+Radix Sort,500,200,0.00113560
+Radix Sort,500,201,0.00113820
+Radix Sort,500,202,0.00119470
+Radix Sort,500,203,0.00114880
+Radix Sort,500,204,0.00107660
+Radix Sort,500,205,0.00117410
+Radix Sort,500,206,0.00114690
+Radix Sort,500,207,0.00123770
+Radix Sort,500,208,0.00115430
+Radix Sort,500,209,0.00098540
+Radix Sort,500,210,0.00114910
+Radix Sort,500,211,0.00114480
+Radix Sort,500,212,0.00115300
+Radix Sort,500,213,0.00115430
+Radix Sort,500,214,0.00069650
+Radix Sort,500,215,0.00105410
+Radix Sort,500,216,0.00115350
+Radix Sort,500,217,0.00119660
+Radix Sort,500,218,0.00094490
+Radix Sort,500,219,0.00116210
+Radix Sort,500,220,0.00075530
+Radix Sort,500,221,0.00111890
+Radix Sort,500,222,0.00114740
+Radix Sort,500,223,0.00119200
+Radix Sort,500,224,0.00116100
+Radix Sort,500,225,0.00070470
+Radix Sort,500,226,0.00115000
+Radix Sort,500,227,0.00091750
+Radix Sort,500,228,0.00106940
+Radix Sort,500,229,0.00071470
+Radix Sort,500,230,0.00090410
+Radix Sort,500,231,0.00109500
+Radix Sort,500,232,0.00100690
+Radix Sort,500,233,0.00094250
+Radix Sort,500,234,0.00113300
+Radix Sort,500,235,0.00116070
+Radix Sort,500,236,0.00093010
+Radix Sort,500,237,0.00112320
+Radix Sort,500,238,0.00116210
+Radix Sort,500,239,0.00073250
+Radix Sort,500,240,0.00116120
+Radix Sort,500,241,0.00120710
+Radix Sort,500,242,0.00106910
+Radix Sort,500,243,0.00110970
+Radix Sort,500,244,0.00121320
+Radix Sort,500,245,0.00122720
+Radix Sort,500,246,0.00113980
+Radix Sort,500,247,0.00095310
+Radix Sort,500,248,0.00095560
+Radix Sort,500,249,0.00086570
+Radix Sort,500,250,0.00108130
+Radix Sort,500,251,0.00084170
+Radix Sort,500,252,0.00118010
+Radix Sort,500,253,0.00104410
+Radix Sort,500,254,0.00133080
+Radix Sort,500,255,0.00124030
+Radix Sort,500,256,0.00129360
+Radix Sort,500,257,0.00116940
+Radix Sort,500,258,0.00115920
+Radix Sort,500,259,0.00114970
+Radix Sort,500,260,0.00114620
+Radix Sort,500,261,0.00109160
+Radix Sort,500,262,0.00123580
+Radix Sort,500,263,0.00086740
+Radix Sort,500,264,0.00116300
+Radix Sort,500,265,0.00117580
+Radix Sort,500,266,0.00110180
+Radix Sort,500,267,0.00102710
+Radix Sort,500,268,0.00116630
+Radix Sort,500,269,0.00121800
+Radix Sort,500,270,0.00121070
+Radix Sort,500,271,0.00109640
+Radix Sort,500,272,0.00114310
+Radix Sort,500,273,0.00111610
+Radix Sort,500,274,0.00092470
+Radix Sort,500,275,0.00100860
+Radix Sort,500,276,0.00114300
+Radix Sort,500,277,0.00120150
+Radix Sort,500,278,0.00112640
+Radix Sort,500,279,0.00085500
+Radix Sort,500,280,0.00116090
+Radix Sort,500,281,0.00094850
+Radix Sort,500,282,0.00120270
+Radix Sort,500,283,0.00117530
+Radix Sort,500,284,0.00102100
+Radix Sort,500,285,0.00087960
+Radix Sort,500,286,0.00071040
+Radix Sort,500,287,0.00101610
+Radix Sort,500,288,0.00069620
+Radix Sort,500,289,0.00101820
+Radix Sort,500,290,0.00112940
+Radix Sort,500,291,0.00089420
+Radix Sort,500,292,0.00116020
+Radix Sort,500,293,0.00071010
+Radix Sort,500,294,0.00073770
+Radix Sort,500,295,0.00110690
+Radix Sort,500,296,0.00099920
+Radix Sort,500,297,0.00068360
+Radix Sort,500,298,0.00118720
+Radix Sort,500,299,0.00102250
+Radix Sort,500,300,0.00084600
+Radix Sort,500,301,0.00111050
+Radix Sort,500,302,0.00095050
+Radix Sort,500,303,0.00114040
+Radix Sort,500,304,0.00082680
+Radix Sort,500,305,0.00079890
+Radix Sort,500,306,0.00115990
+Radix Sort,500,307,0.00087930
+Radix Sort,500,308,0.00083930
+Radix Sort,500,309,0.00087630
+Radix Sort,500,310,0.00102270
+Radix Sort,500,311,0.00114320
+Radix Sort,500,312,0.00114860
+Radix Sort,500,313,0.00130140
+Radix Sort,500,314,0.00074740
+Radix Sort,500,315,0.00091000
+Radix Sort,500,316,0.00112530
+Radix Sort,500,317,0.00124130
+Radix Sort,500,318,0.00084670
+Radix Sort,500,319,0.00115990
+Radix Sort,500,320,0.00115600
+Radix Sort,500,321,0.00112490
+Radix Sort,500,322,0.00119910
+Radix Sort,500,323,0.00110960
+Radix Sort,500,324,0.00069680
+Radix Sort,500,325,0.00120110
+Radix Sort,500,326,0.00091550
+Radix Sort,500,327,0.00115160
+Radix Sort,500,328,0.00120260
+Radix Sort,500,329,0.00120260
+Radix Sort,500,330,0.00117110
+Radix Sort,500,331,0.00117170
+Radix Sort,500,332,0.00089610
+Radix Sort,500,333,0.00118140
+Radix Sort,500,334,0.00119730
+Radix Sort,500,335,0.00105400
+Radix Sort,500,336,0.00112510
+Radix Sort,500,337,0.00088060
+Radix Sort,500,338,0.00115620
+Radix Sort,500,339,0.00120390
+Radix Sort,500,340,0.00100620
+Radix Sort,500,341,0.00075980
+Radix Sort,500,342,0.00140560
+Radix Sort,500,343,0.00085610
+Radix Sort,500,344,0.00104600
+Radix Sort,500,345,0.00116980
+Radix Sort,500,346,0.00107140
+Radix Sort,500,347,0.00113060
+Radix Sort,500,348,0.00114600
+Radix Sort,500,349,0.00116120
+Radix Sort,500,350,0.00113460
+Radix Sort,500,351,0.00114780
+Radix Sort,500,352,0.00117020
+Radix Sort,500,353,0.00085150
+Radix Sort,500,354,0.00110520
+Radix Sort,500,355,0.00132640
+Radix Sort,500,356,0.00120220
+Radix Sort,500,357,0.00111360
+Radix Sort,500,358,0.00121710
+Radix Sort,500,359,0.00086850
+Radix Sort,500,360,0.00116410
+Radix Sort,500,361,0.00121580
+Radix Sort,500,362,0.00115640
+Radix Sort,500,363,0.00113740
+Radix Sort,500,364,0.00106990
+Radix Sort,500,365,0.00071150
+Radix Sort,500,366,0.00105860
+Radix Sort,500,367,0.00112660
+Radix Sort,500,368,0.00102190
+Radix Sort,500,369,0.00117420
+Radix Sort,500,370,0.00095850
+Radix Sort,500,371,0.00089050
+Radix Sort,500,372,0.00115450
+Radix Sort,500,373,0.00112400
+Radix Sort,500,374,0.00096060
+Radix Sort,500,375,0.00111510
+Radix Sort,500,376,0.00112970
+Radix Sort,500,377,0.00108800
+Radix Sort,500,378,0.00118290
+Radix Sort,500,379,0.00085510
+Radix Sort,500,380,0.00110800
+Radix Sort,500,381,0.00109520
+Radix Sort,500,382,0.00099480
+Radix Sort,500,383,0.00118350
+Radix Sort,500,384,0.00118840
+Radix Sort,500,385,0.00100830
+Radix Sort,500,386,0.00116340
+Radix Sort,500,387,0.00121120
+Radix Sort,500,388,0.00112720
+Radix Sort,500,389,0.00097920
+Radix Sort,500,390,0.00112910
+Radix Sort,500,391,0.00106440
+Radix Sort,500,392,0.00114750
+Radix Sort,500,393,0.00069710
+Radix Sort,500,394,0.00100620
+Radix Sort,500,395,0.00114710
+Radix Sort,500,396,0.00090640
+Radix Sort,500,397,0.00113180
+Radix Sort,500,398,0.00068060
+Radix Sort,500,399,0.00107370
+Radix Sort,500,400,0.00105800
+Radix Sort,500,401,0.00120330
+Radix Sort,500,402,0.00116780
+Radix Sort,500,403,0.00112480
+Radix Sort,500,404,0.00114160
+Radix Sort,500,405,0.00114390
+Radix Sort,500,406,0.00099770
+Radix Sort,500,407,0.00117070
+Radix Sort,500,408,0.00076220
+Radix Sort,500,409,0.00112680
+Radix Sort,500,410,0.00113360
+Radix Sort,500,411,0.00099040
+Radix Sort,500,412,0.00083200
+Radix Sort,500,413,0.00139800
+Radix Sort,500,414,0.00122500
+Radix Sort,500,415,0.00094550
+Radix Sort,500,416,0.00118400
+Radix Sort,500,417,0.00103730
+Radix Sort,500,418,0.00116710
+Radix Sort,500,419,0.00096380
+Radix Sort,500,420,0.00088950
+Radix Sort,500,421,0.00121830
+Radix Sort,500,422,0.00128470
+Radix Sort,500,423,0.00067280
+Radix Sort,500,424,0.00116320
+Radix Sort,500,425,0.00114680
+Radix Sort,500,426,0.00100220
+Radix Sort,500,427,0.00068010
+Radix Sort,500,428,0.00113560
+Radix Sort,500,429,0.00113040
+Radix Sort,500,430,0.00113920
+Radix Sort,500,431,0.00114380
+Radix Sort,500,432,0.00082820
+Radix Sort,500,433,0.00113950
+Radix Sort,500,434,0.00113280
+Radix Sort,500,435,0.00083110
+Radix Sort,500,436,0.00071450
+Radix Sort,500,437,0.00113830
+Radix Sort,500,438,0.00115340
+Radix Sort,500,439,0.00117360
+Radix Sort,500,440,0.00132500
+Radix Sort,500,441,0.00084060
+Radix Sort,500,442,0.00118030
+Radix Sort,500,443,0.00103830
+Radix Sort,500,444,0.00107430
+Radix Sort,500,445,0.00093260
+Radix Sort,500,446,0.00113550
+Radix Sort,500,447,0.00115970
+Radix Sort,500,448,0.00106220
+Radix Sort,500,449,0.00089290
+Radix Sort,500,450,0.00118600
+Radix Sort,500,451,0.00119190
+Radix Sort,500,452,0.00072970
+Radix Sort,500,453,0.00118340
+Radix Sort,500,454,0.00102490
+Radix Sort,500,455,0.00117310
+Radix Sort,500,456,0.00116820
+Radix Sort,500,457,0.00115030
+Radix Sort,500,458,0.00121620
+Radix Sort,500,459,0.00104510
+Radix Sort,500,460,0.00115890
+Radix Sort,500,461,0.00101470
+Radix Sort,500,462,0.00111720
+Radix Sort,500,463,0.00115500
+Radix Sort,500,464,0.00100600
+Radix Sort,500,465,0.00113770
+Radix Sort,500,466,0.00128090
+Radix Sort,500,467,0.00129020
+Radix Sort,500,468,0.00134120
+Radix Sort,500,469,0.00139210
+Radix Sort,500,470,0.00115200
+Radix Sort,500,471,0.00115610
+Radix Sort,500,472,0.00119740
+Radix Sort,500,473,0.00121870
+Radix Sort,500,474,0.00116860
+Radix Sort,500,475,0.00114520
+Radix Sort,500,476,0.00078840
+Radix Sort,500,477,0.00117830
+Radix Sort,500,478,0.00108920
+Radix Sort,500,479,0.00117650
+Radix Sort,500,480,0.00075520
+Radix Sort,500,481,0.00125120
+Radix Sort,500,482,0.00119650
+Radix Sort,500,483,0.00112510
+Radix Sort,500,484,0.00149920
+Radix Sort,500,485,0.00117580
+Radix Sort,500,486,0.00115840
+Radix Sort,500,487,0.00128650
+Radix Sort,500,488,0.00112260
+Radix Sort,500,489,0.00109140
+Radix Sort,500,490,0.00093070
+Radix Sort,500,491,0.00119150
+Radix Sort,500,492,0.00120770
+Radix Sort,500,493,0.00117210
+Radix Sort,500,494,0.00115810
+Radix Sort,500,495,0.00105560
+Radix Sort,500,496,0.00126100
+Radix Sort,500,497,0.00173030
+Radix Sort,500,498,0.00117390
+Radix Sort,500,499,0.00131740
+Radix Sort,500,500,0.00117570
+Replacement Selection Sort,500,1,0.00025540
+Replacement Selection Sort,500,2,0.00029780
+Replacement Selection Sort,500,3,0.00037030
+Replacement Selection Sort,500,4,0.00024910
+Replacement Selection Sort,500,5,0.00023290
+Replacement Selection Sort,500,6,0.00022370
+Replacement Selection Sort,500,7,0.00027780
+Replacement Selection Sort,500,8,0.00029720
+Replacement Selection Sort,500,9,0.00024970
+Replacement Selection Sort,500,10,0.00022850
+Replacement Selection Sort,500,11,0.00022230
+Replacement Selection Sort,500,12,0.00021800
+Replacement Selection Sort,500,13,0.00014960
+Replacement Selection Sort,500,14,0.00022830
+Replacement Selection Sort,500,15,0.00022260
+Replacement Selection Sort,500,16,0.00022490
+Replacement Selection Sort,500,17,0.00014840
+Replacement Selection Sort,500,18,0.00023950
+Replacement Selection Sort,500,19,0.00022180
+Replacement Selection Sort,500,20,0.00034950
+Replacement Selection Sort,500,21,0.00013760
+Replacement Selection Sort,500,22,0.00022160
+Replacement Selection Sort,500,23,0.00023110
+Replacement Selection Sort,500,24,0.00023290
+Replacement Selection Sort,500,25,0.00025290
+Replacement Selection Sort,500,26,0.00022210
+Replacement Selection Sort,500,27,0.00023950
+Replacement Selection Sort,500,28,0.00023420
+Replacement Selection Sort,500,29,0.00024450
+Replacement Selection Sort,500,30,0.00021560
+Replacement Selection Sort,500,31,0.00025270
+Replacement Selection Sort,500,32,0.00024830
+Replacement Selection Sort,500,33,0.00022480
+Replacement Selection Sort,500,34,0.00022180
+Replacement Selection Sort,500,35,0.00019910
+Replacement Selection Sort,500,36,0.00020270
+Replacement Selection Sort,500,37,0.00021590
+Replacement Selection Sort,500,38,0.00021420
+Replacement Selection Sort,500,39,0.00021620
+Replacement Selection Sort,500,40,0.00022420
+Replacement Selection Sort,500,41,0.00015720
+Replacement Selection Sort,500,42,0.00020510
+Replacement Selection Sort,500,43,0.00013190
+Replacement Selection Sort,500,44,0.00022150
+Replacement Selection Sort,500,45,0.00015760
+Replacement Selection Sort,500,46,0.00023030
+Replacement Selection Sort,500,47,0.00023030
+Replacement Selection Sort,500,48,0.00020470
+Replacement Selection Sort,500,49,0.00022570
+Replacement Selection Sort,500,50,0.00018110
+Replacement Selection Sort,500,51,0.00020390
+Replacement Selection Sort,500,52,0.00021780
+Replacement Selection Sort,500,53,0.00022740
+Replacement Selection Sort,500,54,0.00021870
+Replacement Selection Sort,500,55,0.00036820
+Replacement Selection Sort,500,56,0.00025000
+Replacement Selection Sort,500,57,0.00023200
+Replacement Selection Sort,500,58,0.00020380
+Replacement Selection Sort,500,59,0.00021610
+Replacement Selection Sort,500,60,0.00023310
+Replacement Selection Sort,500,61,0.00023340
+Replacement Selection Sort,500,62,0.00022170
+Replacement Selection Sort,500,63,0.00021390
+Replacement Selection Sort,500,64,0.00014840
+Replacement Selection Sort,500,65,0.00013820
+Replacement Selection Sort,500,66,0.00022840
+Replacement Selection Sort,500,67,0.00022050
+Replacement Selection Sort,500,68,0.00021380
+Replacement Selection Sort,500,69,0.00013160
+Replacement Selection Sort,500,70,0.00021730
+Replacement Selection Sort,500,71,0.00018990
+Replacement Selection Sort,500,72,0.00024010
+Replacement Selection Sort,500,73,0.00022530
+Replacement Selection Sort,500,74,0.00022120
+Replacement Selection Sort,500,75,0.00015810
+Replacement Selection Sort,500,76,0.00020420
+Replacement Selection Sort,500,77,0.00021700
+Replacement Selection Sort,500,78,0.00013350
+Replacement Selection Sort,500,79,0.00023330
+Replacement Selection Sort,500,80,0.00020540
+Replacement Selection Sort,500,81,0.00026910
+Replacement Selection Sort,500,82,0.00024510
+Replacement Selection Sort,500,83,0.00025040
+Replacement Selection Sort,500,84,0.00024430
+Replacement Selection Sort,500,85,0.00024840
+Replacement Selection Sort,500,86,0.00019540
+Replacement Selection Sort,500,87,0.00026180
+Replacement Selection Sort,500,88,0.00025520
+Replacement Selection Sort,500,89,0.00022300
+Replacement Selection Sort,500,90,0.00023520
+Replacement Selection Sort,500,91,0.00022680
+Replacement Selection Sort,500,92,0.00025010
+Replacement Selection Sort,500,93,0.00013530
+Replacement Selection Sort,500,94,0.00014580
+Replacement Selection Sort,500,95,0.00021870
+Replacement Selection Sort,500,96,0.00022390
+Replacement Selection Sort,500,97,0.00021950
+Replacement Selection Sort,500,98,0.00022240
+Replacement Selection Sort,500,99,0.00013060
+Replacement Selection Sort,500,100,0.00014250
+Replacement Selection Sort,500,101,0.00021770
+Replacement Selection Sort,500,102,0.00014230
+Replacement Selection Sort,500,103,0.00022150
+Replacement Selection Sort,500,104,0.00013660
+Replacement Selection Sort,500,105,0.00021110
+Replacement Selection Sort,500,106,0.00017650
+Replacement Selection Sort,500,107,0.00017120
+Replacement Selection Sort,500,108,0.00026720
+Replacement Selection Sort,500,109,0.00021840
+Replacement Selection Sort,500,110,0.00022280
+Replacement Selection Sort,500,111,0.00013480
+Replacement Selection Sort,500,112,0.00015770
+Replacement Selection Sort,500,113,0.00015220
+Replacement Selection Sort,500,114,0.00022870
+Replacement Selection Sort,500,115,0.00025110
+Replacement Selection Sort,500,116,0.00014740
+Replacement Selection Sort,500,117,0.00014600
+Replacement Selection Sort,500,118,0.00013500
+Replacement Selection Sort,500,119,0.00013860
+Replacement Selection Sort,500,120,0.00021260
+Replacement Selection Sort,500,121,0.00020320
+Replacement Selection Sort,500,122,0.00014350
+Replacement Selection Sort,500,123,0.00032310
+Replacement Selection Sort,500,124,0.00015470
+Replacement Selection Sort,500,125,0.00022750
+Replacement Selection Sort,500,126,0.00020880
+Replacement Selection Sort,500,127,0.00023050
+Replacement Selection Sort,500,128,0.00020570
+Replacement Selection Sort,500,129,0.00022530
+Replacement Selection Sort,500,130,0.00013660
+Replacement Selection Sort,500,131,0.00019760
+Replacement Selection Sort,500,132,0.00019460
+Replacement Selection Sort,500,133,0.00015320
+Replacement Selection Sort,500,134,0.00016520
+Replacement Selection Sort,500,135,0.00013390
+Replacement Selection Sort,500,136,0.00014400
+Replacement Selection Sort,500,137,0.00014830
+Replacement Selection Sort,500,138,0.00019950
+Replacement Selection Sort,500,139,0.00013570
+Replacement Selection Sort,500,140,0.00013440
+Replacement Selection Sort,500,141,0.00013650
+Replacement Selection Sort,500,142,0.00018910
+Replacement Selection Sort,500,143,0.00022950
+Replacement Selection Sort,500,144,0.00017380
+Replacement Selection Sort,500,145,0.00025190
+Replacement Selection Sort,500,146,0.00022290
+Replacement Selection Sort,500,147,0.00017870
+Replacement Selection Sort,500,148,0.00014890
+Replacement Selection Sort,500,149,0.00021640
+Replacement Selection Sort,500,150,0.00013630
+Replacement Selection Sort,500,151,0.00013640
+Replacement Selection Sort,500,152,0.00022050
+Replacement Selection Sort,500,153,0.00017360
+Replacement Selection Sort,500,154,0.00022370
+Replacement Selection Sort,500,155,0.00013750
+Replacement Selection Sort,500,156,0.00014080
+Replacement Selection Sort,500,157,0.00013550
+Replacement Selection Sort,500,158,0.00014790
+Replacement Selection Sort,500,159,0.00023300
+Replacement Selection Sort,500,160,0.00015560
+Replacement Selection Sort,500,161,0.00020130
+Replacement Selection Sort,500,162,0.00020290
+Replacement Selection Sort,500,163,0.00024270
+Replacement Selection Sort,500,164,0.00021090
+Replacement Selection Sort,500,165,0.00013810
+Replacement Selection Sort,500,166,0.00020880
+Replacement Selection Sort,500,167,0.00017260
+Replacement Selection Sort,500,168,0.00013620
+Replacement Selection Sort,500,169,0.00022210
+Replacement Selection Sort,500,170,0.00013840
+Replacement Selection Sort,500,171,0.00013410
+Replacement Selection Sort,500,172,0.00014560
+Replacement Selection Sort,500,173,0.00017670
+Replacement Selection Sort,500,174,0.00014320
+Replacement Selection Sort,500,175,0.00019790
+Replacement Selection Sort,500,176,0.00024690
+Replacement Selection Sort,500,177,0.00017170
+Replacement Selection Sort,500,178,0.00013200
+Replacement Selection Sort,500,179,0.00013740
+Replacement Selection Sort,500,180,0.00013710
+Replacement Selection Sort,500,181,0.00013610
+Replacement Selection Sort,500,182,0.00014490
+Replacement Selection Sort,500,183,0.00013690
+Replacement Selection Sort,500,184,0.00013340
+Replacement Selection Sort,500,185,0.00013810
+Replacement Selection Sort,500,186,0.00013400
+Replacement Selection Sort,500,187,0.00014220
+Replacement Selection Sort,500,188,0.00013730
+Replacement Selection Sort,500,189,0.00013550
+Replacement Selection Sort,500,190,0.00013670
+Replacement Selection Sort,500,191,0.00013700
+Replacement Selection Sort,500,192,0.00019360
+Replacement Selection Sort,500,193,0.00014250
+Replacement Selection Sort,500,194,0.00013550
+Replacement Selection Sort,500,195,0.00013860
+Replacement Selection Sort,500,196,0.00013520
+Replacement Selection Sort,500,197,0.00013690
+Replacement Selection Sort,500,198,0.00016930
+Replacement Selection Sort,500,199,0.00013880
+Replacement Selection Sort,500,200,0.00013550
+Replacement Selection Sort,500,201,0.00014210
+Replacement Selection Sort,500,202,0.00013680
+Replacement Selection Sort,500,203,0.00013440
+Replacement Selection Sort,500,204,0.00013720
+Replacement Selection Sort,500,205,0.00015790
+Replacement Selection Sort,500,206,0.00013830
+Replacement Selection Sort,500,207,0.00013530
+Replacement Selection Sort,500,208,0.00013690
+Replacement Selection Sort,500,209,0.00013640
+Replacement Selection Sort,500,210,0.00013320
+Replacement Selection Sort,500,211,0.00023760
+Replacement Selection Sort,500,212,0.00013430
+Replacement Selection Sort,500,213,0.00014530
+Replacement Selection Sort,500,214,0.00023750
+Replacement Selection Sort,500,215,0.00013830
+Replacement Selection Sort,500,216,0.00013510
+Replacement Selection Sort,500,217,0.00022390
+Replacement Selection Sort,500,218,0.00013710
+Replacement Selection Sort,500,219,0.00013310
+Replacement Selection Sort,500,220,0.00013580
+Replacement Selection Sort,500,221,0.00014020
+Replacement Selection Sort,500,222,0.00017090
+Replacement Selection Sort,500,223,0.00016210
+Replacement Selection Sort,500,224,0.00016970
+Replacement Selection Sort,500,225,0.00013550
+Replacement Selection Sort,500,226,0.00013770
+Replacement Selection Sort,500,227,0.00013460
+Replacement Selection Sort,500,228,0.00016470
+Replacement Selection Sort,500,229,0.00023530
+Replacement Selection Sort,500,230,0.00014250
+Replacement Selection Sort,500,231,0.00013600
+Replacement Selection Sort,500,232,0.00013560
+Replacement Selection Sort,500,233,0.00013390
+Replacement Selection Sort,500,234,0.00013400
+Replacement Selection Sort,500,235,0.00013420
+Replacement Selection Sort,500,236,0.00023470
+Replacement Selection Sort,500,237,0.00014460
+Replacement Selection Sort,500,238,0.00015100
+Replacement Selection Sort,500,239,0.00015700
+Replacement Selection Sort,500,240,0.00013430
+Replacement Selection Sort,500,241,0.00015270
+Replacement Selection Sort,500,242,0.00013620
+Replacement Selection Sort,500,243,0.00013430
+Replacement Selection Sort,500,244,0.00014270
+Replacement Selection Sort,500,245,0.00018200
+Replacement Selection Sort,500,246,0.00020260
+Replacement Selection Sort,500,247,0.00013430
+Replacement Selection Sort,500,248,0.00013360
+Replacement Selection Sort,500,249,0.00021220
+Replacement Selection Sort,500,250,0.00013480
+Replacement Selection Sort,500,251,0.00013980
+Replacement Selection Sort,500,252,0.00013650
+Replacement Selection Sort,500,253,0.00014020
+Replacement Selection Sort,500,254,0.00015020
+Replacement Selection Sort,500,255,0.00013420
+Replacement Selection Sort,500,256,0.00013460
+Replacement Selection Sort,500,257,0.00013690
+Replacement Selection Sort,500,258,0.00013550
+Replacement Selection Sort,500,259,0.00013730
+Replacement Selection Sort,500,260,0.00013660
+Replacement Selection Sort,500,261,0.00016600
+Replacement Selection Sort,500,262,0.00013630
+Replacement Selection Sort,500,263,0.00015180
+Replacement Selection Sort,500,264,0.00021540
+Replacement Selection Sort,500,265,0.00013830
+Replacement Selection Sort,500,266,0.00013610
+Replacement Selection Sort,500,267,0.00014700
+Replacement Selection Sort,500,268,0.00013420
+Replacement Selection Sort,500,269,0.00013320
+Replacement Selection Sort,500,270,0.00013450
+Replacement Selection Sort,500,271,0.00013380
+Replacement Selection Sort,500,272,0.00013670
+Replacement Selection Sort,500,273,0.00013860
+Replacement Selection Sort,500,274,0.00013450
+Replacement Selection Sort,500,275,0.00016680
+Replacement Selection Sort,500,276,0.00013450
+Replacement Selection Sort,500,277,0.00013720
+Replacement Selection Sort,500,278,0.00021120
+Replacement Selection Sort,500,279,0.00032040
+Replacement Selection Sort,500,280,0.00014890
+Replacement Selection Sort,500,281,0.00022370
+Replacement Selection Sort,500,282,0.00013790
+Replacement Selection Sort,500,283,0.00013330
+Replacement Selection Sort,500,284,0.00015480
+Replacement Selection Sort,500,285,0.00013480
+Replacement Selection Sort,500,286,0.00014910
+Replacement Selection Sort,500,287,0.00013850
+Replacement Selection Sort,500,288,0.00015590
+Replacement Selection Sort,500,289,0.00013440
+Replacement Selection Sort,500,290,0.00013330
+Replacement Selection Sort,500,291,0.00041710
+Replacement Selection Sort,500,292,0.00013460
+Replacement Selection Sort,500,293,0.00013640
+Replacement Selection Sort,500,294,0.00013740
+Replacement Selection Sort,500,295,0.00013480
+Replacement Selection Sort,500,296,0.00014980
+Replacement Selection Sort,500,297,0.00013760
+Replacement Selection Sort,500,298,0.00013450
+Replacement Selection Sort,500,299,0.00013500
+Replacement Selection Sort,500,300,0.00013660
+Replacement Selection Sort,500,301,0.00014320
+Replacement Selection Sort,500,302,0.00022080
+Replacement Selection Sort,500,303,0.00013400
+Replacement Selection Sort,500,304,0.00014590
+Replacement Selection Sort,500,305,0.00013310
+Replacement Selection Sort,500,306,0.00013670
+Replacement Selection Sort,500,307,0.00013520
+Replacement Selection Sort,500,308,0.00013790
+Replacement Selection Sort,500,309,0.00013360
+Replacement Selection Sort,500,310,0.00013420
+Replacement Selection Sort,500,311,0.00015270
+Replacement Selection Sort,500,312,0.00013340
+Replacement Selection Sort,500,313,0.00013470
+Replacement Selection Sort,500,314,0.00013600
+Replacement Selection Sort,500,315,0.00013440
+Replacement Selection Sort,500,316,0.00013340
+Replacement Selection Sort,500,317,0.00013900
+Replacement Selection Sort,500,318,0.00013170
+Replacement Selection Sort,500,319,0.00013450
+Replacement Selection Sort,500,320,0.00013370
+Replacement Selection Sort,500,321,0.00015350
+Replacement Selection Sort,500,322,0.00013730
+Replacement Selection Sort,500,323,0.00013430
+Replacement Selection Sort,500,324,0.00013400
+Replacement Selection Sort,500,325,0.00014720
+Replacement Selection Sort,500,326,0.00013470
+Replacement Selection Sort,500,327,0.00014140
+Replacement Selection Sort,500,328,0.00013670
+Replacement Selection Sort,500,329,0.00013630
+Replacement Selection Sort,500,330,0.00023510
+Replacement Selection Sort,500,331,0.00015780
+Replacement Selection Sort,500,332,0.00016310
+Replacement Selection Sort,500,333,0.00015650
+Replacement Selection Sort,500,334,0.00013390
+Replacement Selection Sort,500,335,0.00013650
+Replacement Selection Sort,500,336,0.00013670
+Replacement Selection Sort,500,337,0.00014000
+Replacement Selection Sort,500,338,0.00014320
+Replacement Selection Sort,500,339,0.00018200
+Replacement Selection Sort,500,340,0.00013450
+Replacement Selection Sort,500,341,0.00015140
+Replacement Selection Sort,500,342,0.00014150
+Replacement Selection Sort,500,343,0.00013850
+Replacement Selection Sort,500,344,0.00030060
+Replacement Selection Sort,500,345,0.00013390
+Replacement Selection Sort,500,346,0.00014810
+Replacement Selection Sort,500,347,0.00022130
+Replacement Selection Sort,500,348,0.00017990
+Replacement Selection Sort,500,349,0.00019090
+Replacement Selection Sort,500,350,0.00018910
+Replacement Selection Sort,500,351,0.00021430
+Replacement Selection Sort,500,352,0.00013570
+Replacement Selection Sort,500,353,0.00013490
+Replacement Selection Sort,500,354,0.00013520
+Replacement Selection Sort,500,355,0.00021360
+Replacement Selection Sort,500,356,0.00013660
+Replacement Selection Sort,500,357,0.00013760
+Replacement Selection Sort,500,358,0.00015420
+Replacement Selection Sort,500,359,0.00013490
+Replacement Selection Sort,500,360,0.00021940
+Replacement Selection Sort,500,361,0.00014340
+Replacement Selection Sort,500,362,0.00013410
+Replacement Selection Sort,500,363,0.00013720
+Replacement Selection Sort,500,364,0.00026470
+Replacement Selection Sort,500,365,0.00017430
+Replacement Selection Sort,500,366,0.00013630
+Replacement Selection Sort,500,367,0.00013310
+Replacement Selection Sort,500,368,0.00015110
+Replacement Selection Sort,500,369,0.00015850
+Replacement Selection Sort,500,370,0.00013520
+Replacement Selection Sort,500,371,0.00014780
+Replacement Selection Sort,500,372,0.00013460
+Replacement Selection Sort,500,373,0.00014780
+Replacement Selection Sort,500,374,0.00013560
+Replacement Selection Sort,500,375,0.00016420
+Replacement Selection Sort,500,376,0.00013480
+Replacement Selection Sort,500,377,0.00014170
+Replacement Selection Sort,500,378,0.00013770
+Replacement Selection Sort,500,379,0.00015900
+Replacement Selection Sort,500,380,0.00024120
+Replacement Selection Sort,500,381,0.00015830
+Replacement Selection Sort,500,382,0.00014070
+Replacement Selection Sort,500,383,0.00013550
+Replacement Selection Sort,500,384,0.00013650
+Replacement Selection Sort,500,385,0.00014870
+Replacement Selection Sort,500,386,0.00015480
+Replacement Selection Sort,500,387,0.00013560
+Replacement Selection Sort,500,388,0.00013910
+Replacement Selection Sort,500,389,0.00013320
+Replacement Selection Sort,500,390,0.00013450
+Replacement Selection Sort,500,391,0.00024920
+Replacement Selection Sort,500,392,0.00013730
+Replacement Selection Sort,500,393,0.00013880
+Replacement Selection Sort,500,394,0.00013320
+Replacement Selection Sort,500,395,0.00040200
+Replacement Selection Sort,500,396,0.00021580
+Replacement Selection Sort,500,397,0.00014200
+Replacement Selection Sort,500,398,0.00013540
+Replacement Selection Sort,500,399,0.00013790
+Replacement Selection Sort,500,400,0.00025500
+Replacement Selection Sort,500,401,0.00016500
+Replacement Selection Sort,500,402,0.00019430
+Replacement Selection Sort,500,403,0.00013950
+Replacement Selection Sort,500,404,0.00013650
+Replacement Selection Sort,500,405,0.00013770
+Replacement Selection Sort,500,406,0.00013550
+Replacement Selection Sort,500,407,0.00013570
+Replacement Selection Sort,500,408,0.00013270
+Replacement Selection Sort,500,409,0.00013430
+Replacement Selection Sort,500,410,0.00014910
+Replacement Selection Sort,500,411,0.00016770
+Replacement Selection Sort,500,412,0.00032540
+Replacement Selection Sort,500,413,0.00014560
+Replacement Selection Sort,500,414,0.00013580
+Replacement Selection Sort,500,415,0.00016830
+Replacement Selection Sort,500,416,0.00021820
+Replacement Selection Sort,500,417,0.00021580
+Replacement Selection Sort,500,418,0.00014120
+Replacement Selection Sort,500,419,0.00021480
+Replacement Selection Sort,500,420,0.00018310
+Replacement Selection Sort,500,421,0.00014180
+Replacement Selection Sort,500,422,0.00013750
+Replacement Selection Sort,500,423,0.00018050
+Replacement Selection Sort,500,424,0.00013860
+Replacement Selection Sort,500,425,0.00013430
+Replacement Selection Sort,500,426,0.00020520
+Replacement Selection Sort,500,427,0.00015580
+Replacement Selection Sort,500,428,0.00015820
+Replacement Selection Sort,500,429,0.00013680
+Replacement Selection Sort,500,430,0.00023010
+Replacement Selection Sort,500,431,0.00022070
+Replacement Selection Sort,500,432,0.00023530
+Replacement Selection Sort,500,433,0.00020700
+Replacement Selection Sort,500,434,0.00023590
+Replacement Selection Sort,500,435,0.00019650
+Replacement Selection Sort,500,436,0.00018950
+Replacement Selection Sort,500,437,0.00015290
+Replacement Selection Sort,500,438,0.00015630
+Replacement Selection Sort,500,439,0.00013370
+Replacement Selection Sort,500,440,0.00022870
+Replacement Selection Sort,500,441,0.00014040
+Replacement Selection Sort,500,442,0.00013680
+Replacement Selection Sort,500,443,0.00019010
+Replacement Selection Sort,500,444,0.00015440
+Replacement Selection Sort,500,445,0.00013450
+Replacement Selection Sort,500,446,0.00015550
+Replacement Selection Sort,500,447,0.00016040
+Replacement Selection Sort,500,448,0.00015620
+Replacement Selection Sort,500,449,0.00014200
+Replacement Selection Sort,500,450,0.00013480
+Replacement Selection Sort,500,451,0.00013770
+Replacement Selection Sort,500,452,0.00016870
+Replacement Selection Sort,500,453,0.00025600
+Replacement Selection Sort,500,454,0.00016000
+Replacement Selection Sort,500,455,0.00016230
+Replacement Selection Sort,500,456,0.00013520
+Replacement Selection Sort,500,457,0.00013610
+Replacement Selection Sort,500,458,0.00014650
+Replacement Selection Sort,500,459,0.00014740
+Replacement Selection Sort,500,460,0.00013830
+Replacement Selection Sort,500,461,0.00013420
+Replacement Selection Sort,500,462,0.00014840
+Replacement Selection Sort,500,463,0.00013640
+Replacement Selection Sort,500,464,0.00014810
+Replacement Selection Sort,500,465,0.00016350
+Replacement Selection Sort,500,466,0.00013510
+Replacement Selection Sort,500,467,0.00013430
+Replacement Selection Sort,500,468,0.00013800
+Replacement Selection Sort,500,469,0.00014960
+Replacement Selection Sort,500,470,0.00014480
+Replacement Selection Sort,500,471,0.00013820
+Replacement Selection Sort,500,472,0.00013260
+Replacement Selection Sort,500,473,0.00013470
+Replacement Selection Sort,500,474,0.00013480
+Replacement Selection Sort,500,475,0.00017240
+Replacement Selection Sort,500,476,0.00013560
+Replacement Selection Sort,500,477,0.00014720
+Replacement Selection Sort,500,478,0.00022320
+Replacement Selection Sort,500,479,0.00024640
+Replacement Selection Sort,500,480,0.00015340
+Replacement Selection Sort,500,481,0.00020030
+Replacement Selection Sort,500,482,0.00014660
+Replacement Selection Sort,500,483,0.00013630
+Replacement Selection Sort,500,484,0.00015030
+Replacement Selection Sort,500,485,0.00013720
+Replacement Selection Sort,500,486,0.00013690
+Replacement Selection Sort,500,487,0.00013650
+Replacement Selection Sort,500,488,0.00020110
+Replacement Selection Sort,500,489,0.00016830
+Replacement Selection Sort,500,490,0.00014700
+Replacement Selection Sort,500,491,0.00014870
+Replacement Selection Sort,500,492,0.00016150
+Replacement Selection Sort,500,493,0.00015040
+Replacement Selection Sort,500,494,0.00013890
+Replacement Selection Sort,500,495,0.00019550
+Replacement Selection Sort,500,496,0.00015300
+Replacement Selection Sort,500,497,0.00014870
+Replacement Selection Sort,500,498,0.00013770
+Replacement Selection Sort,500,499,0.00015830
+Replacement Selection Sort,500,500,0.00013550
+Sample Sort,500,1,0.00176160
+Sample Sort,500,2,0.00106020
+Sample Sort,500,3,0.00180230
+Sample Sort,500,4,0.00190550
+Sample Sort,500,5,0.00181400
+Sample Sort,500,6,0.00179390
+Sample Sort,500,7,0.00120880
+Sample Sort,500,8,0.00187350
+Sample Sort,500,9,0.00152650
+Sample Sort,500,10,0.00184130
+Sample Sort,500,11,0.00185330
+Sample Sort,500,12,0.00187390
+Sample Sort,500,13,0.00176950
+Sample Sort,500,14,0.00217210
+Sample Sort,500,15,0.00109650
+Sample Sort,500,16,0.00133490
+Sample Sort,500,17,0.00157600
+Sample Sort,500,18,0.00128350
+Sample Sort,500,19,0.00111010
+Sample Sort,500,20,0.00187850
+Sample Sort,500,21,0.00185690
+Sample Sort,500,22,0.00129210
+Sample Sort,500,23,0.00130930
+Sample Sort,500,24,0.00175390
+Sample Sort,500,25,0.00122910
+Sample Sort,500,26,0.00146110
+Sample Sort,500,27,0.00163640
+Sample Sort,500,28,0.00154480
+Sample Sort,500,29,0.00182910
+Sample Sort,500,30,0.00147110
+Sample Sort,500,31,0.00102610
+Sample Sort,500,32,0.00137970
+Sample Sort,500,33,0.00126440
+Sample Sort,500,34,0.00115870
+Sample Sort,500,35,0.00130240
+Sample Sort,500,36,0.00116200
+Sample Sort,500,37,0.00127710
+Sample Sort,500,38,0.00184690
+Sample Sort,500,39,0.00181440
+Sample Sort,500,40,0.00179720
+Sample Sort,500,41,0.00117050
+Sample Sort,500,42,0.00144410
+Sample Sort,500,43,0.00182490
+Sample Sort,500,44,0.00120840
+Sample Sort,500,45,0.00107090
+Sample Sort,500,46,0.00102770
+Sample Sort,500,47,0.00184660
+Sample Sort,500,48,0.00177290
+Sample Sort,500,49,0.00196950
+Sample Sort,500,50,0.00102890
+Sample Sort,500,51,0.00193730
+Sample Sort,500,52,0.00193110
+Sample Sort,500,53,0.00104950
+Sample Sort,500,54,0.00121870
+Sample Sort,500,55,0.00136280
+Sample Sort,500,56,0.00176570
+Sample Sort,500,57,0.00103240
+Sample Sort,500,58,0.00184780
+Sample Sort,500,59,0.00181930
+Sample Sort,500,60,0.00181510
+Sample Sort,500,61,0.00193980
+Sample Sort,500,62,0.00184970
+Sample Sort,500,63,0.00104700
+Sample Sort,500,64,0.00101850
+Sample Sort,500,65,0.00181250
+Sample Sort,500,66,0.00144000
+Sample Sort,500,67,0.00169610
+Sample Sort,500,68,0.00195750
+Sample Sort,500,69,0.00183860
+Sample Sort,500,70,0.00120240
+Sample Sort,500,71,0.00165560
+Sample Sort,500,72,0.00135360
+Sample Sort,500,73,0.00185570
+Sample Sort,500,74,0.00154120
+Sample Sort,500,75,0.00104900
+Sample Sort,500,76,0.00168440
+Sample Sort,500,77,0.00114000
+Sample Sort,500,78,0.00105840
+Sample Sort,500,79,0.00185530
+Sample Sort,500,80,0.00188350
+Sample Sort,500,81,0.00107330
+Sample Sort,500,82,0.00173070
+Sample Sort,500,83,0.00150340
+Sample Sort,500,84,0.00122700
+Sample Sort,500,85,0.00146220
+Sample Sort,500,86,0.00185080
+Sample Sort,500,87,0.00101330
+Sample Sort,500,88,0.00181390
+Sample Sort,500,89,0.00167790
+Sample Sort,500,90,0.00103890
+Sample Sort,500,91,0.00138220
+Sample Sort,500,92,0.00184510
+Sample Sort,500,93,0.00185540
+Sample Sort,500,94,0.00104450
+Sample Sort,500,95,0.00181450
+Sample Sort,500,96,0.00124280
+Sample Sort,500,97,0.00188980
+Sample Sort,500,98,0.00124070
+Sample Sort,500,99,0.00117860
+Sample Sort,500,100,0.00157850
+Sample Sort,500,101,0.00105630
+Sample Sort,500,102,0.00184940
+Sample Sort,500,103,0.00107530
+Sample Sort,500,104,0.00136750
+Sample Sort,500,105,0.00142210
+Sample Sort,500,106,0.00188660
+Sample Sort,500,107,0.00163690
+Sample Sort,500,108,0.00188200
+Sample Sort,500,109,0.00107000
+Sample Sort,500,110,0.00119980
+Sample Sort,500,111,0.00125960
+Sample Sort,500,112,0.00163760
+Sample Sort,500,113,0.00184780
+Sample Sort,500,114,0.00142640
+Sample Sort,500,115,0.00116380
+Sample Sort,500,116,0.00113920
+Sample Sort,500,117,0.00136970
+Sample Sort,500,118,0.00191920
+Sample Sort,500,119,0.00186420
+Sample Sort,500,120,0.00187880
+Sample Sort,500,121,0.00105280
+Sample Sort,500,122,0.00182530
+Sample Sort,500,123,0.00122220
+Sample Sort,500,124,0.00195330
+Sample Sort,500,125,0.00159280
+Sample Sort,500,126,0.00165360
+Sample Sort,500,127,0.00186760
+Sample Sort,500,128,0.00187380
+Sample Sort,500,129,0.00190440
+Sample Sort,500,130,0.00170260
+Sample Sort,500,131,0.00150570
+Sample Sort,500,132,0.00188480
+Sample Sort,500,133,0.00191210
+Sample Sort,500,134,0.00124640
+Sample Sort,500,135,0.00187680
+Sample Sort,500,136,0.00185820
+Sample Sort,500,137,0.00180860
+Sample Sort,500,138,0.00170080
+Sample Sort,500,139,0.00181460
+Sample Sort,500,140,0.00188270
+Sample Sort,500,141,0.00198540
+Sample Sort,500,142,0.00173000
+Sample Sort,500,143,0.00186150
+Sample Sort,500,144,0.00191210
+Sample Sort,500,145,0.00189070
+Sample Sort,500,146,0.00183420
+Sample Sort,500,147,0.00184820
+Sample Sort,500,148,0.00187880
+Sample Sort,500,149,0.00155760
+Sample Sort,500,150,0.00158130
+Sample Sort,500,151,0.00185420
+Sample Sort,500,152,0.00169520
+Sample Sort,500,153,0.00185240
+Sample Sort,500,154,0.00124320
+Sample Sort,500,155,0.00183600
+Sample Sort,500,156,0.00170840
+Sample Sort,500,157,0.00188990
+Sample Sort,500,158,0.00144850
+Sample Sort,500,159,0.00166550
+Sample Sort,500,160,0.00119740
+Sample Sort,500,161,0.00186610
+Sample Sort,500,162,0.00183320
+Sample Sort,500,163,0.00169680
+Sample Sort,500,164,0.00185990
+Sample Sort,500,165,0.00176140
+Sample Sort,500,166,0.00190780
+Sample Sort,500,167,0.00176460
+Sample Sort,500,168,0.00173740
+Sample Sort,500,169,0.00186300
+Sample Sort,500,170,0.00174520
+Sample Sort,500,171,0.00162500
+Sample Sort,500,172,0.00105920
+Sample Sort,500,173,0.00171360
+Sample Sort,500,174,0.00192840
+Sample Sort,500,175,0.00189690
+Sample Sort,500,176,0.00181890
+Sample Sort,500,177,0.00108560
+Sample Sort,500,178,0.00192100
+Sample Sort,500,179,0.00178910
+Sample Sort,500,180,0.00169260
+Sample Sort,500,181,0.00165230
+Sample Sort,500,182,0.00163570
+Sample Sort,500,183,0.00181750
+Sample Sort,500,184,0.00206240
+Sample Sort,500,185,0.00186710
+Sample Sort,500,186,0.00172760
+Sample Sort,500,187,0.00168540
+Sample Sort,500,188,0.00197990
+Sample Sort,500,189,0.00182630
+Sample Sort,500,190,0.00203950
+Sample Sort,500,191,0.00198270
+Sample Sort,500,192,0.00202450
+Sample Sort,500,193,0.00208360
+Sample Sort,500,194,0.00208590
+Sample Sort,500,195,0.00201750
+Sample Sort,500,196,0.00186590
+Sample Sort,500,197,0.00199050
+Sample Sort,500,198,0.00215780
+Sample Sort,500,199,0.00174350
+Sample Sort,500,200,0.00186260
+Sample Sort,500,201,0.00205270
+Sample Sort,500,202,0.00151110
+Sample Sort,500,203,0.00190510
+Sample Sort,500,204,0.00192530
+Sample Sort,500,205,0.00219570
+Sample Sort,500,206,0.00188870
+Sample Sort,500,207,0.00201320
+Sample Sort,500,208,0.00185390
+Sample Sort,500,209,0.00157680
+Sample Sort,500,210,0.00196190
+Sample Sort,500,211,0.00179970
+Sample Sort,500,212,0.00173430
+Sample Sort,500,213,0.00179030
+Sample Sort,500,214,0.00179110
+Sample Sort,500,215,0.00190660
+Sample Sort,500,216,0.00145300
+Sample Sort,500,217,0.00202410
+Sample Sort,500,218,0.00206200
+Sample Sort,500,219,0.00179820
+Sample Sort,500,220,0.00188000
+Sample Sort,500,221,0.00197100
+Sample Sort,500,222,0.00188180
+Sample Sort,500,223,0.00182180
+Sample Sort,500,224,0.00187660
+Sample Sort,500,225,0.00181370
+Sample Sort,500,226,0.00188280
+Sample Sort,500,227,0.00132930
+Sample Sort,500,228,0.00139490
+Sample Sort,500,229,0.00191710
+Sample Sort,500,230,0.00194510
+Sample Sort,500,231,0.00196940
+Sample Sort,500,232,0.00183870
+Sample Sort,500,233,0.00204920
+Sample Sort,500,234,0.00181010
+Sample Sort,500,235,0.00181940
+Sample Sort,500,236,0.00185600
+Sample Sort,500,237,0.00187410
+Sample Sort,500,238,0.00184490
+Sample Sort,500,239,0.00162840
+Sample Sort,500,240,0.00188750
+Sample Sort,500,241,0.00204920
+Sample Sort,500,242,0.00244700
+Sample Sort,500,243,0.00210910
+Sample Sort,500,244,0.00150850
+Sample Sort,500,245,0.00266460
+Sample Sort,500,246,0.00217450
+Sample Sort,500,247,0.00189040
+Sample Sort,500,248,0.00174430
+Sample Sort,500,249,0.00185420
+Sample Sort,500,250,0.00146020
+Sample Sort,500,251,0.00189050
+Sample Sort,500,252,0.00199180
+Sample Sort,500,253,0.00229270
+Sample Sort,500,254,0.00199630
+Sample Sort,500,255,0.00184540
+Sample Sort,500,256,0.00170090
+Sample Sort,500,257,0.00173660
+Sample Sort,500,258,0.00186630
+Sample Sort,500,259,0.00174470
+Sample Sort,500,260,0.00213630
+Sample Sort,500,261,0.00176990
+Sample Sort,500,262,0.00177070
+Sample Sort,500,263,0.00208230
+Sample Sort,500,264,0.00196980
+Sample Sort,500,265,0.00121600
+Sample Sort,500,266,0.00136050
+Sample Sort,500,267,0.00190030
+Sample Sort,500,268,0.00199600
+Sample Sort,500,269,0.00179250
+Sample Sort,500,270,0.00179850
+Sample Sort,500,271,0.00132310
+Sample Sort,500,272,0.00139190
+Sample Sort,500,273,0.00115680
+Sample Sort,500,274,0.00193780
+Sample Sort,500,275,0.00185250
+Sample Sort,500,276,0.00128220
+Sample Sort,500,277,0.00214500
+Sample Sort,500,278,0.00191350
+Sample Sort,500,279,0.00120550
+Sample Sort,500,280,0.00186030
+Sample Sort,500,281,0.00103750
+Sample Sort,500,282,0.00219450
+Sample Sort,500,283,0.00189560
+Sample Sort,500,284,0.00250490
+Sample Sort,500,285,0.00185690
+Sample Sort,500,286,0.00228760
+Sample Sort,500,287,0.00189570
+Sample Sort,500,288,0.00197980
+Sample Sort,500,289,0.00194940
+Sample Sort,500,290,0.00197370
+Sample Sort,500,291,0.00211120
+Sample Sort,500,292,0.00252220
+Sample Sort,500,293,0.00207160
+Sample Sort,500,294,0.00193030
+Sample Sort,500,295,0.00236830
+Sample Sort,500,296,0.00188160
+Sample Sort,500,297,0.00189620
+Sample Sort,500,298,0.00200280
+Sample Sort,500,299,0.00218010
+Sample Sort,500,300,0.00177140
+Sample Sort,500,301,0.00191950
+Sample Sort,500,302,0.00202280
+Sample Sort,500,303,0.00184870
+Sample Sort,500,304,0.00185620
+Sample Sort,500,305,0.00220670
+Sample Sort,500,306,0.00184670
+Sample Sort,500,307,0.00165990
+Sample Sort,500,308,0.00151840
+Sample Sort,500,309,0.00134720
+Sample Sort,500,310,0.00187670
+Sample Sort,500,311,0.00149750
+Sample Sort,500,312,0.00188890
+Sample Sort,500,313,0.00172750
+Sample Sort,500,314,0.00187850
+Sample Sort,500,315,0.00175330
+Sample Sort,500,316,0.00194360
+Sample Sort,500,317,0.00135970
+Sample Sort,500,318,0.00185840
+Sample Sort,500,319,0.00187880
+Sample Sort,500,320,0.00193580
+Sample Sort,500,321,0.00132190
+Sample Sort,500,322,0.00167980
+Sample Sort,500,323,0.00235860
+Sample Sort,500,324,0.00179820
+Sample Sort,500,325,0.00179250
+Sample Sort,500,326,0.00180420
+Sample Sort,500,327,0.00114680
+Sample Sort,500,328,0.00189680
+Sample Sort,500,329,0.00158980
+Sample Sort,500,330,0.00167660
+Sample Sort,500,331,0.00143610
+Sample Sort,500,332,0.00188910
+Sample Sort,500,333,0.00185320
+Sample Sort,500,334,0.00116800
+Sample Sort,500,335,0.00131390
+Sample Sort,500,336,0.00171830
+Sample Sort,500,337,0.00158990
+Sample Sort,500,338,0.00187060
+Sample Sort,500,339,0.00182950
+Sample Sort,500,340,0.00157430
+Sample Sort,500,341,0.00186560
+Sample Sort,500,342,0.00174380
+Sample Sort,500,343,0.00190810
+Sample Sort,500,344,0.00188150
+Sample Sort,500,345,0.00180910
+Sample Sort,500,346,0.00184770
+Sample Sort,500,347,0.00189630
+Sample Sort,500,348,0.00184880
+Sample Sort,500,349,0.00192080
+Sample Sort,500,350,0.00187130
+Sample Sort,500,351,0.00183030
+Sample Sort,500,352,0.00199740
+Sample Sort,500,353,0.00217900
+Sample Sort,500,354,0.00171490
+Sample Sort,500,355,0.00187030
+Sample Sort,500,356,0.00165630
+Sample Sort,500,357,0.00207620
+Sample Sort,500,358,0.00186520
+Sample Sort,500,359,0.00183430
+Sample Sort,500,360,0.00186190
+Sample Sort,500,361,0.00191180
+Sample Sort,500,362,0.00160610
+Sample Sort,500,363,0.00185580
+Sample Sort,500,364,0.00155290
+Sample Sort,500,365,0.00198150
+Sample Sort,500,366,0.00201670
+Sample Sort,500,367,0.00184770
+Sample Sort,500,368,0.00142670
+Sample Sort,500,369,0.00179780
+Sample Sort,500,370,0.00199160
+Sample Sort,500,371,0.00191480
+Sample Sort,500,372,0.00187580
+Sample Sort,500,373,0.00192130
+Sample Sort,500,374,0.00192800
+Sample Sort,500,375,0.00184910
+Sample Sort,500,376,0.00168170
+Sample Sort,500,377,0.00198760
+Sample Sort,500,378,0.00205420
+Sample Sort,500,379,0.00186550
+Sample Sort,500,380,0.00183410
+Sample Sort,500,381,0.00189350
+Sample Sort,500,382,0.00185170
+Sample Sort,500,383,0.00211580
+Sample Sort,500,384,0.00165330
+Sample Sort,500,385,0.00186410
+Sample Sort,500,386,0.00179800
+Sample Sort,500,387,0.00146220
+Sample Sort,500,388,0.00185980
+Sample Sort,500,389,0.00193980
+Sample Sort,500,390,0.00166740
+Sample Sort,500,391,0.00199170
+Sample Sort,500,392,0.00193670
+Sample Sort,500,393,0.00186450
+Sample Sort,500,394,0.00195260
+Sample Sort,500,395,0.00191580
+Sample Sort,500,396,0.00160120
+Sample Sort,500,397,0.00185130
+Sample Sort,500,398,0.00160870
+Sample Sort,500,399,0.00157810
+Sample Sort,500,400,0.00134580
+Sample Sort,500,401,0.00113380
+Sample Sort,500,402,0.00132150
+Sample Sort,500,403,0.00151450
+Sample Sort,500,404,0.00207910
+Sample Sort,500,405,0.00158010
+Sample Sort,500,406,0.00173880
+Sample Sort,500,407,0.00179760
+Sample Sort,500,408,0.00184180
+Sample Sort,500,409,0.00153770
+Sample Sort,500,410,0.00223380
+Sample Sort,500,411,0.00105760
+Sample Sort,500,412,0.00181430
+Sample Sort,500,413,0.00141960
+Sample Sort,500,414,0.00153840
+Sample Sort,500,415,0.00115760
+Sample Sort,500,416,0.00178440
+Sample Sort,500,417,0.00114080
+Sample Sort,500,418,0.00112570
+Sample Sort,500,419,0.00183750
+Sample Sort,500,420,0.00133060
+Sample Sort,500,421,0.00150920
+Sample Sort,500,422,0.00171000
+Sample Sort,500,423,0.00151410
+Sample Sort,500,424,0.00192300
+Sample Sort,500,425,0.00122230
+Sample Sort,500,426,0.00187390
+Sample Sort,500,427,0.00108260
+Sample Sort,500,428,0.00161760
+Sample Sort,500,429,0.00115280
+Sample Sort,500,430,0.00186550
+Sample Sort,500,431,0.00110960
+Sample Sort,500,432,0.00185030
+Sample Sort,500,433,0.00189680
+Sample Sort,500,434,0.00102020
+Sample Sort,500,435,0.00153800
+Sample Sort,500,436,0.00135760
+Sample Sort,500,437,0.00123650
+Sample Sort,500,438,0.00174280
+Sample Sort,500,439,0.00167030
+Sample Sort,500,440,0.00182910
+Sample Sort,500,441,0.00161170
+Sample Sort,500,442,0.00135830
+Sample Sort,500,443,0.00187290
+Sample Sort,500,444,0.00185010
+Sample Sort,500,445,0.00115940
+Sample Sort,500,446,0.00188450
+Sample Sort,500,447,0.00186630
+Sample Sort,500,448,0.00178380
+Sample Sort,500,449,0.00171970
+Sample Sort,500,450,0.00109950
+Sample Sort,500,451,0.00128180
+Sample Sort,500,452,0.00188100
+Sample Sort,500,453,0.00151340
+Sample Sort,500,454,0.00124000
+Sample Sort,500,455,0.00128620
+Sample Sort,500,456,0.00126720
+Sample Sort,500,457,0.00157040
+Sample Sort,500,458,0.00173860
+Sample Sort,500,459,0.00115600
+Sample Sort,500,460,0.00125020
+Sample Sort,500,461,0.00181730
+Sample Sort,500,462,0.00178080
+Sample Sort,500,463,0.00104310
+Sample Sort,500,464,0.00182300
+Sample Sort,500,465,0.00176470
+Sample Sort,500,466,0.00112160
+Sample Sort,500,467,0.00164080
+Sample Sort,500,468,0.00123140
+Sample Sort,500,469,0.00117280
+Sample Sort,500,470,0.00199180
+Sample Sort,500,471,0.00178270
+Sample Sort,500,472,0.00181870
+Sample Sort,500,473,0.00111910
+Sample Sort,500,474,0.00158860
+Sample Sort,500,475,0.00104560
+Sample Sort,500,476,0.00152660
+Sample Sort,500,477,0.00148240
+Sample Sort,500,478,0.00106820
+Sample Sort,500,479,0.00101540
+Sample Sort,500,480,0.00180430
+Sample Sort,500,481,0.00179560
+Sample Sort,500,482,0.00195120
+Sample Sort,500,483,0.00164160
+Sample Sort,500,484,0.00164260
+Sample Sort,500,485,0.00111230
+Sample Sort,500,486,0.00103830
+Sample Sort,500,487,0.00187380
+Sample Sort,500,488,0.00181070
+Sample Sort,500,489,0.00109370
+Sample Sort,500,490,0.00178800
+Sample Sort,500,491,0.00186260
+Sample Sort,500,492,0.00178460
+Sample Sort,500,493,0.00103090
+Sample Sort,500,494,0.00185760
+Sample Sort,500,495,0.00183210
+Sample Sort,500,496,0.00114430
+Sample Sort,500,497,0.00119810
+Sample Sort,500,498,0.00178680
+Sample Sort,500,499,0.00178600
+Sample Sort,500,500,0.00178760
+Selection Sort,500,1,0.00631530
+Selection Sort,500,2,0.00794370
+Selection Sort,500,3,0.00504780
+Selection Sort,500,4,0.00492510
+Selection Sort,500,5,0.00601820
+Selection Sort,500,6,0.00761980
+Selection Sort,500,7,0.00779210
+Selection Sort,500,8,0.00694020
+Selection Sort,500,9,0.00542460
+Selection Sort,500,10,0.00627050
+Selection Sort,500,11,0.00580390
+Selection Sort,500,12,0.00632400
+Selection Sort,500,13,0.00634080
+Selection Sort,500,14,0.00591410
+Selection Sort,500,15,0.00581590
+Selection Sort,500,16,0.00657910
+Selection Sort,500,17,0.00631110
+Selection Sort,500,18,0.00539330
+Selection Sort,500,19,0.00793340
+Selection Sort,500,20,0.00542950
+Selection Sort,500,21,0.00609270
+Selection Sort,500,22,0.00637720
+Selection Sort,500,23,0.00639780
+Selection Sort,500,24,0.00759730
+Selection Sort,500,25,0.00598960
+Selection Sort,500,26,0.00637640
+Selection Sort,500,27,0.00786180
+Selection Sort,500,28,0.00592340
+Selection Sort,500,29,0.00560070
+Selection Sort,500,30,0.00718250
+Selection Sort,500,31,0.00618350
+Selection Sort,500,32,0.00744590
+Selection Sort,500,33,0.00711170
+Selection Sort,500,34,0.00721840
+Selection Sort,500,35,0.00637450
+Selection Sort,500,36,0.00755380
+Selection Sort,500,37,0.00649550
+Selection Sort,500,38,0.00576070
+Selection Sort,500,39,0.00727010
+Selection Sort,500,40,0.00721970
+Selection Sort,500,41,0.00664180
+Selection Sort,500,42,0.00777370
+Selection Sort,500,43,0.00628520
+Selection Sort,500,44,0.00656580
+Selection Sort,500,45,0.00703130
+Selection Sort,500,46,0.00633640
+Selection Sort,500,47,0.00669190
+Selection Sort,500,48,0.00680130
+Selection Sort,500,49,0.00707860
+Selection Sort,500,50,0.00537710
+Selection Sort,500,51,0.00799260
+Selection Sort,500,52,0.00538920
+Selection Sort,500,53,0.00778640
+Selection Sort,500,54,0.00655230
+Selection Sort,500,55,0.00668520
+Selection Sort,500,56,0.00694310
+Selection Sort,500,57,0.00498450
+Selection Sort,500,58,0.00760110
+Selection Sort,500,59,0.00645940
+Selection Sort,500,60,0.00658980
+Selection Sort,500,61,0.00525160
+Selection Sort,500,62,0.00673120
+Selection Sort,500,63,0.00490590
+Selection Sort,500,64,0.00744270
+Selection Sort,500,65,0.00687490
+Selection Sort,500,66,0.00519870
+Selection Sort,500,67,0.00679960
+Selection Sort,500,68,0.00715790
+Selection Sort,500,69,0.00786750
+Selection Sort,500,70,0.00489470
+Selection Sort,500,71,0.00703590
+Selection Sort,500,72,0.00600440
+Selection Sort,500,73,0.00662660
+Selection Sort,500,74,0.00750420
+Selection Sort,500,75,0.00663640
+Selection Sort,500,76,0.00497570
+Selection Sort,500,77,0.00536380
+Selection Sort,500,78,0.00782880
+Selection Sort,500,79,0.00545760
+Selection Sort,500,80,0.00721760
+Selection Sort,500,81,0.00680960
+Selection Sort,500,82,0.00573020
+Selection Sort,500,83,0.00699920
+Selection Sort,500,84,0.00718270
+Selection Sort,500,85,0.00660160
+Selection Sort,500,86,0.00584410
+Selection Sort,500,87,0.00755200
+Selection Sort,500,88,0.00721520
+Selection Sort,500,89,0.00732140
+Selection Sort,500,90,0.00521830
+Selection Sort,500,91,0.00635410
+Selection Sort,500,92,0.00796930
+Selection Sort,500,93,0.00499690
+Selection Sort,500,94,0.00504600
+Selection Sort,500,95,0.00567600
+Selection Sort,500,96,0.00809320
+Selection Sort,500,97,0.00783590
+Selection Sort,500,98,0.00714410
+Selection Sort,500,99,0.00650550
+Selection Sort,500,100,0.00603430
+Selection Sort,500,101,0.00632910
+Selection Sort,500,102,0.00687510
+Selection Sort,500,103,0.00757440
+Selection Sort,500,104,0.00605680
+Selection Sort,500,105,0.00647400
+Selection Sort,500,106,0.00716430
+Selection Sort,500,107,0.00776960
+Selection Sort,500,108,0.00602330
+Selection Sort,500,109,0.00641380
+Selection Sort,500,110,0.00763400
+Selection Sort,500,111,0.00753180
+Selection Sort,500,112,0.00620760
+Selection Sort,500,113,0.00810620
+Selection Sort,500,114,0.00756480
+Selection Sort,500,115,0.00662680
+Selection Sort,500,116,0.00632290
+Selection Sort,500,117,0.00773130
+Selection Sort,500,118,0.00580470
+Selection Sort,500,119,0.00787210
+Selection Sort,500,120,0.00518000
+Selection Sort,500,121,0.00798980
+Selection Sort,500,122,0.00774200
+Selection Sort,500,123,0.00611910
+Selection Sort,500,124,0.00582410
+Selection Sort,500,125,0.00791530
+Selection Sort,500,126,0.00703810
+Selection Sort,500,127,0.00671730
+Selection Sort,500,128,0.00658080
+Selection Sort,500,129,0.00597900
+Selection Sort,500,130,0.00637900
+Selection Sort,500,131,0.00695900
+Selection Sort,500,132,0.00741810
+Selection Sort,500,133,0.00805530
+Selection Sort,500,134,0.00661070
+Selection Sort,500,135,0.00613230
+Selection Sort,500,136,0.00703990
+Selection Sort,500,137,0.00667470
+Selection Sort,500,138,0.00671200
+Selection Sort,500,139,0.00821170
+Selection Sort,500,140,0.00750540
+Selection Sort,500,141,0.00806660
+Selection Sort,500,142,0.00776110
+Selection Sort,500,143,0.00743310
+Selection Sort,500,144,0.00808120
+Selection Sort,500,145,0.00801570
+Selection Sort,500,146,0.00779110
+Selection Sort,500,147,0.00779650
+Selection Sort,500,148,0.00674570
+Selection Sort,500,149,0.00826330
+Selection Sort,500,150,0.00782890
+Selection Sort,500,151,0.00829550
+Selection Sort,500,152,0.00799360
+Selection Sort,500,153,0.00782920
+Selection Sort,500,154,0.00805500
+Selection Sort,500,155,0.00737170
+Selection Sort,500,156,0.00816330
+Selection Sort,500,157,0.00780110
+Selection Sort,500,158,0.00708810
+Selection Sort,500,159,0.00825530
+Selection Sort,500,160,0.00668650
+Selection Sort,500,161,0.00759540
+Selection Sort,500,162,0.00702390
+Selection Sort,500,163,0.00788260
+Selection Sort,500,164,0.00801510
+Selection Sort,500,165,0.00787160
+Selection Sort,500,166,0.00681950
+Selection Sort,500,167,0.00806220
+Selection Sort,500,168,0.00824390
+Selection Sort,500,169,0.00731860
+Selection Sort,500,170,0.00765470
+Selection Sort,500,171,0.00717720
+Selection Sort,500,172,0.00727820
+Selection Sort,500,173,0.00601090
+Selection Sort,500,174,0.00787390
+Selection Sort,500,175,0.00629270
+Selection Sort,500,176,0.00533660
+Selection Sort,500,177,0.00658620
+Selection Sort,500,178,0.00496470
+Selection Sort,500,179,0.00726000
+Selection Sort,500,180,0.00608010
+Selection Sort,500,181,0.00611330
+Selection Sort,500,182,0.00629170
+Selection Sort,500,183,0.00648840
+Selection Sort,500,184,0.00760120
+Selection Sort,500,185,0.00697910
+Selection Sort,500,186,0.00732600
+Selection Sort,500,187,0.00658280
+Selection Sort,500,188,0.00790800
+Selection Sort,500,189,0.00560490
+Selection Sort,500,190,0.00703540
+Selection Sort,500,191,0.00532680
+Selection Sort,500,192,0.00631780
+Selection Sort,500,193,0.00727630
+Selection Sort,500,194,0.00605670
+Selection Sort,500,195,0.00543240
+Selection Sort,500,196,0.00705050
+Selection Sort,500,197,0.00737830
+Selection Sort,500,198,0.00615080
+Selection Sort,500,199,0.00800040
+Selection Sort,500,200,0.00599820
+Selection Sort,500,201,0.00626790
+Selection Sort,500,202,0.00734830
+Selection Sort,500,203,0.00518050
+Selection Sort,500,204,0.00485200
+Selection Sort,500,205,0.00649170
+Selection Sort,500,206,0.00822100
+Selection Sort,500,207,0.00736660
+Selection Sort,500,208,0.00739530
+Selection Sort,500,209,0.00721830
+Selection Sort,500,210,0.00806890
+Selection Sort,500,211,0.00568560
+Selection Sort,500,212,0.00662140
+Selection Sort,500,213,0.00712150
+Selection Sort,500,214,0.00553970
+Selection Sort,500,215,0.00658180
+Selection Sort,500,216,0.00607290
+Selection Sort,500,217,0.00773920
+Selection Sort,500,218,0.00584980
+Selection Sort,500,219,0.00766020
+Selection Sort,500,220,0.00614800
+Selection Sort,500,221,0.00557090
+Selection Sort,500,222,0.00670260
+Selection Sort,500,223,0.00632500
+Selection Sort,500,224,0.00815380
+Selection Sort,500,225,0.00528120
+Selection Sort,500,226,0.00713240
+Selection Sort,500,227,0.00804620
+Selection Sort,500,228,0.00793720
+Selection Sort,500,229,0.00477930
+Selection Sort,500,230,0.00590430
+Selection Sort,500,231,0.00788360
+Selection Sort,500,232,0.00769440
+Selection Sort,500,233,0.00776610
+Selection Sort,500,234,0.00709230
+Selection Sort,500,235,0.00645630
+Selection Sort,500,236,0.00783470
+Selection Sort,500,237,0.00785480
+Selection Sort,500,238,0.00666020
+Selection Sort,500,239,0.00767250
+Selection Sort,500,240,0.00687840
+Selection Sort,500,241,0.00687080
+Selection Sort,500,242,0.00602360
+Selection Sort,500,243,0.00773060
+Selection Sort,500,244,0.00736330
+Selection Sort,500,245,0.00625080
+Selection Sort,500,246,0.00718160
+Selection Sort,500,247,0.00739610
+Selection Sort,500,248,0.00634130
+Selection Sort,500,249,0.00696820
+Selection Sort,500,250,0.00532570
+Selection Sort,500,251,0.00765170
+Selection Sort,500,252,0.00622470
+Selection Sort,500,253,0.00707940
+Selection Sort,500,254,0.00627250
+Selection Sort,500,255,0.00649230
+Selection Sort,500,256,0.00754330
+Selection Sort,500,257,0.00648300
+Selection Sort,500,258,0.00547730
+Selection Sort,500,259,0.00730250
+Selection Sort,500,260,0.00705850
+Selection Sort,500,261,0.00720800
+Selection Sort,500,262,0.00608680
+Selection Sort,500,263,0.00618100
+Selection Sort,500,264,0.00569720
+Selection Sort,500,265,0.00644800
+Selection Sort,500,266,0.00590270
+Selection Sort,500,267,0.00602200
+Selection Sort,500,268,0.00648970
+Selection Sort,500,269,0.00561350
+Selection Sort,500,270,0.00705690
+Selection Sort,500,271,0.00549900
+Selection Sort,500,272,0.00669480
+Selection Sort,500,273,0.00573220
+Selection Sort,500,274,0.00644370
+Selection Sort,500,275,0.00712910
+Selection Sort,500,276,0.00513790
+Selection Sort,500,277,0.00529400
+Selection Sort,500,278,0.00551040
+Selection Sort,500,279,0.00569640
+Selection Sort,500,280,0.00692400
+Selection Sort,500,281,0.00580630
+Selection Sort,500,282,0.00731030
+Selection Sort,500,283,0.00611570
+Selection Sort,500,284,0.00642590
+Selection Sort,500,285,0.00586410
+Selection Sort,500,286,0.00672580
+Selection Sort,500,287,0.00686040
+Selection Sort,500,288,0.00623290
+Selection Sort,500,289,0.00689280
+Selection Sort,500,290,0.00480490
+Selection Sort,500,291,0.00574230
+Selection Sort,500,292,0.00742690
+Selection Sort,500,293,0.00629470
+Selection Sort,500,294,0.00727440
+Selection Sort,500,295,0.00693760
+Selection Sort,500,296,0.00599410
+Selection Sort,500,297,0.00661720
+Selection Sort,500,298,0.00708610
+Selection Sort,500,299,0.00742130
+Selection Sort,500,300,0.00783980
+Selection Sort,500,301,0.00681000
+Selection Sort,500,302,0.00718690
+Selection Sort,500,303,0.00814650
+Selection Sort,500,304,0.00741820
+Selection Sort,500,305,0.00726770
+Selection Sort,500,306,0.00698250
+Selection Sort,500,307,0.00718030
+Selection Sort,500,308,0.00767070
+Selection Sort,500,309,0.00790780
+Selection Sort,500,310,0.00573750
+Selection Sort,500,311,0.00566700
+Selection Sort,500,312,0.00739480
+Selection Sort,500,313,0.00694460
+Selection Sort,500,314,0.00786960
+Selection Sort,500,315,0.00666470
+Selection Sort,500,316,0.00702470
+Selection Sort,500,317,0.00839750
+Selection Sort,500,318,0.00726550
+Selection Sort,500,319,0.00778440
+Selection Sort,500,320,0.00774280
+Selection Sort,500,321,0.00713110
+Selection Sort,500,322,0.00734480
+Selection Sort,500,323,0.00749070
+Selection Sort,500,324,0.00723650
+Selection Sort,500,325,0.00723160
+Selection Sort,500,326,0.00634650
+Selection Sort,500,327,0.00753990
+Selection Sort,500,328,0.00667970
+Selection Sort,500,329,0.00826000
+Selection Sort,500,330,0.00785750
+Selection Sort,500,331,0.00765520
+Selection Sort,500,332,0.00740120
+Selection Sort,500,333,0.00717570
+Selection Sort,500,334,0.00752120
+Selection Sort,500,335,0.00724920
+Selection Sort,500,336,0.00770720
+Selection Sort,500,337,0.00841090
+Selection Sort,500,338,0.00690420
+Selection Sort,500,339,0.00710380
+Selection Sort,500,340,0.00764200
+Selection Sort,500,341,0.00573860
+Selection Sort,500,342,0.00792230
+Selection Sort,500,343,0.00670840
+Selection Sort,500,344,0.00652020
+Selection Sort,500,345,0.00677280
+Selection Sort,500,346,0.00659510
+Selection Sort,500,347,0.00563690
+Selection Sort,500,348,0.00805420
+Selection Sort,500,349,0.00628780
+Selection Sort,500,350,0.00687980
+Selection Sort,500,351,0.00803880
+Selection Sort,500,352,0.00738330
+Selection Sort,500,353,0.00554730
+Selection Sort,500,354,0.00537380
+Selection Sort,500,355,0.00562230
+Selection Sort,500,356,0.00792430
+Selection Sort,500,357,0.00550600
+Selection Sort,500,358,0.00805300
+Selection Sort,500,359,0.00743820
+Selection Sort,500,360,0.00597640
+Selection Sort,500,361,0.00741670
+Selection Sort,500,362,0.00569550
+Selection Sort,500,363,0.00609790
+Selection Sort,500,364,0.00586990
+Selection Sort,500,365,0.00731930
+Selection Sort,500,366,0.00689510
+Selection Sort,500,367,0.00540730
+Selection Sort,500,368,0.00734390
+Selection Sort,500,369,0.00721810
+Selection Sort,500,370,0.00634530
+Selection Sort,500,371,0.00729870
+Selection Sort,500,372,0.00626730
+Selection Sort,500,373,0.00644800
+Selection Sort,500,374,0.00678020
+Selection Sort,500,375,0.00619630
+Selection Sort,500,376,0.00591060
+Selection Sort,500,377,0.00754450
+Selection Sort,500,378,0.00707420
+Selection Sort,500,379,0.00751950
+Selection Sort,500,380,0.00686100
+Selection Sort,500,381,0.00556640
+Selection Sort,500,382,0.00761390
+Selection Sort,500,383,0.00582670
+Selection Sort,500,384,0.00756090
+Selection Sort,500,385,0.00558850
+Selection Sort,500,386,0.00728460
+Selection Sort,500,387,0.00559950
+Selection Sort,500,388,0.00706380
+Selection Sort,500,389,0.00572120
+Selection Sort,500,390,0.00701800
+Selection Sort,500,391,0.00546930
+Selection Sort,500,392,0.00790980
+Selection Sort,500,393,0.00788000
+Selection Sort,500,394,0.00499840
+Selection Sort,500,395,0.00593560
+Selection Sort,500,396,0.00579110
+Selection Sort,500,397,0.00533660
+Selection Sort,500,398,0.00538710
+Selection Sort,500,399,0.00502180
+Selection Sort,500,400,0.00651230
+Selection Sort,500,401,0.00658220
+Selection Sort,500,402,0.00793810
+Selection Sort,500,403,0.00762040
+Selection Sort,500,404,0.00523470
+Selection Sort,500,405,0.00555240
+Selection Sort,500,406,0.00651990
+Selection Sort,500,407,0.00621400
+Selection Sort,500,408,0.00747660
+Selection Sort,500,409,0.00735570
+Selection Sort,500,410,0.00547610
+Selection Sort,500,411,0.00773160
+Selection Sort,500,412,0.00571480
+Selection Sort,500,413,0.00806340
+Selection Sort,500,414,0.00777360
+Selection Sort,500,415,0.00596760
+Selection Sort,500,416,0.00659110
+Selection Sort,500,417,0.00817140
+Selection Sort,500,418,0.00586690
+Selection Sort,500,419,0.00569080
+Selection Sort,500,420,0.00779450
+Selection Sort,500,421,0.00667890
+Selection Sort,500,422,0.00722090
+Selection Sort,500,423,0.00627460
+Selection Sort,500,424,0.00663050
+Selection Sort,500,425,0.00701810
+Selection Sort,500,426,0.00585810
+Selection Sort,500,427,0.00606300
+Selection Sort,500,428,0.00753060
+Selection Sort,500,429,0.00663120
+Selection Sort,500,430,0.00576740
+Selection Sort,500,431,0.00775710
+Selection Sort,500,432,0.00530180
+Selection Sort,500,433,0.00526870
+Selection Sort,500,434,0.00723700
+Selection Sort,500,435,0.00662810
+Selection Sort,500,436,0.00550700
+Selection Sort,500,437,0.00784780
+Selection Sort,500,438,0.00689280
+Selection Sort,500,439,0.00539600
+Selection Sort,500,440,0.00644050
+Selection Sort,500,441,0.00761790
+Selection Sort,500,442,0.00653970
+Selection Sort,500,443,0.00662030
+Selection Sort,500,444,0.00623900
+Selection Sort,500,445,0.00577630
+Selection Sort,500,446,0.00722710
+Selection Sort,500,447,0.00572330
+Selection Sort,500,448,0.00654320
+Selection Sort,500,449,0.00680640
+Selection Sort,500,450,0.00562950
+Selection Sort,500,451,0.00711290
+Selection Sort,500,452,0.00788710
+Selection Sort,500,453,0.00771600
+Selection Sort,500,454,0.00631040
+Selection Sort,500,455,0.00797270
+Selection Sort,500,456,0.00753770
+Selection Sort,500,457,0.00679710
+Selection Sort,500,458,0.00776470
+Selection Sort,500,459,0.00809240
+Selection Sort,500,460,0.00766750
+Selection Sort,500,461,0.00824940
+Selection Sort,500,462,0.00772130
+Selection Sort,500,463,0.00766420
+Selection Sort,500,464,0.00760780
+Selection Sort,500,465,0.00838710
+Selection Sort,500,466,0.00846030
+Selection Sort,500,467,0.00851880
+Selection Sort,500,468,0.00824240
+Selection Sort,500,469,0.00776650
+Selection Sort,500,470,0.00826930
+Selection Sort,500,471,0.00746830
+Selection Sort,500,472,0.00831280
+Selection Sort,500,473,0.00902840
+Selection Sort,500,474,0.00884180
+Selection Sort,500,475,0.00822350
+Selection Sort,500,476,0.00824730
+Selection Sort,500,477,0.00792680
+Selection Sort,500,478,0.00844730
+Selection Sort,500,479,0.00721460
+Selection Sort,500,480,0.00799780
+Selection Sort,500,481,0.00663900
+Selection Sort,500,482,0.00761080
+Selection Sort,500,483,0.00676070
+Selection Sort,500,484,0.00754620
+Selection Sort,500,485,0.00581130
+Selection Sort,500,486,0.00620260
+Selection Sort,500,487,0.00793480
+Selection Sort,500,488,0.00763290
+Selection Sort,500,489,0.00730860
+Selection Sort,500,490,0.00663320
+Selection Sort,500,491,0.00759670
+Selection Sort,500,492,0.00711750
+Selection Sort,500,493,0.00776790
+Selection Sort,500,494,0.00727150
+Selection Sort,500,495,0.00781710
+Selection Sort,500,496,0.00728060
+Selection Sort,500,497,0.00693830
+Selection Sort,500,498,0.00748530
+Selection Sort,500,499,0.00708800
+Selection Sort,500,500,0.00734410
+Shell Sort,500,1,0.00096590
+Shell Sort,500,2,0.00061570
+Shell Sort,500,3,0.00089820
+Shell Sort,500,4,0.00087190
+Shell Sort,500,5,0.00088160
+Shell Sort,500,6,0.00096680
+Shell Sort,500,7,0.00085790
+Shell Sort,500,8,0.00089300
+Shell Sort,500,9,0.00081680
+Shell Sort,500,10,0.00073400
+Shell Sort,500,11,0.00092950
+Shell Sort,500,12,0.00091450
+Shell Sort,500,13,0.00086840
+Shell Sort,500,14,0.00096640
+Shell Sort,500,15,0.00065280
+Shell Sort,500,16,0.00087640
+Shell Sort,500,17,0.00053970
+Shell Sort,500,18,0.00087590
+Shell Sort,500,19,0.00096010
+Shell Sort,500,20,0.00088630
+Shell Sort,500,21,0.00071800
+Shell Sort,500,22,0.00055690
+Shell Sort,500,23,0.00050640
+Shell Sort,500,24,0.00112250
+Shell Sort,500,25,0.00095110
+Shell Sort,500,26,0.00104030
+Shell Sort,500,27,0.00094860
+Shell Sort,500,28,0.00103000
+Shell Sort,500,29,0.00077370
+Shell Sort,500,30,0.00084880
+Shell Sort,500,31,0.00107530
+Shell Sort,500,32,0.00089840
+Shell Sort,500,33,0.00067190
+Shell Sort,500,34,0.00094380
+Shell Sort,500,35,0.00095130
+Shell Sort,500,36,0.00097100
+Shell Sort,500,37,0.00103260
+Shell Sort,500,38,0.00103860
+Shell Sort,500,39,0.00103810
+Shell Sort,500,40,0.00083320
+Shell Sort,500,41,0.00089580
+Shell Sort,500,42,0.00081720
+Shell Sort,500,43,0.00065450
+Shell Sort,500,44,0.00090000
+Shell Sort,500,45,0.00100720
+Shell Sort,500,46,0.00108570
+Shell Sort,500,47,0.00081060
+Shell Sort,500,48,0.00085050
+Shell Sort,500,49,0.00070420
+Shell Sort,500,50,0.00094480
+Shell Sort,500,51,0.00085250
+Shell Sort,500,52,0.00083980
+Shell Sort,500,53,0.00100980
+Shell Sort,500,54,0.00097120
+Shell Sort,500,55,0.00079020
+Shell Sort,500,56,0.00089600
+Shell Sort,500,57,0.00062630
+Shell Sort,500,58,0.00087480
+Shell Sort,500,59,0.00094310
+Shell Sort,500,60,0.00090180
+Shell Sort,500,61,0.00095200
+Shell Sort,500,62,0.00074790
+Shell Sort,500,63,0.00093290
+Shell Sort,500,64,0.00065150
+Shell Sort,500,65,0.00089950
+Shell Sort,500,66,0.00096700
+Shell Sort,500,67,0.00094800
+Shell Sort,500,68,0.00092730
+Shell Sort,500,69,0.00091580
+Shell Sort,500,70,0.00071210
+Shell Sort,500,71,0.00090990
+Shell Sort,500,72,0.00094540
+Shell Sort,500,73,0.00092550
+Shell Sort,500,74,0.00073940
+Shell Sort,500,75,0.00055500
+Shell Sort,500,76,0.00083500
+Shell Sort,500,77,0.00059690
+Shell Sort,500,78,0.00094220
+Shell Sort,500,79,0.00094360
+Shell Sort,500,80,0.00094910
+Shell Sort,500,81,0.00050800
+Shell Sort,500,82,0.00087250
+Shell Sort,500,83,0.00063270
+Shell Sort,500,84,0.00078860
+Shell Sort,500,85,0.00090620
+Shell Sort,500,86,0.00059530
+Shell Sort,500,87,0.00090650
+Shell Sort,500,88,0.00092890
+Shell Sort,500,89,0.00095520
+Shell Sort,500,90,0.00069570
+Shell Sort,500,91,0.00087280
+Shell Sort,500,92,0.00085620
+Shell Sort,500,93,0.00057760
+Shell Sort,500,94,0.00094690
+Shell Sort,500,95,0.00093440
+Shell Sort,500,96,0.00097870
+Shell Sort,500,97,0.00088800
+Shell Sort,500,98,0.00098750
+Shell Sort,500,99,0.00081750
+Shell Sort,500,100,0.00081240
+Shell Sort,500,101,0.00102790
+Shell Sort,500,102,0.00062920
+Shell Sort,500,103,0.00063900
+Shell Sort,500,104,0.00069240
+Shell Sort,500,105,0.00090400
+Shell Sort,500,106,0.00092330
+Shell Sort,500,107,0.00090180
+Shell Sort,500,108,0.00092560
+Shell Sort,500,109,0.00065450
+Shell Sort,500,110,0.00077810
+Shell Sort,500,111,0.00065460
+Shell Sort,500,112,0.00095500
+Shell Sort,500,113,0.00091260
+Shell Sort,500,114,0.00078050
+Shell Sort,500,115,0.00084600
+Shell Sort,500,116,0.00109510
+Shell Sort,500,117,0.00075740
+Shell Sort,500,118,0.00091370
+Shell Sort,500,119,0.00093330
+Shell Sort,500,120,0.00107410
+Shell Sort,500,121,0.00088350
+Shell Sort,500,122,0.00091160
+Shell Sort,500,123,0.00096770
+Shell Sort,500,124,0.00095260
+Shell Sort,500,125,0.00090970
+Shell Sort,500,126,0.00098860
+Shell Sort,500,127,0.00091920
+Shell Sort,500,128,0.00088200
+Shell Sort,500,129,0.00093570
+Shell Sort,500,130,0.00092280
+Shell Sort,500,131,0.00073530
+Shell Sort,500,132,0.00072040
+Shell Sort,500,133,0.00089260
+Shell Sort,500,134,0.00097420
+Shell Sort,500,135,0.00098770
+Shell Sort,500,136,0.00094190
+Shell Sort,500,137,0.00096270
+Shell Sort,500,138,0.00100710
+Shell Sort,500,139,0.00092910
+Shell Sort,500,140,0.00098240
+Shell Sort,500,141,0.00094800
+Shell Sort,500,142,0.00099040
+Shell Sort,500,143,0.00105390
+Shell Sort,500,144,0.00090180
+Shell Sort,500,145,0.00099360
+Shell Sort,500,146,0.00090490
+Shell Sort,500,147,0.00091240
+Shell Sort,500,148,0.00088640
+Shell Sort,500,149,0.00099820
+Shell Sort,500,150,0.00096650
+Shell Sort,500,151,0.00088320
+Shell Sort,500,152,0.00089560
+Shell Sort,500,153,0.00061200
+Shell Sort,500,154,0.00054050
+Shell Sort,500,155,0.00085340
+Shell Sort,500,156,0.00097930
+Shell Sort,500,157,0.00072060
+Shell Sort,500,158,0.00090390
+Shell Sort,500,159,0.00105060
+Shell Sort,500,160,0.00062950
+Shell Sort,500,161,0.00104460
+Shell Sort,500,162,0.00109880
+Shell Sort,500,163,0.00080160
+Shell Sort,500,164,0.00090370
+Shell Sort,500,165,0.00059660
+Shell Sort,500,166,0.00059380
+Shell Sort,500,167,0.00091500
+Shell Sort,500,168,0.00092880
+Shell Sort,500,169,0.00097770
+Shell Sort,500,170,0.00075170
+Shell Sort,500,171,0.00097630
+Shell Sort,500,172,0.00052080
+Shell Sort,500,173,0.00062580
+Shell Sort,500,174,0.00081630
+Shell Sort,500,175,0.00087730
+Shell Sort,500,176,0.00092470
+Shell Sort,500,177,0.00066100
+Shell Sort,500,178,0.00069220
+Shell Sort,500,179,0.00100430
+Shell Sort,500,180,0.00069240
+Shell Sort,500,181,0.00090970
+Shell Sort,500,182,0.00062960
+Shell Sort,500,183,0.00077730
+Shell Sort,500,184,0.00061500
+Shell Sort,500,185,0.00057560
+Shell Sort,500,186,0.00094110
+Shell Sort,500,187,0.00090060
+Shell Sort,500,188,0.00070500
+Shell Sort,500,189,0.00062980
+Shell Sort,500,190,0.00087310
+Shell Sort,500,191,0.00089330
+Shell Sort,500,192,0.00091030
+Shell Sort,500,193,0.00065940
+Shell Sort,500,194,0.00089520
+Shell Sort,500,195,0.00060710
+Shell Sort,500,196,0.00052930
+Shell Sort,500,197,0.00072460
+Shell Sort,500,198,0.00064230
+Shell Sort,500,199,0.00082590
+Shell Sort,500,200,0.00077730
+Shell Sort,500,201,0.00060840
+Shell Sort,500,202,0.00061350
+Shell Sort,500,203,0.00053570
+Shell Sort,500,204,0.00061740
+Shell Sort,500,205,0.00059220
+Shell Sort,500,206,0.00090090
+Shell Sort,500,207,0.00078000
+Shell Sort,500,208,0.00064850
+Shell Sort,500,209,0.00064150
+Shell Sort,500,210,0.00062530
+Shell Sort,500,211,0.00055950
+Shell Sort,500,212,0.00059630
+Shell Sort,500,213,0.00063180
+Shell Sort,500,214,0.00073000
+Shell Sort,500,215,0.00060710
+Shell Sort,500,216,0.00057440
+Shell Sort,500,217,0.00066790
+Shell Sort,500,218,0.00065380
+Shell Sort,500,219,0.00067590
+Shell Sort,500,220,0.00055190
+Shell Sort,500,221,0.00065590
+Shell Sort,500,222,0.00072040
+Shell Sort,500,223,0.00093650
+Shell Sort,500,224,0.00088460
+Shell Sort,500,225,0.00072540
+Shell Sort,500,226,0.00052680
+Shell Sort,500,227,0.00055420
+Shell Sort,500,228,0.00070200
+Shell Sort,500,229,0.00058150
+Shell Sort,500,230,0.00089410
+Shell Sort,500,231,0.00060980
+Shell Sort,500,232,0.00093240
+Shell Sort,500,233,0.00073730
+Shell Sort,500,234,0.00050520
+Shell Sort,500,235,0.00054200
+Shell Sort,500,236,0.00058210
+Shell Sort,500,237,0.00055210
+Shell Sort,500,238,0.00074090
+Shell Sort,500,239,0.00057280
+Shell Sort,500,240,0.00077120
+Shell Sort,500,241,0.00073840
+Shell Sort,500,242,0.00062500
+Shell Sort,500,243,0.00054470
+Shell Sort,500,244,0.00061530
+Shell Sort,500,245,0.00068040
+Shell Sort,500,246,0.00063130
+Shell Sort,500,247,0.00085980
+Shell Sort,500,248,0.00054070
+Shell Sort,500,249,0.00052480
+Shell Sort,500,250,0.00059460
+Shell Sort,500,251,0.00074430
+Shell Sort,500,252,0.00058860
+Shell Sort,500,253,0.00054460
+Shell Sort,500,254,0.00060510
+Shell Sort,500,255,0.00076050
+Shell Sort,500,256,0.00081810
+Shell Sort,500,257,0.00056510
+Shell Sort,500,258,0.00057180
+Shell Sort,500,259,0.00063010
+Shell Sort,500,260,0.00092220
+Shell Sort,500,261,0.00053390
+Shell Sort,500,262,0.00092260
+Shell Sort,500,263,0.00053240
+Shell Sort,500,264,0.00067450
+Shell Sort,500,265,0.00053190
+Shell Sort,500,266,0.00052540
+Shell Sort,500,267,0.00059950
+Shell Sort,500,268,0.00054990
+Shell Sort,500,269,0.00055670
+Shell Sort,500,270,0.00051860
+Shell Sort,500,271,0.00054650
+Shell Sort,500,272,0.00079330
+Shell Sort,500,273,0.00090500
+Shell Sort,500,274,0.00059450
+Shell Sort,500,275,0.00077610
+Shell Sort,500,276,0.00089400
+Shell Sort,500,277,0.00092520
+Shell Sort,500,278,0.00053180
+Shell Sort,500,279,0.00078020
+Shell Sort,500,280,0.00096320
+Shell Sort,500,281,0.00074660
+Shell Sort,500,282,0.00053440
+Shell Sort,500,283,0.00074920
+Shell Sort,500,284,0.00055540
+Shell Sort,500,285,0.00056740
+Shell Sort,500,286,0.00056050
+Shell Sort,500,287,0.00061370
+Shell Sort,500,288,0.00073720
+Shell Sort,500,289,0.00099320
+Shell Sort,500,290,0.00074550
+Shell Sort,500,291,0.00076610
+Shell Sort,500,292,0.00083170
+Shell Sort,500,293,0.00055230
+Shell Sort,500,294,0.00096770
+Shell Sort,500,295,0.00078700
+Shell Sort,500,296,0.00054350
+Shell Sort,500,297,0.00098570
+Shell Sort,500,298,0.00092340
+Shell Sort,500,299,0.00091030
+Shell Sort,500,300,0.00078370
+Shell Sort,500,301,0.00073000
+Shell Sort,500,302,0.00059610
+Shell Sort,500,303,0.00053940
+Shell Sort,500,304,0.00068790
+Shell Sort,500,305,0.00098490
+Shell Sort,500,306,0.00058050
+Shell Sort,500,307,0.00052850
+Shell Sort,500,308,0.00076550
+Shell Sort,500,309,0.00071040
+Shell Sort,500,310,0.00084240
+Shell Sort,500,311,0.00091960
+Shell Sort,500,312,0.00092850
+Shell Sort,500,313,0.00077470
+Shell Sort,500,314,0.00078720
+Shell Sort,500,315,0.00096940
+Shell Sort,500,316,0.00087430
+Shell Sort,500,317,0.00095940
+Shell Sort,500,318,0.00079000
+Shell Sort,500,319,0.00061670
+Shell Sort,500,320,0.00059700
+Shell Sort,500,321,0.00098820
+Shell Sort,500,322,0.00054640
+Shell Sort,500,323,0.00062980
+Shell Sort,500,324,0.00051830
+Shell Sort,500,325,0.00093420
+Shell Sort,500,326,0.00087250
+Shell Sort,500,327,0.00057940
+Shell Sort,500,328,0.00053990
+Shell Sort,500,329,0.00055690
+Shell Sort,500,330,0.00093340
+Shell Sort,500,331,0.00058820
+Shell Sort,500,332,0.00090530
+Shell Sort,500,333,0.00055820
+Shell Sort,500,334,0.00062690
+Shell Sort,500,335,0.00053990
+Shell Sort,500,336,0.00064850
+Shell Sort,500,337,0.00059090
+Shell Sort,500,338,0.00085250
+Shell Sort,500,339,0.00066760
+Shell Sort,500,340,0.00052560
+Shell Sort,500,341,0.00067730
+Shell Sort,500,342,0.00055330
+Shell Sort,500,343,0.00095350
+Shell Sort,500,344,0.00058860
+Shell Sort,500,345,0.00085430
+Shell Sort,500,346,0.00080660
+Shell Sort,500,347,0.00054420
+Shell Sort,500,348,0.00055220
+Shell Sort,500,349,0.00060880
+Shell Sort,500,350,0.00064370
+Shell Sort,500,351,0.00058980
+Shell Sort,500,352,0.00092280
+Shell Sort,500,353,0.00091490
+Shell Sort,500,354,0.00075030
+Shell Sort,500,355,0.00062100
+Shell Sort,500,356,0.00067580
+Shell Sort,500,357,0.00062020
+Shell Sort,500,358,0.00093990
+Shell Sort,500,359,0.00064430
+Shell Sort,500,360,0.00077570
+Shell Sort,500,361,0.00094340
+Shell Sort,500,362,0.00094870
+Shell Sort,500,363,0.00075680
+Shell Sort,500,364,0.00081040
+Shell Sort,500,365,0.00060080
+Shell Sort,500,366,0.00077790
+Shell Sort,500,367,0.00096260
+Shell Sort,500,368,0.00063930
+Shell Sort,500,369,0.00060350
+Shell Sort,500,370,0.00085470
+Shell Sort,500,371,0.00097590
+Shell Sort,500,372,0.00088140
+Shell Sort,500,373,0.00076000
+Shell Sort,500,374,0.00073610
+Shell Sort,500,375,0.00079550
+Shell Sort,500,376,0.00073080
+Shell Sort,500,377,0.00066190
+Shell Sort,500,378,0.00090120
+Shell Sort,500,379,0.00051720
+Shell Sort,500,380,0.00077790
+Shell Sort,500,381,0.00053400
+Shell Sort,500,382,0.00062070
+Shell Sort,500,383,0.00061310
+Shell Sort,500,384,0.00060850
+Shell Sort,500,385,0.00088910
+Shell Sort,500,386,0.00062480
+Shell Sort,500,387,0.00059490
+Shell Sort,500,388,0.00054330
+Shell Sort,500,389,0.00055250
+Shell Sort,500,390,0.00057780
+Shell Sort,500,391,0.00078090
+Shell Sort,500,392,0.00077860
+Shell Sort,500,393,0.00065950
+Shell Sort,500,394,0.00061710
+Shell Sort,500,395,0.00055050
+Shell Sort,500,396,0.00059730
+Shell Sort,500,397,0.00053970
+Shell Sort,500,398,0.00077770
+Shell Sort,500,399,0.00073770
+Shell Sort,500,400,0.00072870
+Shell Sort,500,401,0.00066480
+Shell Sort,500,402,0.00058740
+Shell Sort,500,403,0.00091680
+Shell Sort,500,404,0.00084910
+Shell Sort,500,405,0.00066690
+Shell Sort,500,406,0.00062700
+Shell Sort,500,407,0.00086180
+Shell Sort,500,408,0.00062060
+Shell Sort,500,409,0.00075280
+Shell Sort,500,410,0.00084540
+Shell Sort,500,411,0.00081220
+Shell Sort,500,412,0.00051830
+Shell Sort,500,413,0.00063460
+Shell Sort,500,414,0.00055750
+Shell Sort,500,415,0.00058050
+Shell Sort,500,416,0.00052970
+Shell Sort,500,417,0.00059930
+Shell Sort,500,418,0.00097490
+Shell Sort,500,419,0.00081620
+Shell Sort,500,420,0.00071860
+Shell Sort,500,421,0.00068250
+Shell Sort,500,422,0.00057260
+Shell Sort,500,423,0.00056840
+Shell Sort,500,424,0.00077280
+Shell Sort,500,425,0.00067390
+Shell Sort,500,426,0.00065960
+Shell Sort,500,427,0.00075580
+Shell Sort,500,428,0.00091170
+Shell Sort,500,429,0.00082920
+Shell Sort,500,430,0.00069850
+Shell Sort,500,431,0.00063340
+Shell Sort,500,432,0.00059930
+Shell Sort,500,433,0.00085370
+Shell Sort,500,434,0.00066720
+Shell Sort,500,435,0.00086020
+Shell Sort,500,436,0.00085130
+Shell Sort,500,437,0.00092570
+Shell Sort,500,438,0.00084940
+Shell Sort,500,439,0.00088900
+Shell Sort,500,440,0.00074410
+Shell Sort,500,441,0.00081990
+Shell Sort,500,442,0.00091980
+Shell Sort,500,443,0.00064650
+Shell Sort,500,444,0.00065200
+Shell Sort,500,445,0.00056050
+Shell Sort,500,446,0.00053610
+Shell Sort,500,447,0.00090870
+Shell Sort,500,448,0.00058350
+Shell Sort,500,449,0.00095640
+Shell Sort,500,450,0.00055280
+Shell Sort,500,451,0.00070930
+Shell Sort,500,452,0.00051660
+Shell Sort,500,453,0.00056600
+Shell Sort,500,454,0.00087200
+Shell Sort,500,455,0.00059340
+Shell Sort,500,456,0.00059680
+Shell Sort,500,457,0.00090860
+Shell Sort,500,458,0.00057520
+Shell Sort,500,459,0.00068690
+Shell Sort,500,460,0.00069910
+Shell Sort,500,461,0.00060260
+Shell Sort,500,462,0.00063590
+Shell Sort,500,463,0.00051450
+Shell Sort,500,464,0.00089500
+Shell Sort,500,465,0.00065630
+Shell Sort,500,466,0.00053040
+Shell Sort,500,467,0.00067790
+Shell Sort,500,468,0.00059170
+Shell Sort,500,469,0.00060840
+Shell Sort,500,470,0.00052290
+Shell Sort,500,471,0.00059810
+Shell Sort,500,472,0.00052390
+Shell Sort,500,473,0.00101370
+Shell Sort,500,474,0.00052290
+Shell Sort,500,475,0.00054760
+Shell Sort,500,476,0.00060130
+Shell Sort,500,477,0.00086570
+Shell Sort,500,478,0.00061060
+Shell Sort,500,479,0.00090480
+Shell Sort,500,480,0.00088140
+Shell Sort,500,481,0.00081180
+Shell Sort,500,482,0.00093730
+Shell Sort,500,483,0.00092700
+Shell Sort,500,484,0.00061360
+Shell Sort,500,485,0.00115930
+Shell Sort,500,486,0.00094450
+Shell Sort,500,487,0.00066460
+Shell Sort,500,488,0.00090760
+Shell Sort,500,489,0.00066400
+Shell Sort,500,490,0.00054370
+Shell Sort,500,491,0.00058430
+Shell Sort,500,492,0.00090470
+Shell Sort,500,493,0.00068190
+Shell Sort,500,494,0.00090850
+Shell Sort,500,495,0.00096710
+Shell Sort,500,496,0.00080560
+Shell Sort,500,497,0.00058120
+Shell Sort,500,498,0.00090780
+Shell Sort,500,499,0.00063330
+Shell Sort,500,500,0.00054220
+Sleep Sort,500,1,2.07888220
+Sleep Sort,500,2,2.06602880
+Sleep Sort,500,3,2.06124420
+Sleep Sort,500,4,2.04779020
+Sleep Sort,500,5,2.08920050
+Sleep Sort,500,6,2.04854110
+Sleep Sort,500,7,2.07386230
+Sleep Sort,500,8,2.05170720
+Sleep Sort,500,9,2.05926110
+Sleep Sort,500,10,2.04811430
+Sleep Sort,500,11,2.04857450
+Sleep Sort,500,12,2.03757120
+Sleep Sort,500,13,2.08306090
+Sleep Sort,500,14,2.07373950
+Sleep Sort,500,15,2.06929760
+Sleep Sort,500,16,2.05879640
+Sleep Sort,500,17,2.03618940
+Sleep Sort,500,18,2.06636800
+Sleep Sort,500,19,2.07094390
+Sleep Sort,500,20,2.05012170
+Sleep Sort,500,21,2.07107960
+Sleep Sort,500,22,2.04607080
+Sleep Sort,500,23,2.04822890
+Sleep Sort,500,24,2.06601150
+Sleep Sort,500,25,2.02171650
+Sleep Sort,500,26,2.03449380
+Sleep Sort,500,27,2.06379330
+Sleep Sort,500,28,2.07009580
+Sleep Sort,500,29,2.06573820
+Sleep Sort,500,30,2.06094020
+Sleep Sort,500,31,2.04830430
+Sleep Sort,500,32,2.06606770
+Sleep Sort,500,33,2.05628440
+Sleep Sort,500,34,2.06546270
+Sleep Sort,500,35,2.04157000
+Sleep Sort,500,36,2.04265230
+Sleep Sort,500,37,2.06722750
+Sleep Sort,500,38,2.05863560
+Sleep Sort,500,39,2.06301110
+Sleep Sort,500,40,2.06855310
+Sleep Sort,500,41,2.05307340
+Sleep Sort,500,42,2.05405660
+Sleep Sort,500,43,2.06026780
+Sleep Sort,500,44,2.05586130
+Sleep Sort,500,45,2.03907620
+Sleep Sort,500,46,2.04637180
+Sleep Sort,500,47,2.05124290
+Sleep Sort,500,48,2.04998130
+Sleep Sort,500,49,2.04949990
+Sleep Sort,500,50,2.06311440
+Sleep Sort,500,51,2.03570850
+Sleep Sort,500,52,2.07363560
+Sleep Sort,500,53,2.06167310
+Sleep Sort,500,54,2.06645210
+Sleep Sort,500,55,2.06473890
+Sleep Sort,500,56,2.06345100
+Sleep Sort,500,57,2.05103230
+Sleep Sort,500,58,2.05422510
+Sleep Sort,500,59,2.06051770
+Sleep Sort,500,60,2.04960330
+Sleep Sort,500,61,2.06385460
+Sleep Sort,500,62,2.04318670
+Sleep Sort,500,63,2.04500670
+Sleep Sort,500,64,2.04507090
+Sleep Sort,500,65,2.05121740
+Sleep Sort,500,66,2.05929380
+Sleep Sort,500,67,2.05410370
+Sleep Sort,500,68,2.05904760
+Sleep Sort,500,69,2.07147050
+Sleep Sort,500,70,2.05811620
+Sleep Sort,500,71,2.04349940
+Sleep Sort,500,72,2.05430760
+Sleep Sort,500,73,2.04047440
+Sleep Sort,500,74,2.05959760
+Sleep Sort,500,75,2.05500250
+Sleep Sort,500,76,2.06278310
+Sleep Sort,500,77,2.05536100
+Sleep Sort,500,78,2.05510660
+Sleep Sort,500,79,2.05043500
+Sleep Sort,500,80,2.07175020
+Sleep Sort,500,81,2.04215900
+Sleep Sort,500,82,2.06288800
+Sleep Sort,500,83,2.05062220
+Sleep Sort,500,84,2.06067400
+Sleep Sort,500,85,2.05743870
+Sleep Sort,500,86,2.04607880
+Sleep Sort,500,87,2.05142160
+Sleep Sort,500,88,2.04535490
+Sleep Sort,500,89,2.06509160
+Sleep Sort,500,90,2.02549630
+Sleep Sort,500,91,2.04630570
+Sleep Sort,500,92,2.05556490
+Sleep Sort,500,93,2.06646880
+Sleep Sort,500,94,2.05991090
+Sleep Sort,500,95,2.06563220
+Sleep Sort,500,96,2.06341020
+Sleep Sort,500,97,2.04578450
+Sleep Sort,500,98,2.06235900
+Sleep Sort,500,99,2.06790980
+Sleep Sort,500,100,2.05687370
+Sleep Sort,500,101,2.07659620
+Sleep Sort,500,102,2.06434690
+Sleep Sort,500,103,2.06151300
+Sleep Sort,500,104,2.03650970
+Sleep Sort,500,105,2.07325040
+Sleep Sort,500,106,2.05425230
+Sleep Sort,500,107,2.04859170
+Sleep Sort,500,108,2.02998550
+Sleep Sort,500,109,2.07073830
+Sleep Sort,500,110,2.03782520
+Sleep Sort,500,111,2.05025460
+Sleep Sort,500,112,2.06149530
+Sleep Sort,500,113,2.05840890
+Sleep Sort,500,114,2.03819600
+Sleep Sort,500,115,2.04316110
+Sleep Sort,500,116,2.05475280
+Sleep Sort,500,117,2.05970790
+Sleep Sort,500,118,2.04087250
+Sleep Sort,500,119,2.06498870
+Sleep Sort,500,120,2.06138410
+Sleep Sort,500,121,2.06172970
+Sleep Sort,500,122,2.06337240
+Sleep Sort,500,123,2.02525710
+Sleep Sort,500,124,2.04403220
+Sleep Sort,500,125,2.05928900
+Sleep Sort,500,126,2.06713640
+Sleep Sort,500,127,2.04677190
+Sleep Sort,500,128,2.06029470
+Sleep Sort,500,129,2.05181440
+Sleep Sort,500,130,2.06634660
+Sleep Sort,500,131,2.05644910
+Sleep Sort,500,132,2.05031910
+Sleep Sort,500,133,2.05707280
+Sleep Sort,500,134,2.06345340
+Sleep Sort,500,135,2.06406690
+Sleep Sort,500,136,2.04376450
+Sleep Sort,500,137,2.04662300
+Sleep Sort,500,138,2.03960490
+Sleep Sort,500,139,2.04879290
+Sleep Sort,500,140,2.01778220
+Sleep Sort,500,141,2.05955990
+Sleep Sort,500,142,2.06297700
+Sleep Sort,500,143,2.04488950
+Sleep Sort,500,144,2.06533340
+Sleep Sort,500,145,2.06264630
+Sleep Sort,500,146,2.06380780
+Sleep Sort,500,147,2.04856160
+Sleep Sort,500,148,2.05150010
+Sleep Sort,500,149,2.02312280
+Sleep Sort,500,150,2.05628320
+Sleep Sort,500,151,2.06781850
+Sleep Sort,500,152,2.08001670
+Sleep Sort,500,153,2.06012590
+Sleep Sort,500,154,2.05659720
+Sleep Sort,500,155,2.05145960
+Sleep Sort,500,156,2.06456530
+Sleep Sort,500,157,2.05285550
+Sleep Sort,500,158,2.06859000
+Sleep Sort,500,159,2.05326380
+Sleep Sort,500,160,2.05575290
+Sleep Sort,500,161,2.03034830
+Sleep Sort,500,162,2.04964300
+Sleep Sort,500,163,2.03904140
+Sleep Sort,500,164,2.05574060
+Sleep Sort,500,165,2.05901500
+Sleep Sort,500,166,2.04775060
+Sleep Sort,500,167,2.06725480
+Sleep Sort,500,168,2.04488760
+Sleep Sort,500,169,2.02424510
+Sleep Sort,500,170,2.03992830
+Sleep Sort,500,171,2.06582030
+Sleep Sort,500,172,2.03760990
+Sleep Sort,500,173,2.06330560
+Sleep Sort,500,174,2.05536110
+Sleep Sort,500,175,2.07121290
+Sleep Sort,500,176,2.07496420
+Sleep Sort,500,177,2.04708510
+Sleep Sort,500,178,2.03850030
+Sleep Sort,500,179,2.04946870
+Sleep Sort,500,180,2.06268590
+Sleep Sort,500,181,2.05161030
+Sleep Sort,500,182,2.05752540
+Sleep Sort,500,183,2.04476220
+Sleep Sort,500,184,2.06531960
+Sleep Sort,500,185,2.04838190
+Sleep Sort,500,186,2.04114820
+Sleep Sort,500,187,2.04816590
+Sleep Sort,500,188,2.05763430
+Sleep Sort,500,189,2.06337700
+Sleep Sort,500,190,2.05695560
+Sleep Sort,500,191,2.02896390
+Sleep Sort,500,192,2.05319930
+Sleep Sort,500,193,2.02315230
+Sleep Sort,500,194,2.05397530
+Sleep Sort,500,195,2.03754320
+Sleep Sort,500,196,2.03699390
+Sleep Sort,500,197,2.06638980
+Sleep Sort,500,198,2.02593560
+Sleep Sort,500,199,2.04514820
+Sleep Sort,500,200,2.05352820
+Sleep Sort,500,201,2.03845130
+Sleep Sort,500,202,2.04204740
+Sleep Sort,500,203,2.04734790
+Sleep Sort,500,204,2.05408960
+Sleep Sort,500,205,2.02249150
+Sleep Sort,500,206,2.06082300
+Sleep Sort,500,207,2.04059130
+Sleep Sort,500,208,2.06002870
+Sleep Sort,500,209,2.06219630
+Sleep Sort,500,210,2.06300950
+Sleep Sort,500,211,2.04800160
+Sleep Sort,500,212,2.05227890
+Sleep Sort,500,213,2.03649170
+Sleep Sort,500,214,2.06606440
+Sleep Sort,500,215,2.05031050
+Sleep Sort,500,216,2.05971690
+Sleep Sort,500,217,2.06866370
+Sleep Sort,500,218,2.04458810
+Sleep Sort,500,219,2.04175420
+Sleep Sort,500,220,2.04806030
+Sleep Sort,500,221,2.05392100
+Sleep Sort,500,222,2.06511500
+Sleep Sort,500,223,2.05610420
+Sleep Sort,500,224,2.06590080
+Sleep Sort,500,225,2.05451810
+Sleep Sort,500,226,2.03574400
+Sleep Sort,500,227,2.06483660
+Sleep Sort,500,228,2.04067210
+Sleep Sort,500,229,2.04601080
+Sleep Sort,500,230,2.07177240
+Sleep Sort,500,231,2.06896700
+Sleep Sort,500,232,2.05160750
+Sleep Sort,500,233,2.03247550
+Sleep Sort,500,234,2.03860880
+Sleep Sort,500,235,2.05811380
+Sleep Sort,500,236,2.04596870
+Sleep Sort,500,237,2.06530380
+Sleep Sort,500,238,2.05105740
+Sleep Sort,500,239,2.05237340
+Sleep Sort,500,240,2.06128590
+Sleep Sort,500,241,2.04956800
+Sleep Sort,500,242,2.06201790
+Sleep Sort,500,243,2.04238340
+Sleep Sort,500,244,2.05375000
+Sleep Sort,500,245,2.06410290
+Sleep Sort,500,246,2.06429470
+Sleep Sort,500,247,2.05453750
+Sleep Sort,500,248,2.06343230
+Sleep Sort,500,249,2.07292680
+Sleep Sort,500,250,2.06128950
+Sleep Sort,500,251,2.04583630
+Sleep Sort,500,252,2.02260090
+Sleep Sort,500,253,2.05588380
+Sleep Sort,500,254,2.06164650
+Sleep Sort,500,255,2.04309770
+Sleep Sort,500,256,2.03831170
+Sleep Sort,500,257,2.05917960
+Sleep Sort,500,258,2.06456050
+Sleep Sort,500,259,2.06843170
+Sleep Sort,500,260,2.05800850
+Sleep Sort,500,261,2.03037100
+Sleep Sort,500,262,2.05626710
+Sleep Sort,500,263,2.07083410
+Sleep Sort,500,264,2.06945290
+Sleep Sort,500,265,2.05622720
+Sleep Sort,500,266,2.05363460
+Sleep Sort,500,267,2.05529200
+Sleep Sort,500,268,2.05701840
+Sleep Sort,500,269,2.04238610
+Sleep Sort,500,270,2.04094680
+Sleep Sort,500,271,2.05185100
+Sleep Sort,500,272,2.06467680
+Sleep Sort,500,273,2.06505470
+Sleep Sort,500,274,2.06961890
+Sleep Sort,500,275,2.04553500
+Sleep Sort,500,276,2.04409730
+Sleep Sort,500,277,2.06243170
+Sleep Sort,500,278,2.03069700
+Sleep Sort,500,279,2.03889530
+Sleep Sort,500,280,2.04180510
+Sleep Sort,500,281,2.03482770
+Sleep Sort,500,282,2.05449780
+Sleep Sort,500,283,2.04518980
+Sleep Sort,500,284,2.05550650
+Sleep Sort,500,285,2.06337390
+Sleep Sort,500,286,2.07073530
+Sleep Sort,500,287,2.03457160
+Sleep Sort,500,288,2.05729750
+Sleep Sort,500,289,2.06238650
+Sleep Sort,500,290,2.05783060
+Sleep Sort,500,291,2.06403440
+Sleep Sort,500,292,2.03560280
+Sleep Sort,500,293,2.04358880
+Sleep Sort,500,294,2.06368970
+Sleep Sort,500,295,2.06546630
+Sleep Sort,500,296,2.06573790
+Sleep Sort,500,297,2.05857210
+Sleep Sort,500,298,2.06608480
+Sleep Sort,500,299,2.05421370
+Sleep Sort,500,300,2.04646940
+Sleep Sort,500,301,2.06056650
+Sleep Sort,500,302,2.01900100
+Sleep Sort,500,303,2.04916880
+Sleep Sort,500,304,2.06239360
+Sleep Sort,500,305,2.04976430
+Sleep Sort,500,306,2.07095090
+Sleep Sort,500,307,2.07243080
+Sleep Sort,500,308,2.05627640
+Sleep Sort,500,309,2.04014120
+Sleep Sort,500,310,2.03045840
+Sleep Sort,500,311,2.05370430
+Sleep Sort,500,312,2.04801720
+Sleep Sort,500,313,2.04427490
+Sleep Sort,500,314,2.06362500
+Sleep Sort,500,315,2.04387780
+Sleep Sort,500,316,2.05551730
+Sleep Sort,500,317,2.03757380
+Sleep Sort,500,318,2.06840410
+Sleep Sort,500,319,2.06071220
+Sleep Sort,500,320,2.04119450
+Sleep Sort,500,321,2.05246740
+Sleep Sort,500,322,2.06135470
+Sleep Sort,500,323,2.03824470
+Sleep Sort,500,324,2.05493510
+Sleep Sort,500,325,2.04330410
+Sleep Sort,500,326,2.03917060
+Sleep Sort,500,327,2.00287360
+Sleep Sort,500,328,2.04542450
+Sleep Sort,500,329,2.05695960
+Sleep Sort,500,330,2.04294210
+Sleep Sort,500,331,2.04637800
+Sleep Sort,500,332,2.07053630
+Sleep Sort,500,333,2.05424660
+Sleep Sort,500,334,2.05278090
+Sleep Sort,500,335,2.06404450
+Sleep Sort,500,336,2.07151050
+Sleep Sort,500,337,2.06441670
+Sleep Sort,500,338,2.06676340
+Sleep Sort,500,339,2.04572030
+Sleep Sort,500,340,2.01593320
+Sleep Sort,500,341,2.03921920
+Sleep Sort,500,342,2.06417620
+Sleep Sort,500,343,2.04338590
+Sleep Sort,500,344,2.05213790
+Sleep Sort,500,345,2.05322970
+Sleep Sort,500,346,2.05790050
+Sleep Sort,500,347,2.06677730
+Sleep Sort,500,348,2.05379770
+Sleep Sort,500,349,2.04790930
+Sleep Sort,500,350,2.06461600
+Sleep Sort,500,351,2.03251430
+Sleep Sort,500,352,2.05718920
+Sleep Sort,500,353,2.05946230
+Sleep Sort,500,354,2.04439490
+Sleep Sort,500,355,2.05027570
+Sleep Sort,500,356,2.06071900
+Sleep Sort,500,357,2.06657030
+Sleep Sort,500,358,2.06203210
+Sleep Sort,500,359,2.04403530
+Sleep Sort,500,360,2.06678710
+Sleep Sort,500,361,2.05342850
+Sleep Sort,500,362,2.05630720
+Sleep Sort,500,363,2.05644960
+Sleep Sort,500,364,2.06169120
+Sleep Sort,500,365,2.04615750
+Sleep Sort,500,366,2.04342440
+Sleep Sort,500,367,2.04065180
+Sleep Sort,500,368,2.05618340
+Sleep Sort,500,369,2.04396420
+Sleep Sort,500,370,2.05168270
+Sleep Sort,500,371,2.05245890
+Sleep Sort,500,372,2.04248440
+Sleep Sort,500,373,2.04991710
+Sleep Sort,500,374,2.05308000
+Sleep Sort,500,375,2.05764050
+Sleep Sort,500,376,2.03079240
+Sleep Sort,500,377,2.03327760
+Sleep Sort,500,378,2.04221740
+Sleep Sort,500,379,2.05336880
+Sleep Sort,500,380,2.06141000
+Sleep Sort,500,381,2.02143760
+Sleep Sort,500,382,2.05744000
+Sleep Sort,500,383,2.05632050
+Sleep Sort,500,384,2.05392010
+Sleep Sort,500,385,2.02077830
+Sleep Sort,500,386,2.05599560
+Sleep Sort,500,387,2.03944930
+Sleep Sort,500,388,2.07420270
+Sleep Sort,500,389,2.04009740
+Sleep Sort,500,390,2.05254880
+Sleep Sort,500,391,2.05388780
+Sleep Sort,500,392,2.04070380
+Sleep Sort,500,393,2.05654190
+Sleep Sort,500,394,2.06249760
+Sleep Sort,500,395,2.04608940
+Sleep Sort,500,396,2.03957840
+Sleep Sort,500,397,2.07079890
+Sleep Sort,500,398,2.05956840
+Sleep Sort,500,399,2.01761820
+Sleep Sort,500,400,2.05261930
+Sleep Sort,500,401,2.04470520
+Sleep Sort,500,402,2.04730470
+Sleep Sort,500,403,2.06371840
+Sleep Sort,500,404,2.06389920
+Sleep Sort,500,405,2.06189290
+Sleep Sort,500,406,2.04646840
+Sleep Sort,500,407,2.04699580
+Sleep Sort,500,408,2.04911700
+Sleep Sort,500,409,2.04969610
+Sleep Sort,500,410,2.07188850
+Sleep Sort,500,411,2.07122090
+Sleep Sort,500,412,2.07072620
+Sleep Sort,500,413,2.03543840
+Sleep Sort,500,414,2.05526450
+Sleep Sort,500,415,2.05958600
+Sleep Sort,500,416,2.03783400
+Sleep Sort,500,417,2.01670390
+Sleep Sort,500,418,2.05498540
+Sleep Sort,500,419,2.03067770
+Sleep Sort,500,420,2.06017870
+Sleep Sort,500,421,2.03691130
+Sleep Sort,500,422,2.05938890
+Sleep Sort,500,423,2.05444100
+Sleep Sort,500,424,2.04325000
+Sleep Sort,500,425,2.04448130
+Sleep Sort,500,426,2.05041340
+Sleep Sort,500,427,2.05817930
+Sleep Sort,500,428,2.05029170
+Sleep Sort,500,429,2.04706250
+Sleep Sort,500,430,2.05302840
+Sleep Sort,500,431,2.06308370
+Sleep Sort,500,432,2.03384750
+Sleep Sort,500,433,2.04211400
+Sleep Sort,500,434,2.04742630
+Sleep Sort,500,435,2.05136090
+Sleep Sort,500,436,2.06198900
+Sleep Sort,500,437,2.04508880
+Sleep Sort,500,438,2.02637360
+Sleep Sort,500,439,2.05430320
+Sleep Sort,500,440,2.04259100
+Sleep Sort,500,441,2.04782200
+Sleep Sort,500,442,2.05110370
+Sleep Sort,500,443,2.06771280
+Sleep Sort,500,444,2.02347370
+Sleep Sort,500,445,2.05538960
+Sleep Sort,500,446,2.06207060
+Sleep Sort,500,447,2.05843040
+Sleep Sort,500,448,2.03863770
+Sleep Sort,500,449,2.05050980
+Sleep Sort,500,450,2.03790530
+Sleep Sort,500,451,2.05787590
+Sleep Sort,500,452,2.05528950
+Sleep Sort,500,453,2.04901240
+Sleep Sort,500,454,2.05247230
+Sleep Sort,500,455,2.05103200
+Sleep Sort,500,456,2.03604250
+Sleep Sort,500,457,2.05881150
+Sleep Sort,500,458,2.06188350
+Sleep Sort,500,459,2.06623160
+Sleep Sort,500,460,2.02561650
+Sleep Sort,500,461,2.06360830
+Sleep Sort,500,462,2.03377600
+Sleep Sort,500,463,2.06381860
+Sleep Sort,500,464,2.02378510
+Sleep Sort,500,465,2.02404220
+Sleep Sort,500,466,2.04824030
+Sleep Sort,500,467,2.04941810
+Sleep Sort,500,468,2.06027660
+Sleep Sort,500,469,2.04375590
+Sleep Sort,500,470,2.04806700
+Sleep Sort,500,471,2.06978300
+Sleep Sort,500,472,2.06474800
+Sleep Sort,500,473,2.06074010
+Sleep Sort,500,474,2.05711160
+Sleep Sort,500,475,2.04715520
+Sleep Sort,500,476,2.01978180
+Sleep Sort,500,477,2.06649720
+Sleep Sort,500,478,2.04363660
+Sleep Sort,500,479,2.04779930
+Sleep Sort,500,480,2.05676330
+Sleep Sort,500,481,2.05722830
+Sleep Sort,500,482,2.02344750
+Sleep Sort,500,483,2.04725700
+Sleep Sort,500,484,2.06709620
+Sleep Sort,500,485,2.06130730
+Sleep Sort,500,486,2.06087650
+Sleep Sort,500,487,2.02882880
+Sleep Sort,500,488,2.03785120
+Sleep Sort,500,489,2.06301320
+Sleep Sort,500,490,2.04706150
+Sleep Sort,500,491,2.06170960
+Sleep Sort,500,492,2.06898710
+Sleep Sort,500,493,2.03933450
+Sleep Sort,500,494,2.06337790
+Sleep Sort,500,495,2.05608910
+Sleep Sort,500,496,2.06537070
+Sleep Sort,500,497,2.06388800
+Sleep Sort,500,498,2.11392390
+Sleep Sort,500,499,2.11816300
+Sleep Sort,500,500,2.09681120
+Smooth Sort,500,1,0.02595430
+Smooth Sort,500,2,0.02310160
+Smooth Sort,500,3,0.02452670
+Smooth Sort,500,4,0.02107020
+Smooth Sort,500,5,0.01999450
+Smooth Sort,500,6,0.01941440
+Smooth Sort,500,7,0.01793230
+Smooth Sort,500,8,0.01773680
+Smooth Sort,500,9,0.01738380
+Smooth Sort,500,10,0.01565580
+Smooth Sort,500,11,0.01667060
+Smooth Sort,500,12,0.01732870
+Smooth Sort,500,13,0.02080010
+Smooth Sort,500,14,0.01909770
+Smooth Sort,500,15,0.01885290
+Smooth Sort,500,16,0.01693380
+Smooth Sort,500,17,0.02106700
+Smooth Sort,500,18,0.01646860
+Smooth Sort,500,19,0.01881100
+Smooth Sort,500,20,0.02159370
+Smooth Sort,500,21,0.02311060
+Smooth Sort,500,22,0.02088190
+Smooth Sort,500,23,0.01754090
+Smooth Sort,500,24,0.01939280
+Smooth Sort,500,25,0.01725330
+Smooth Sort,500,26,0.01570150
+Smooth Sort,500,27,0.01705450
+Smooth Sort,500,28,0.01608350
+Smooth Sort,500,29,0.01541270
+Smooth Sort,500,30,0.01513150
+Smooth Sort,500,31,0.01676310
+Smooth Sort,500,32,0.01588380
+Smooth Sort,500,33,0.01849400
+Smooth Sort,500,34,0.01937970
+Smooth Sort,500,35,0.01915380
+Smooth Sort,500,36,0.01644560
+Smooth Sort,500,37,0.01703860
+Smooth Sort,500,38,0.01588840
+Smooth Sort,500,39,0.01654840
+Smooth Sort,500,40,0.01990600
+Smooth Sort,500,41,0.01894940
+Smooth Sort,500,42,0.01652700
+Smooth Sort,500,43,0.01742030
+Smooth Sort,500,44,0.01774290
+Smooth Sort,500,45,0.01925610
+Smooth Sort,500,46,0.01573130
+Smooth Sort,500,47,0.01591870
+Smooth Sort,500,48,0.02138150
+Smooth Sort,500,49,0.02138930
+Smooth Sort,500,50,0.01792020
+Smooth Sort,500,51,0.02217190
+Smooth Sort,500,52,0.02034050
+Smooth Sort,500,53,0.01811870
+Smooth Sort,500,54,0.02198350
+Smooth Sort,500,55,0.01846360
+Smooth Sort,500,56,0.01684610
+Smooth Sort,500,57,0.01609220
+Smooth Sort,500,58,0.01640330
+Smooth Sort,500,59,0.01795110
+Smooth Sort,500,60,0.02035550
+Smooth Sort,500,61,0.01684150
+Smooth Sort,500,62,0.01760430
+Smooth Sort,500,63,0.01775320
+Smooth Sort,500,64,0.02174830
+Smooth Sort,500,65,0.01847850
+Smooth Sort,500,66,0.01611370
+Smooth Sort,500,67,0.01868710
+Smooth Sort,500,68,0.01956470
+Smooth Sort,500,69,0.01820850
+Smooth Sort,500,70,0.01800970
+Smooth Sort,500,71,0.01681410
+Smooth Sort,500,72,0.01648280
+Smooth Sort,500,73,0.01945300
+Smooth Sort,500,74,0.01982030
+Smooth Sort,500,75,0.01829740
+Smooth Sort,500,76,0.01491790
+Smooth Sort,500,77,0.01560340
+Smooth Sort,500,78,0.01691440
+Smooth Sort,500,79,0.01652050
+Smooth Sort,500,80,0.01500320
+Smooth Sort,500,81,0.01731810
+Smooth Sort,500,82,0.01607310
+Smooth Sort,500,83,0.01557970
+Smooth Sort,500,84,0.01619560
+Smooth Sort,500,85,0.02063180
+Smooth Sort,500,86,0.02376510
+Smooth Sort,500,87,0.01615890
+Smooth Sort,500,88,0.01754010
+Smooth Sort,500,89,0.01622060
+Smooth Sort,500,90,0.01898390
+Smooth Sort,500,91,0.02391070
+Smooth Sort,500,92,0.02240600
+Smooth Sort,500,93,0.02274850
+Smooth Sort,500,94,0.02097030
+Smooth Sort,500,95,0.01826130
+Smooth Sort,500,96,0.01670600
+Smooth Sort,500,97,0.01733730
+Smooth Sort,500,98,0.01954680
+Smooth Sort,500,99,0.01721370
+Smooth Sort,500,100,0.01940660
+Smooth Sort,500,101,0.01660070
+Smooth Sort,500,102,0.01848040
+Smooth Sort,500,103,0.01699380
+Smooth Sort,500,104,0.01769490
+Smooth Sort,500,105,0.01930060
+Smooth Sort,500,106,0.02125980
+Smooth Sort,500,107,0.01614370
+Smooth Sort,500,108,0.01834620
+Smooth Sort,500,109,0.02292530
+Smooth Sort,500,110,0.02109640
+Smooth Sort,500,111,0.02138180
+Smooth Sort,500,112,0.02259830
+Smooth Sort,500,113,0.01702170
+Smooth Sort,500,114,0.01977570
+Smooth Sort,500,115,0.01946960
+Smooth Sort,500,116,0.01862020
+Smooth Sort,500,117,0.01902730
+Smooth Sort,500,118,0.01812490
+Smooth Sort,500,119,0.01928940
+Smooth Sort,500,120,0.01808730
+Smooth Sort,500,121,0.02129800
+Smooth Sort,500,122,0.01866990
+Smooth Sort,500,123,0.02035910
+Smooth Sort,500,124,0.01719160
+Smooth Sort,500,125,0.02054410
+Smooth Sort,500,126,0.02069740
+Smooth Sort,500,127,0.02140820
+Smooth Sort,500,128,0.02290600
+Smooth Sort,500,129,0.01573600
+Smooth Sort,500,130,0.01673990
+Smooth Sort,500,131,0.02041150
+Smooth Sort,500,132,0.01895220
+Smooth Sort,500,133,0.02465240
+Smooth Sort,500,134,0.01566050
+Smooth Sort,500,135,0.02106050
+Smooth Sort,500,136,0.02287720
+Smooth Sort,500,137,0.01837140
+Smooth Sort,500,138,0.02024210
+Smooth Sort,500,139,0.01857000
+Smooth Sort,500,140,0.02123240
+Smooth Sort,500,141,0.02010930
+Smooth Sort,500,142,0.02027540
+Smooth Sort,500,143,0.02065090
+Smooth Sort,500,144,0.02214520
+Smooth Sort,500,145,0.02076850
+Smooth Sort,500,146,0.02230030
+Smooth Sort,500,147,0.02387100
+Smooth Sort,500,148,0.01965580
+Smooth Sort,500,149,0.02151630
+Smooth Sort,500,150,0.01969160
+Smooth Sort,500,151,0.01850720
+Smooth Sort,500,152,0.02302450
+Smooth Sort,500,153,0.01907270
+Smooth Sort,500,154,0.01690960
+Smooth Sort,500,155,0.02141520
+Smooth Sort,500,156,0.01836940
+Smooth Sort,500,157,0.01785260
+Smooth Sort,500,158,0.02162100
+Smooth Sort,500,159,0.01785690
+Smooth Sort,500,160,0.01950610
+Smooth Sort,500,161,0.01890990
+Smooth Sort,500,162,0.01954800
+Smooth Sort,500,163,0.01925090
+Smooth Sort,500,164,0.01902870
+Smooth Sort,500,165,0.01809090
+Smooth Sort,500,166,0.01858950
+Smooth Sort,500,167,0.02204880
+Smooth Sort,500,168,0.02121250
+Smooth Sort,500,169,0.01743840
+Smooth Sort,500,170,0.02481680
+Smooth Sort,500,171,0.02863320
+Smooth Sort,500,172,0.02703980
+Smooth Sort,500,173,0.02749030
+Smooth Sort,500,174,0.02691190
+Smooth Sort,500,175,0.02597020
+Smooth Sort,500,176,0.02438470
+Smooth Sort,500,177,0.02434080
+Smooth Sort,500,178,0.02098990
+Smooth Sort,500,179,0.01891080
+Smooth Sort,500,180,0.01968780
+Smooth Sort,500,181,0.01923470
+Smooth Sort,500,182,0.01851280
+Smooth Sort,500,183,0.02338140
+Smooth Sort,500,184,0.02360390
+Smooth Sort,500,185,0.02274740
+Smooth Sort,500,186,0.02173520
+Smooth Sort,500,187,0.02258920
+Smooth Sort,500,188,0.02292620
+Smooth Sort,500,189,0.02031220
+Smooth Sort,500,190,0.02464050
+Smooth Sort,500,191,0.02078200
+Smooth Sort,500,192,0.02304690
+Smooth Sort,500,193,0.02159280
+Smooth Sort,500,194,0.02406770
+Smooth Sort,500,195,0.02315450
+Smooth Sort,500,196,0.02249280
+Smooth Sort,500,197,0.02293090
+Smooth Sort,500,198,0.02014330
+Smooth Sort,500,199,0.02140690
+Smooth Sort,500,200,0.01735490
+Smooth Sort,500,201,0.01765440
+Smooth Sort,500,202,0.01847150
+Smooth Sort,500,203,0.01577360
+Smooth Sort,500,204,0.01678920
+Smooth Sort,500,205,0.01852790
+Smooth Sort,500,206,0.01864740
+Smooth Sort,500,207,0.02124170
+Smooth Sort,500,208,0.02592550
+Smooth Sort,500,209,0.01665510
+Smooth Sort,500,210,0.01606490
+Smooth Sort,500,211,0.02316570
+Smooth Sort,500,212,0.01883530
+Smooth Sort,500,213,0.01693470
+Smooth Sort,500,214,0.02078420
+Smooth Sort,500,215,0.01784990
+Smooth Sort,500,216,0.01776750
+Smooth Sort,500,217,0.01818500
+Smooth Sort,500,218,0.02067800
+Smooth Sort,500,219,0.02140440
+Smooth Sort,500,220,0.01810630
+Smooth Sort,500,221,0.01956670
+Smooth Sort,500,222,0.01972050
+Smooth Sort,500,223,0.01580230
+Smooth Sort,500,224,0.01749500
+Smooth Sort,500,225,0.01585240
+Smooth Sort,500,226,0.01822810
+Smooth Sort,500,227,0.01944850
+Smooth Sort,500,228,0.01565120
+Smooth Sort,500,229,0.01676080
+Smooth Sort,500,230,0.01831950
+Smooth Sort,500,231,0.01628380
+Smooth Sort,500,232,0.01586260
+Smooth Sort,500,233,0.01563060
+Smooth Sort,500,234,0.01687060
+Smooth Sort,500,235,0.01659130
+Smooth Sort,500,236,0.02168270
+Smooth Sort,500,237,0.02199540
+Smooth Sort,500,238,0.01705880
+Smooth Sort,500,239,0.01750810
+Smooth Sort,500,240,0.01635440
+Smooth Sort,500,241,0.01720930
+Smooth Sort,500,242,0.01687480
+Smooth Sort,500,243,0.01827370
+Smooth Sort,500,244,0.01759620
+Smooth Sort,500,245,0.01948140
+Smooth Sort,500,246,0.01916520
+Smooth Sort,500,247,0.01783150
+Smooth Sort,500,248,0.02024240
+Smooth Sort,500,249,0.01699750
+Smooth Sort,500,250,0.01623180
+Smooth Sort,500,251,0.01987650
+Smooth Sort,500,252,0.01768920
+Smooth Sort,500,253,0.01771550
+Smooth Sort,500,254,0.01677780
+Smooth Sort,500,255,0.01834970
+Smooth Sort,500,256,0.01777420
+Smooth Sort,500,257,0.01880390
+Smooth Sort,500,258,0.01952660
+Smooth Sort,500,259,0.01654980
+Smooth Sort,500,260,0.01802490
+Smooth Sort,500,261,0.01589100
+Smooth Sort,500,262,0.01663670
+Smooth Sort,500,263,0.01594620
+Smooth Sort,500,264,0.01578940
+Smooth Sort,500,265,0.01795020
+Smooth Sort,500,266,0.01829060
+Smooth Sort,500,267,0.01734760
+Smooth Sort,500,268,0.01706590
+Smooth Sort,500,269,0.01647010
+Smooth Sort,500,270,0.02135400
+Smooth Sort,500,271,0.01938550
+Smooth Sort,500,272,0.01866410
+Smooth Sort,500,273,0.01669470
+Smooth Sort,500,274,0.01722190
+Smooth Sort,500,275,0.02051810
+Smooth Sort,500,276,0.01998020
+Smooth Sort,500,277,0.01890110
+Smooth Sort,500,278,0.02035790
+Smooth Sort,500,279,0.01958470
+Smooth Sort,500,280,0.01803800
+Smooth Sort,500,281,0.01645670
+Smooth Sort,500,282,0.01741270
+Smooth Sort,500,283,0.01700950
+Smooth Sort,500,284,0.01699550
+Smooth Sort,500,285,0.02204430
+Smooth Sort,500,286,0.02284020
+Smooth Sort,500,287,0.01940700
+Smooth Sort,500,288,0.01682380
+Smooth Sort,500,289,0.02160130
+Smooth Sort,500,290,0.01841090
+Smooth Sort,500,291,0.01822340
+Smooth Sort,500,292,0.01938100
+Smooth Sort,500,293,0.02023520
+Smooth Sort,500,294,0.02113930
+Smooth Sort,500,295,0.02160110
+Smooth Sort,500,296,0.02267650
+Smooth Sort,500,297,0.02088840
+Smooth Sort,500,298,0.01974870
+Smooth Sort,500,299,0.01662150
+Smooth Sort,500,300,0.01702880
+Smooth Sort,500,301,0.01855780
+Smooth Sort,500,302,0.01759380
+Smooth Sort,500,303,0.01597590
+Smooth Sort,500,304,0.01952180
+Smooth Sort,500,305,0.01906170
+Smooth Sort,500,306,0.01601570
+Smooth Sort,500,307,0.01990830
+Smooth Sort,500,308,0.01628800
+Smooth Sort,500,309,0.02350850
+Smooth Sort,500,310,0.01511830
+Smooth Sort,500,311,0.02425250
+Smooth Sort,500,312,0.01722810
+Smooth Sort,500,313,0.01661660
+Smooth Sort,500,314,0.02395030
+Smooth Sort,500,315,0.02126680
+Smooth Sort,500,316,0.02145350
+Smooth Sort,500,317,0.02122760
+Smooth Sort,500,318,0.02066110
+Smooth Sort,500,319,0.01564860
+Smooth Sort,500,320,0.01750170
+Smooth Sort,500,321,0.01602490
+Smooth Sort,500,322,0.01571330
+Smooth Sort,500,323,0.01675910
+Smooth Sort,500,324,0.01704120
+Smooth Sort,500,325,0.01620500
+Smooth Sort,500,326,0.01494180
+Smooth Sort,500,327,0.01731590
+Smooth Sort,500,328,0.01801200
+Smooth Sort,500,329,0.01761170
+Smooth Sort,500,330,0.01853240
+Smooth Sort,500,331,0.01974530
+Smooth Sort,500,332,0.02132130
+Smooth Sort,500,333,0.01964750
+Smooth Sort,500,334,0.02204320
+Smooth Sort,500,335,0.02044640
+Smooth Sort,500,336,0.01941570
+Smooth Sort,500,337,0.02118140
+Smooth Sort,500,338,0.01673720
+Smooth Sort,500,339,0.01678060
+Smooth Sort,500,340,0.01594930
+Smooth Sort,500,341,0.01828100
+Smooth Sort,500,342,0.01804300
+Smooth Sort,500,343,0.01970510
+Smooth Sort,500,344,0.02168900
+Smooth Sort,500,345,0.01767150
+Smooth Sort,500,346,0.02325780
+Smooth Sort,500,347,0.01742370
+Smooth Sort,500,348,0.01733010
+Smooth Sort,500,349,0.02390610
+Smooth Sort,500,350,0.02235390
+Smooth Sort,500,351,0.01587610
+Smooth Sort,500,352,0.01520230
+Smooth Sort,500,353,0.02153810
+Smooth Sort,500,354,0.01779160
+Smooth Sort,500,355,0.01753430
+Smooth Sort,500,356,0.02038240
+Smooth Sort,500,357,0.02121050
+Smooth Sort,500,358,0.01721980
+Smooth Sort,500,359,0.01986760
+Smooth Sort,500,360,0.01855690
+Smooth Sort,500,361,0.01967170
+Smooth Sort,500,362,0.01846270
+Smooth Sort,500,363,0.02180390
+Smooth Sort,500,364,0.01895530
+Smooth Sort,500,365,0.01898170
+Smooth Sort,500,366,0.01834400
+Smooth Sort,500,367,0.01779130
+Smooth Sort,500,368,0.01832330
+Smooth Sort,500,369,0.01921460
+Smooth Sort,500,370,0.01753280
+Smooth Sort,500,371,0.02314750
+Smooth Sort,500,372,0.01639400
+Smooth Sort,500,373,0.01948550
+Smooth Sort,500,374,0.01520710
+Smooth Sort,500,375,0.01618370
+Smooth Sort,500,376,0.01765180
+Smooth Sort,500,377,0.01858180
+Smooth Sort,500,378,0.01799460
+Smooth Sort,500,379,0.01963960
+Smooth Sort,500,380,0.01692950
+Smooth Sort,500,381,0.02011200
+Smooth Sort,500,382,0.01739220
+Smooth Sort,500,383,0.02073910
+Smooth Sort,500,384,0.01695870
+Smooth Sort,500,385,0.01651570
+Smooth Sort,500,386,0.02438470
+Smooth Sort,500,387,0.02000120
+Smooth Sort,500,388,0.02243260
+Smooth Sort,500,389,0.02021550
+Smooth Sort,500,390,0.01769430
+Smooth Sort,500,391,0.01763410
+Smooth Sort,500,392,0.01702260
+Smooth Sort,500,393,0.01716060
+Smooth Sort,500,394,0.01857210
+Smooth Sort,500,395,0.01731070
+Smooth Sort,500,396,0.01723010
+Smooth Sort,500,397,0.01599250
+Smooth Sort,500,398,0.01858010
+Smooth Sort,500,399,0.02145330
+Smooth Sort,500,400,0.01884400
+Smooth Sort,500,401,0.01812690
+Smooth Sort,500,402,0.01714430
+Smooth Sort,500,403,0.01926320
+Smooth Sort,500,404,0.02261170
+Smooth Sort,500,405,0.01638440
+Smooth Sort,500,406,0.01814660
+Smooth Sort,500,407,0.02113820
+Smooth Sort,500,408,0.02158310
+Smooth Sort,500,409,0.02436030
+Smooth Sort,500,410,0.02305960
+Smooth Sort,500,411,0.02256700
+Smooth Sort,500,412,0.02039560
+Smooth Sort,500,413,0.02118780
+Smooth Sort,500,414,0.01756500
+Smooth Sort,500,415,0.01894030
+Smooth Sort,500,416,0.02345130
+Smooth Sort,500,417,0.02070420
+Smooth Sort,500,418,0.02086820
+Smooth Sort,500,419,0.01986990
+Smooth Sort,500,420,0.02510010
+Smooth Sort,500,421,0.02352540
+Smooth Sort,500,422,0.02470780
+Smooth Sort,500,423,0.02478530
+Smooth Sort,500,424,0.02597220
+Smooth Sort,500,425,0.02349480
+Smooth Sort,500,426,0.02282480
+Smooth Sort,500,427,0.02503420
+Smooth Sort,500,428,0.02323670
+Smooth Sort,500,429,0.02345980
+Smooth Sort,500,430,0.02608190
+Smooth Sort,500,431,0.02846380
+Smooth Sort,500,432,0.02726890
+Smooth Sort,500,433,0.02565430
+Smooth Sort,500,434,0.02601910
+Smooth Sort,500,435,0.02459060
+Smooth Sort,500,436,0.02455960
+Smooth Sort,500,437,0.02553570
+Smooth Sort,500,438,0.02300360
+Smooth Sort,500,439,0.02429540
+Smooth Sort,500,440,0.01988080
+Smooth Sort,500,441,0.02393960
+Smooth Sort,500,442,0.02540360
+Smooth Sort,500,443,0.01853270
+Smooth Sort,500,444,0.02260420
+Smooth Sort,500,445,0.02062420
+Smooth Sort,500,446,0.02466680
+Smooth Sort,500,447,0.02334300
+Smooth Sort,500,448,0.02321850
+Smooth Sort,500,449,0.02350000
+Smooth Sort,500,450,0.02291630
+Smooth Sort,500,451,0.02548130
+Smooth Sort,500,452,0.02277270
+Smooth Sort,500,453,0.02592360
+Smooth Sort,500,454,0.02305060
+Smooth Sort,500,455,0.02392030
+Smooth Sort,500,456,0.02669370
+Smooth Sort,500,457,0.02718000
+Smooth Sort,500,458,0.02559310
+Smooth Sort,500,459,0.02773630
+Smooth Sort,500,460,0.02705500
+Smooth Sort,500,461,0.02473060
+Smooth Sort,500,462,0.02517790
+Smooth Sort,500,463,0.02619160
+Smooth Sort,500,464,0.02501760
+Smooth Sort,500,465,0.02637390
+Smooth Sort,500,466,0.02724740
+Smooth Sort,500,467,0.02446820
+Smooth Sort,500,468,0.02470030
+Smooth Sort,500,469,0.02244370
+Smooth Sort,500,470,0.02300620
+Smooth Sort,500,471,0.02424020
+Smooth Sort,500,472,0.01924400
+Smooth Sort,500,473,0.02661930
+Smooth Sort,500,474,0.02297700
+Smooth Sort,500,475,0.01978590
+Smooth Sort,500,476,0.01960980
+Smooth Sort,500,477,0.02437080
+Smooth Sort,500,478,0.02576480
+Smooth Sort,500,479,0.02257730
+Smooth Sort,500,480,0.02147170
+Smooth Sort,500,481,0.02305930
+Smooth Sort,500,482,0.02086620
+Smooth Sort,500,483,0.02447760
+Smooth Sort,500,484,0.02428380
+Smooth Sort,500,485,0.02285480
+Smooth Sort,500,486,0.02430650
+Smooth Sort,500,487,0.02432740
+Smooth Sort,500,488,0.02278170
+Smooth Sort,500,489,0.02425340
+Smooth Sort,500,490,0.02529640
+Smooth Sort,500,491,0.02379880
+Smooth Sort,500,492,0.02485810
+Smooth Sort,500,493,0.02442330
+Smooth Sort,500,494,0.02423170
+Smooth Sort,500,495,0.02136330
+Smooth Sort,500,496,0.02389400
+Smooth Sort,500,497,0.02116140
+Smooth Sort,500,498,0.02229760
+Smooth Sort,500,499,0.02266900
+Smooth Sort,500,500,0.02040400
+Sorting Network,500,1,0.00232240
+Sorting Network,500,2,0.00228590
+Sorting Network,500,3,0.00318710
+Sorting Network,500,4,0.00335910
+Sorting Network,500,5,0.00279340
+Sorting Network,500,6,0.00280100
+Sorting Network,500,7,0.00382660
+Sorting Network,500,8,0.00300070
+Sorting Network,500,9,0.00384360
+Sorting Network,500,10,0.00395610
+Sorting Network,500,11,0.00326460
+Sorting Network,500,12,0.00290680
+Sorting Network,500,13,0.00353580
+Sorting Network,500,14,0.00354640
+Sorting Network,500,15,0.00411330
+Sorting Network,500,16,0.00270640
+Sorting Network,500,17,0.00402600
+Sorting Network,500,18,0.00404420
+Sorting Network,500,19,0.00362510
+Sorting Network,500,20,0.00273080
+Sorting Network,500,21,0.00306600
+Sorting Network,500,22,0.00249920
+Sorting Network,500,23,0.00299870
+Sorting Network,500,24,0.00264680
+Sorting Network,500,25,0.00345460
+Sorting Network,500,26,0.00367920
+Sorting Network,500,27,0.00309580
+Sorting Network,500,28,0.00328050
+Sorting Network,500,29,0.00294490
+Sorting Network,500,30,0.00303870
+Sorting Network,500,31,0.00344470
+Sorting Network,500,32,0.00388080
+Sorting Network,500,33,0.00378400
+Sorting Network,500,34,0.00369870
+Sorting Network,500,35,0.00283230
+Sorting Network,500,36,0.00240870
+Sorting Network,500,37,0.00300980
+Sorting Network,500,38,0.00224700
+Sorting Network,500,39,0.00305220
+Sorting Network,500,40,0.00398840
+Sorting Network,500,41,0.00387240
+Sorting Network,500,42,0.00404770
+Sorting Network,500,43,0.00268900
+Sorting Network,500,44,0.00384330
+Sorting Network,500,45,0.00256520
+Sorting Network,500,46,0.00387450
+Sorting Network,500,47,0.00309030
+Sorting Network,500,48,0.00326470
+Sorting Network,500,49,0.00404450
+Sorting Network,500,50,0.00286620
+Sorting Network,500,51,0.00378770
+Sorting Network,500,52,0.00271160
+Sorting Network,500,53,0.00366380
+Sorting Network,500,54,0.00362280
+Sorting Network,500,55,0.00287880
+Sorting Network,500,56,0.00436900
+Sorting Network,500,57,0.00322450
+Sorting Network,500,58,0.00478210
+Sorting Network,500,59,0.00455520
+Sorting Network,500,60,0.00428330
+Sorting Network,500,61,0.00318650
+Sorting Network,500,62,0.00323270
+Sorting Network,500,63,0.00347030
+Sorting Network,500,64,0.00407490
+Sorting Network,500,65,0.00457750
+Sorting Network,500,66,0.00430360
+Sorting Network,500,67,0.00459540
+Sorting Network,500,68,0.00438640
+Sorting Network,500,69,0.00404700
+Sorting Network,500,70,0.00383110
+Sorting Network,500,71,0.00492050
+Sorting Network,500,72,0.00458860
+Sorting Network,500,73,0.00418160
+Sorting Network,500,74,0.00492460
+Sorting Network,500,75,0.00460150
+Sorting Network,500,76,0.00434240
+Sorting Network,500,77,0.00420380
+Sorting Network,500,78,0.00431430
+Sorting Network,500,79,0.00429050
+Sorting Network,500,80,0.00474830
+Sorting Network,500,81,0.00497850
+Sorting Network,500,82,0.00407290
+Sorting Network,500,83,0.00506770
+Sorting Network,500,84,0.00427120
+Sorting Network,500,85,0.00413930
+Sorting Network,500,86,0.00422740
+Sorting Network,500,87,0.00467830
+Sorting Network,500,88,0.00381910
+Sorting Network,500,89,0.00404560
+Sorting Network,500,90,0.00400880
+Sorting Network,500,91,0.00401310
+Sorting Network,500,92,0.00395890
+Sorting Network,500,93,0.00380270
+Sorting Network,500,94,0.00385350
+Sorting Network,500,95,0.00330510
+Sorting Network,500,96,0.00332510
+Sorting Network,500,97,0.00322250
+Sorting Network,500,98,0.00411260
+Sorting Network,500,99,0.00325930
+Sorting Network,500,100,0.00398450
+Sorting Network,500,101,0.00424890
+Sorting Network,500,102,0.00387210
+Sorting Network,500,103,0.00390710
+Sorting Network,500,104,0.00332120
+Sorting Network,500,105,0.00352820
+Sorting Network,500,106,0.00355160
+Sorting Network,500,107,0.00382050
+Sorting Network,500,108,0.00447770
+Sorting Network,500,109,0.00404100
+Sorting Network,500,110,0.00380950
+Sorting Network,500,111,0.00421630
+Sorting Network,500,112,0.00317000
+Sorting Network,500,113,0.00373270
+Sorting Network,500,114,0.00413880
+Sorting Network,500,115,0.00387920
+Sorting Network,500,116,0.00284070
+Sorting Network,500,117,0.00364410
+Sorting Network,500,118,0.00317060
+Sorting Network,500,119,0.00283100
+Sorting Network,500,120,0.00273520
+Sorting Network,500,121,0.00404820
+Sorting Network,500,122,0.00413510
+Sorting Network,500,123,0.00407730
+Sorting Network,500,124,0.00265460
+Sorting Network,500,125,0.00298910
+Sorting Network,500,126,0.00380260
+Sorting Network,500,127,0.00371550
+Sorting Network,500,128,0.00328180
+Sorting Network,500,129,0.00349540
+Sorting Network,500,130,0.00374830
+Sorting Network,500,131,0.00401260
+Sorting Network,500,132,0.00428160
+Sorting Network,500,133,0.00370110
+Sorting Network,500,134,0.00301770
+Sorting Network,500,135,0.00405810
+Sorting Network,500,136,0.00357520
+Sorting Network,500,137,0.00298360
+Sorting Network,500,138,0.00361960
+Sorting Network,500,139,0.00264710
+Sorting Network,500,140,0.00375610
+Sorting Network,500,141,0.00324480
+Sorting Network,500,142,0.00436270
+Sorting Network,500,143,0.00342010
+Sorting Network,500,144,0.00405690
+Sorting Network,500,145,0.00335590
+Sorting Network,500,146,0.00347550
+Sorting Network,500,147,0.00302590
+Sorting Network,500,148,0.00409410
+Sorting Network,500,149,0.00342270
+Sorting Network,500,150,0.00280960
+Sorting Network,500,151,0.00364500
+Sorting Network,500,152,0.00386760
+Sorting Network,500,153,0.00256310
+Sorting Network,500,154,0.00283200
+Sorting Network,500,155,0.00263530
+Sorting Network,500,156,0.00255710
+Sorting Network,500,157,0.00380030
+Sorting Network,500,158,0.00336270
+Sorting Network,500,159,0.00400850
+Sorting Network,500,160,0.00380080
+Sorting Network,500,161,0.00283840
+Sorting Network,500,162,0.00235160
+Sorting Network,500,163,0.00278370
+Sorting Network,500,164,0.00277300
+Sorting Network,500,165,0.00302790
+Sorting Network,500,166,0.00369540
+Sorting Network,500,167,0.00251830
+Sorting Network,500,168,0.00398770
+Sorting Network,500,169,0.00226750
+Sorting Network,500,170,0.00341600
+Sorting Network,500,171,0.00272030
+Sorting Network,500,172,0.00395770
+Sorting Network,500,173,0.00256780
+Sorting Network,500,174,0.00477000
+Sorting Network,500,175,0.00429200
+Sorting Network,500,176,0.00409850
+Sorting Network,500,177,0.00283560
+Sorting Network,500,178,0.00306490
+Sorting Network,500,179,0.00312700
+Sorting Network,500,180,0.00334110
+Sorting Network,500,181,0.00390830
+Sorting Network,500,182,0.00374300
+Sorting Network,500,183,0.00401060
+Sorting Network,500,184,0.00352370
+Sorting Network,500,185,0.00383730
+Sorting Network,500,186,0.00340690
+Sorting Network,500,187,0.00301830
+Sorting Network,500,188,0.00406430
+Sorting Network,500,189,0.00339040
+Sorting Network,500,190,0.00300220
+Sorting Network,500,191,0.00312020
+Sorting Network,500,192,0.00332270
+Sorting Network,500,193,0.00387650
+Sorting Network,500,194,0.00348930
+Sorting Network,500,195,0.00269310
+Sorting Network,500,196,0.00390160
+Sorting Network,500,197,0.00388830
+Sorting Network,500,198,0.00392590
+Sorting Network,500,199,0.00327970
+Sorting Network,500,200,0.00324650
+Sorting Network,500,201,0.00236070
+Sorting Network,500,202,0.00260020
+Sorting Network,500,203,0.00259610
+Sorting Network,500,204,0.00225450
+Sorting Network,500,205,0.00414940
+Sorting Network,500,206,0.00389280
+Sorting Network,500,207,0.00350940
+Sorting Network,500,208,0.00316630
+Sorting Network,500,209,0.00279940
+Sorting Network,500,210,0.00351000
+Sorting Network,500,211,0.00324150
+Sorting Network,500,212,0.00264530
+Sorting Network,500,213,0.00296490
+Sorting Network,500,214,0.00413600
+Sorting Network,500,215,0.00361350
+Sorting Network,500,216,0.00342390
+Sorting Network,500,217,0.00361560
+Sorting Network,500,218,0.00375430
+Sorting Network,500,219,0.00386690
+Sorting Network,500,220,0.00326420
+Sorting Network,500,221,0.00336360
+Sorting Network,500,222,0.00405770
+Sorting Network,500,223,0.00405750
+Sorting Network,500,224,0.00388970
+Sorting Network,500,225,0.00320480
+Sorting Network,500,226,0.00373200
+Sorting Network,500,227,0.00401010
+Sorting Network,500,228,0.00395610
+Sorting Network,500,229,0.00406900
+Sorting Network,500,230,0.00356570
+Sorting Network,500,231,0.00395190
+Sorting Network,500,232,0.00322400
+Sorting Network,500,233,0.00354390
+Sorting Network,500,234,0.00399400
+Sorting Network,500,235,0.00404350
+Sorting Network,500,236,0.00374960
+Sorting Network,500,237,0.00344290
+Sorting Network,500,238,0.00336890
+Sorting Network,500,239,0.00258490
+Sorting Network,500,240,0.00358530
+Sorting Network,500,241,0.00362860
+Sorting Network,500,242,0.00345630
+Sorting Network,500,243,0.00353080
+Sorting Network,500,244,0.00400490
+Sorting Network,500,245,0.00344830
+Sorting Network,500,246,0.00379560
+Sorting Network,500,247,0.00376690
+Sorting Network,500,248,0.00410880
+Sorting Network,500,249,0.00372690
+Sorting Network,500,250,0.00273320
+Sorting Network,500,251,0.00251910
+Sorting Network,500,252,0.00342160
+Sorting Network,500,253,0.00308350
+Sorting Network,500,254,0.00226140
+Sorting Network,500,255,0.00235030
+Sorting Network,500,256,0.00384650
+Sorting Network,500,257,0.00351850
+Sorting Network,500,258,0.00232180
+Sorting Network,500,259,0.00398350
+Sorting Network,500,260,0.00397210
+Sorting Network,500,261,0.00398660
+Sorting Network,500,262,0.00303750
+Sorting Network,500,263,0.00246260
+Sorting Network,500,264,0.00377680
+Sorting Network,500,265,0.00258660
+Sorting Network,500,266,0.00333640
+Sorting Network,500,267,0.00303050
+Sorting Network,500,268,0.00372380
+Sorting Network,500,269,0.00407320
+Sorting Network,500,270,0.00327910
+Sorting Network,500,271,0.00330840
+Sorting Network,500,272,0.00344750
+Sorting Network,500,273,0.00323960
+Sorting Network,500,274,0.00407700
+Sorting Network,500,275,0.00344870
+Sorting Network,500,276,0.00412440
+Sorting Network,500,277,0.00411550
+Sorting Network,500,278,0.00387570
+Sorting Network,500,279,0.00408650
+Sorting Network,500,280,0.00407740
+Sorting Network,500,281,0.00361520
+Sorting Network,500,282,0.00359920
+Sorting Network,500,283,0.00330350
+Sorting Network,500,284,0.00400690
+Sorting Network,500,285,0.00240660
+Sorting Network,500,286,0.00337160
+Sorting Network,500,287,0.00398270
+Sorting Network,500,288,0.00399410
+Sorting Network,500,289,0.00265100
+Sorting Network,500,290,0.00402150
+Sorting Network,500,291,0.00253440
+Sorting Network,500,292,0.00280020
+Sorting Network,500,293,0.00286850
+Sorting Network,500,294,0.00276710
+Sorting Network,500,295,0.00353360
+Sorting Network,500,296,0.00384450
+Sorting Network,500,297,0.00277170
+Sorting Network,500,298,0.00288480
+Sorting Network,500,299,0.00392910
+Sorting Network,500,300,0.00322340
+Sorting Network,500,301,0.00269800
+Sorting Network,500,302,0.00248730
+Sorting Network,500,303,0.00253560
+Sorting Network,500,304,0.00303000
+Sorting Network,500,305,0.00252310
+Sorting Network,500,306,0.00378700
+Sorting Network,500,307,0.00234160
+Sorting Network,500,308,0.00296940
+Sorting Network,500,309,0.00376500
+Sorting Network,500,310,0.00304660
+Sorting Network,500,311,0.00362870
+Sorting Network,500,312,0.00289020
+Sorting Network,500,313,0.00313530
+Sorting Network,500,314,0.00309480
+Sorting Network,500,315,0.00405710
+Sorting Network,500,316,0.00379460
+Sorting Network,500,317,0.00280650
+Sorting Network,500,318,0.00312990
+Sorting Network,500,319,0.00323260
+Sorting Network,500,320,0.00233800
+Sorting Network,500,321,0.00340950
+Sorting Network,500,322,0.00400340
+Sorting Network,500,323,0.00316440
+Sorting Network,500,324,0.00356870
+Sorting Network,500,325,0.00246900
+Sorting Network,500,326,0.00244210
+Sorting Network,500,327,0.00238980
+Sorting Network,500,328,0.00255950
+Sorting Network,500,329,0.00318500
+Sorting Network,500,330,0.00321900
+Sorting Network,500,331,0.00358460
+Sorting Network,500,332,0.00359850
+Sorting Network,500,333,0.00370770
+Sorting Network,500,334,0.00318910
+Sorting Network,500,335,0.00444740
+Sorting Network,500,336,0.00290080
+Sorting Network,500,337,0.00333050
+Sorting Network,500,338,0.00314160
+Sorting Network,500,339,0.00354600
+Sorting Network,500,340,0.00318420
+Sorting Network,500,341,0.00348910
+Sorting Network,500,342,0.00227360
+Sorting Network,500,343,0.00271230
+Sorting Network,500,344,0.00327170
+Sorting Network,500,345,0.00347620
+Sorting Network,500,346,0.00298290
+Sorting Network,500,347,0.00247800
+Sorting Network,500,348,0.00273340
+Sorting Network,500,349,0.00354240
+Sorting Network,500,350,0.00398770
+Sorting Network,500,351,0.00241610
+Sorting Network,500,352,0.00320920
+Sorting Network,500,353,0.00309940
+Sorting Network,500,354,0.00334450
+Sorting Network,500,355,0.00270420
+Sorting Network,500,356,0.00380090
+Sorting Network,500,357,0.00279320
+Sorting Network,500,358,0.00402580
+Sorting Network,500,359,0.00302230
+Sorting Network,500,360,0.00321030
+Sorting Network,500,361,0.00309230
+Sorting Network,500,362,0.00304690
+Sorting Network,500,363,0.00314390
+Sorting Network,500,364,0.00361190
+Sorting Network,500,365,0.00434180
+Sorting Network,500,366,0.00437550
+Sorting Network,500,367,0.00416880
+Sorting Network,500,368,0.00305840
+Sorting Network,500,369,0.00309610
+Sorting Network,500,370,0.00349760
+Sorting Network,500,371,0.00311300
+Sorting Network,500,372,0.00311750
+Sorting Network,500,373,0.00418180
+Sorting Network,500,374,0.00279580
+Sorting Network,500,375,0.00282120
+Sorting Network,500,376,0.00375990
+Sorting Network,500,377,0.00264120
+Sorting Network,500,378,0.00342230
+Sorting Network,500,379,0.00405340
+Sorting Network,500,380,0.00251600
+Sorting Network,500,381,0.00330970
+Sorting Network,500,382,0.00424200
+Sorting Network,500,383,0.00272910
+Sorting Network,500,384,0.00398400
+Sorting Network,500,385,0.00334420
+Sorting Network,500,386,0.00349850
+Sorting Network,500,387,0.00319340
+Sorting Network,500,388,0.00401580
+Sorting Network,500,389,0.00239830
+Sorting Network,500,390,0.00403000
+Sorting Network,500,391,0.00273560
+Sorting Network,500,392,0.00388990
+Sorting Network,500,393,0.00242750
+Sorting Network,500,394,0.00399140
+Sorting Network,500,395,0.00277750
+Sorting Network,500,396,0.00405220
+Sorting Network,500,397,0.00397100
+Sorting Network,500,398,0.00268360
+Sorting Network,500,399,0.00320930
+Sorting Network,500,400,0.00358180
+Sorting Network,500,401,0.00325070
+Sorting Network,500,402,0.00334930
+Sorting Network,500,403,0.00294850
+Sorting Network,500,404,0.00316910
+Sorting Network,500,405,0.00343290
+Sorting Network,500,406,0.00308700
+Sorting Network,500,407,0.00357720
+Sorting Network,500,408,0.00349620
+Sorting Network,500,409,0.00328320
+Sorting Network,500,410,0.00420930
+Sorting Network,500,411,0.00327860
+Sorting Network,500,412,0.00397240
+Sorting Network,500,413,0.00291980
+Sorting Network,500,414,0.00347280
+Sorting Network,500,415,0.00373710
+Sorting Network,500,416,0.00283130
+Sorting Network,500,417,0.00408070
+Sorting Network,500,418,0.00335440
+Sorting Network,500,419,0.00277230
+Sorting Network,500,420,0.00407630
+Sorting Network,500,421,0.00418180
+Sorting Network,500,422,0.00398640
+Sorting Network,500,423,0.00386270
+Sorting Network,500,424,0.00325030
+Sorting Network,500,425,0.00376020
+Sorting Network,500,426,0.00375870
+Sorting Network,500,427,0.00250570
+Sorting Network,500,428,0.00328830
+Sorting Network,500,429,0.00348320
+Sorting Network,500,430,0.00353270
+Sorting Network,500,431,0.00405410
+Sorting Network,500,432,0.00415600
+Sorting Network,500,433,0.00415000
+Sorting Network,500,434,0.00416820
+Sorting Network,500,435,0.00413030
+Sorting Network,500,436,0.00419650
+Sorting Network,500,437,0.00448500
+Sorting Network,500,438,0.00419900
+Sorting Network,500,439,0.00336360
+Sorting Network,500,440,0.00278450
+Sorting Network,500,441,0.00310220
+Sorting Network,500,442,0.00438940
+Sorting Network,500,443,0.00394640
+Sorting Network,500,444,0.00432440
+Sorting Network,500,445,0.00386960
+Sorting Network,500,446,0.00398310
+Sorting Network,500,447,0.00406190
+Sorting Network,500,448,0.00347380
+Sorting Network,500,449,0.00406480
+Sorting Network,500,450,0.00304750
+Sorting Network,500,451,0.00368710
+Sorting Network,500,452,0.00411850
+Sorting Network,500,453,0.00423780
+Sorting Network,500,454,0.00258100
+Sorting Network,500,455,0.00319810
+Sorting Network,500,456,0.00366560
+Sorting Network,500,457,0.00393800
+Sorting Network,500,458,0.00380130
+Sorting Network,500,459,0.00341920
+Sorting Network,500,460,0.00315340
+Sorting Network,500,461,0.00341020
+Sorting Network,500,462,0.00404620
+Sorting Network,500,463,0.00328200
+Sorting Network,500,464,0.00420530
+Sorting Network,500,465,0.00363020
+Sorting Network,500,466,0.00426010
+Sorting Network,500,467,0.00343630
+Sorting Network,500,468,0.00340570
+Sorting Network,500,469,0.00390440
+Sorting Network,500,470,0.00324580
+Sorting Network,500,471,0.00303760
+Sorting Network,500,472,0.00392850
+Sorting Network,500,473,0.00395760
+Sorting Network,500,474,0.00397220
+Sorting Network,500,475,0.00361730
+Sorting Network,500,476,0.00409430
+Sorting Network,500,477,0.00426270
+Sorting Network,500,478,0.00402140
+Sorting Network,500,479,0.00428010
+Sorting Network,500,480,0.00420660
+Sorting Network,500,481,0.00414890
+Sorting Network,500,482,0.00338470
+Sorting Network,500,483,0.00395120
+Sorting Network,500,484,0.00337320
+Sorting Network,500,485,0.00246470
+Sorting Network,500,486,0.00388940
+Sorting Network,500,487,0.00408380
+Sorting Network,500,488,0.00304830
+Sorting Network,500,489,0.00264940
+Sorting Network,500,490,0.00333580
+Sorting Network,500,491,0.00280750
+Sorting Network,500,492,0.00393330
+Sorting Network,500,493,0.00356690
+Sorting Network,500,494,0.00399160
+Sorting Network,500,495,0.00390760
+Sorting Network,500,496,0.00321190
+Sorting Network,500,497,0.00313250
+Sorting Network,500,498,0.00283030
+Sorting Network,500,499,0.00365300
+Sorting Network,500,500,0.00305120
+Spaghetti Sort,500,1,0.00267200
+Spaghetti Sort,500,2,0.00256120
+Spaghetti Sort,500,3,0.00185640
+Spaghetti Sort,500,4,0.00268170
+Spaghetti Sort,500,5,0.00253900
+Spaghetti Sort,500,6,0.00258060
+Spaghetti Sort,500,7,0.00198890
+Spaghetti Sort,500,8,0.00235090
+Spaghetti Sort,500,9,0.00175930
+Spaghetti Sort,500,10,0.00211780
+Spaghetti Sort,500,11,0.00267840
+Spaghetti Sort,500,12,0.00204540
+Spaghetti Sort,500,13,0.00279520
+Spaghetti Sort,500,14,0.00275730
+Spaghetti Sort,500,15,0.00223670
+Spaghetti Sort,500,16,0.00236110
+Spaghetti Sort,500,17,0.00298850
+Spaghetti Sort,500,18,0.00250330
+Spaghetti Sort,500,19,0.00283600
+Spaghetti Sort,500,20,0.00278220
+Spaghetti Sort,500,21,0.00277100
+Spaghetti Sort,500,22,0.00157380
+Spaghetti Sort,500,23,0.00254290
+Spaghetti Sort,500,24,0.00160730
+Spaghetti Sort,500,25,0.00212090
+Spaghetti Sort,500,26,0.00279530
+Spaghetti Sort,500,27,0.00186860
+Spaghetti Sort,500,28,0.00286110
+Spaghetti Sort,500,29,0.00190110
+Spaghetti Sort,500,30,0.00199390
+Spaghetti Sort,500,31,0.00237950
+Spaghetti Sort,500,32,0.00184590
+Spaghetti Sort,500,33,0.00277910
+Spaghetti Sort,500,34,0.00265330
+Spaghetti Sort,500,35,0.00267210
+Spaghetti Sort,500,36,0.00165810
+Spaghetti Sort,500,37,0.00205120
+Spaghetti Sort,500,38,0.00228480
+Spaghetti Sort,500,39,0.00203860
+Spaghetti Sort,500,40,0.00263240
+Spaghetti Sort,500,41,0.00280200
+Spaghetti Sort,500,42,0.00255090
+Spaghetti Sort,500,43,0.00247030
+Spaghetti Sort,500,44,0.00249670
+Spaghetti Sort,500,45,0.00206590
+Spaghetti Sort,500,46,0.00224980
+Spaghetti Sort,500,47,0.00238790
+Spaghetti Sort,500,48,0.00244140
+Spaghetti Sort,500,49,0.00258600
+Spaghetti Sort,500,50,0.00160370
+Spaghetti Sort,500,51,0.00281000
+Spaghetti Sort,500,52,0.00220300
+Spaghetti Sort,500,53,0.00176460
+Spaghetti Sort,500,54,0.00186560
+Spaghetti Sort,500,55,0.00157000
+Spaghetti Sort,500,56,0.00265580
+Spaghetti Sort,500,57,0.00189980
+Spaghetti Sort,500,58,0.00270650
+Spaghetti Sort,500,59,0.00274010
+Spaghetti Sort,500,60,0.00276790
+Spaghetti Sort,500,61,0.00256510
+Spaghetti Sort,500,62,0.00188780
+Spaghetti Sort,500,63,0.00268310
+Spaghetti Sort,500,64,0.00237360
+Spaghetti Sort,500,65,0.00222460
+Spaghetti Sort,500,66,0.00292320
+Spaghetti Sort,500,67,0.00255820
+Spaghetti Sort,500,68,0.00243460
+Spaghetti Sort,500,69,0.00288690
+Spaghetti Sort,500,70,0.00243070
+Spaghetti Sort,500,71,0.00263020
+Spaghetti Sort,500,72,0.00244630
+Spaghetti Sort,500,73,0.00280250
+Spaghetti Sort,500,74,0.00233800
+Spaghetti Sort,500,75,0.00278330
+Spaghetti Sort,500,76,0.00277680
+Spaghetti Sort,500,77,0.00204910
+Spaghetti Sort,500,78,0.00258590
+Spaghetti Sort,500,79,0.00227130
+Spaghetti Sort,500,80,0.00251790
+Spaghetti Sort,500,81,0.00199230
+Spaghetti Sort,500,82,0.00197920
+Spaghetti Sort,500,83,0.00175590
+Spaghetti Sort,500,84,0.00294840
+Spaghetti Sort,500,85,0.00244470
+Spaghetti Sort,500,86,0.00291550
+Spaghetti Sort,500,87,0.00177890
+Spaghetti Sort,500,88,0.00217110
+Spaghetti Sort,500,89,0.00223340
+Spaghetti Sort,500,90,0.00244110
+Spaghetti Sort,500,91,0.00265770
+Spaghetti Sort,500,92,0.00276930
+Spaghetti Sort,500,93,0.00161040
+Spaghetti Sort,500,94,0.00234590
+Spaghetti Sort,500,95,0.00273560
+Spaghetti Sort,500,96,0.00205140
+Spaghetti Sort,500,97,0.00250860
+Spaghetti Sort,500,98,0.00256930
+Spaghetti Sort,500,99,0.00244230
+Spaghetti Sort,500,100,0.00244190
+Spaghetti Sort,500,101,0.00273310
+Spaghetti Sort,500,102,0.00277310
+Spaghetti Sort,500,103,0.00196130
+Spaghetti Sort,500,104,0.00261220
+Spaghetti Sort,500,105,0.00162210
+Spaghetti Sort,500,106,0.00274140
+Spaghetti Sort,500,107,0.00246200
+Spaghetti Sort,500,108,0.00279900
+Spaghetti Sort,500,109,0.00173570
+Spaghetti Sort,500,110,0.00194390
+Spaghetti Sort,500,111,0.00181740
+Spaghetti Sort,500,112,0.00213660
+Spaghetti Sort,500,113,0.00200080
+Spaghetti Sort,500,114,0.00278890
+Spaghetti Sort,500,115,0.00161110
+Spaghetti Sort,500,116,0.00213510
+Spaghetti Sort,500,117,0.00160570
+Spaghetti Sort,500,118,0.00285130
+Spaghetti Sort,500,119,0.00244490
+Spaghetti Sort,500,120,0.00241360
+Spaghetti Sort,500,121,0.00222280
+Spaghetti Sort,500,122,0.00190480
+Spaghetti Sort,500,123,0.00256900
+Spaghetti Sort,500,124,0.00202560
+Spaghetti Sort,500,125,0.00173040
+Spaghetti Sort,500,126,0.00235250
+Spaghetti Sort,500,127,0.00280060
+Spaghetti Sort,500,128,0.00256910
+Spaghetti Sort,500,129,0.00244250
+Spaghetti Sort,500,130,0.00268530
+Spaghetti Sort,500,131,0.00288540
+Spaghetti Sort,500,132,0.00236410
+Spaghetti Sort,500,133,0.00234020
+Spaghetti Sort,500,134,0.00215370
+Spaghetti Sort,500,135,0.00230780
+Spaghetti Sort,500,136,0.00281240
+Spaghetti Sort,500,137,0.00182900
+Spaghetti Sort,500,138,0.00288010
+Spaghetti Sort,500,139,0.00230290
+Spaghetti Sort,500,140,0.00279260
+Spaghetti Sort,500,141,0.00300160
+Spaghetti Sort,500,142,0.00244960
+Spaghetti Sort,500,143,0.00205640
+Spaghetti Sort,500,144,0.00246940
+Spaghetti Sort,500,145,0.00159040
+Spaghetti Sort,500,146,0.00275480
+Spaghetti Sort,500,147,0.00191240
+Spaghetti Sort,500,148,0.00277750
+Spaghetti Sort,500,149,0.00318450
+Spaghetti Sort,500,150,0.00178340
+Spaghetti Sort,500,151,0.00276990
+Spaghetti Sort,500,152,0.00217570
+Spaghetti Sort,500,153,0.00226740
+Spaghetti Sort,500,154,0.00226820
+Spaghetti Sort,500,155,0.00214970
+Spaghetti Sort,500,156,0.00237190
+Spaghetti Sort,500,157,0.00258200
+Spaghetti Sort,500,158,0.00153920
+Spaghetti Sort,500,159,0.00220220
+Spaghetti Sort,500,160,0.00194300
+Spaghetti Sort,500,161,0.00191480
+Spaghetti Sort,500,162,0.00202750
+Spaghetti Sort,500,163,0.00267650
+Spaghetti Sort,500,164,0.00174840
+Spaghetti Sort,500,165,0.00179210
+Spaghetti Sort,500,166,0.00158280
+Spaghetti Sort,500,167,0.00231770
+Spaghetti Sort,500,168,0.00276120
+Spaghetti Sort,500,169,0.00185260
+Spaghetti Sort,500,170,0.00158090
+Spaghetti Sort,500,171,0.00153760
+Spaghetti Sort,500,172,0.00191990
+Spaghetti Sort,500,173,0.00278710
+Spaghetti Sort,500,174,0.00195430
+Spaghetti Sort,500,175,0.00237470
+Spaghetti Sort,500,176,0.00271770
+Spaghetti Sort,500,177,0.00266750
+Spaghetti Sort,500,178,0.00153840
+Spaghetti Sort,500,179,0.00276250
+Spaghetti Sort,500,180,0.00175710
+Spaghetti Sort,500,181,0.00199900
+Spaghetti Sort,500,182,0.00179850
+Spaghetti Sort,500,183,0.00265860
+Spaghetti Sort,500,184,0.00259630
+Spaghetti Sort,500,185,0.00214940
+Spaghetti Sort,500,186,0.00203190
+Spaghetti Sort,500,187,0.00265920
+Spaghetti Sort,500,188,0.00274880
+Spaghetti Sort,500,189,0.00183520
+Spaghetti Sort,500,190,0.00276360
+Spaghetti Sort,500,191,0.00152730
+Spaghetti Sort,500,192,0.00155010
+Spaghetti Sort,500,193,0.00243470
+Spaghetti Sort,500,194,0.00162420
+Spaghetti Sort,500,195,0.00205910
+Spaghetti Sort,500,196,0.00277980
+Spaghetti Sort,500,197,0.00279870
+Spaghetti Sort,500,198,0.00236860
+Spaghetti Sort,500,199,0.00278630
+Spaghetti Sort,500,200,0.00184820
+Spaghetti Sort,500,201,0.00273690
+Spaghetti Sort,500,202,0.00190420
+Spaghetti Sort,500,203,0.00167080
+Spaghetti Sort,500,204,0.00242010
+Spaghetti Sort,500,205,0.00197360
+Spaghetti Sort,500,206,0.00261290
+Spaghetti Sort,500,207,0.00268160
+Spaghetti Sort,500,208,0.00203130
+Spaghetti Sort,500,209,0.00235650
+Spaghetti Sort,500,210,0.00278480
+Spaghetti Sort,500,211,0.00195780
+Spaghetti Sort,500,212,0.00189910
+Spaghetti Sort,500,213,0.00174570
+Spaghetti Sort,500,214,0.00157070
+Spaghetti Sort,500,215,0.00261810
+Spaghetti Sort,500,216,0.00168980
+Spaghetti Sort,500,217,0.00264390
+Spaghetti Sort,500,218,0.00224140
+Spaghetti Sort,500,219,0.00275880
+Spaghetti Sort,500,220,0.00219410
+Spaghetti Sort,500,221,0.00185210
+Spaghetti Sort,500,222,0.00218120
+Spaghetti Sort,500,223,0.00163530
+Spaghetti Sort,500,224,0.00203300
+Spaghetti Sort,500,225,0.00265420
+Spaghetti Sort,500,226,0.00276760
+Spaghetti Sort,500,227,0.00230930
+Spaghetti Sort,500,228,0.00157470
+Spaghetti Sort,500,229,0.00258720
+Spaghetti Sort,500,230,0.00215570
+Spaghetti Sort,500,231,0.00243270
+Spaghetti Sort,500,232,0.00274080
+Spaghetti Sort,500,233,0.00278490
+Spaghetti Sort,500,234,0.00155350
+Spaghetti Sort,500,235,0.00153360
+Spaghetti Sort,500,236,0.00195570
+Spaghetti Sort,500,237,0.00268990
+Spaghetti Sort,500,238,0.00161410
+Spaghetti Sort,500,239,0.00261310
+Spaghetti Sort,500,240,0.00233570
+Spaghetti Sort,500,241,0.00194740
+Spaghetti Sort,500,242,0.00160690
+Spaghetti Sort,500,243,0.00175890
+Spaghetti Sort,500,244,0.00233900
+Spaghetti Sort,500,245,0.00255250
+Spaghetti Sort,500,246,0.00216450
+Spaghetti Sort,500,247,0.00157490
+Spaghetti Sort,500,248,0.00221810
+Spaghetti Sort,500,249,0.00274390
+Spaghetti Sort,500,250,0.00173340
+Spaghetti Sort,500,251,0.00199310
+Spaghetti Sort,500,252,0.00204360
+Spaghetti Sort,500,253,0.00277530
+Spaghetti Sort,500,254,0.00267370
+Spaghetti Sort,500,255,0.00312510
+Spaghetti Sort,500,256,0.00158200
+Spaghetti Sort,500,257,0.00271410
+Spaghetti Sort,500,258,0.00281980
+Spaghetti Sort,500,259,0.00261960
+Spaghetti Sort,500,260,0.00154350
+Spaghetti Sort,500,261,0.00189100
+Spaghetti Sort,500,262,0.00199450
+Spaghetti Sort,500,263,0.00211520
+Spaghetti Sort,500,264,0.00243610
+Spaghetti Sort,500,265,0.00259330
+Spaghetti Sort,500,266,0.00167880
+Spaghetti Sort,500,267,0.00161440
+Spaghetti Sort,500,268,0.00272800
+Spaghetti Sort,500,269,0.00243470
+Spaghetti Sort,500,270,0.00262590
+Spaghetti Sort,500,271,0.00160560
+Spaghetti Sort,500,272,0.00195740
+Spaghetti Sort,500,273,0.00182830
+Spaghetti Sort,500,274,0.00283530
+Spaghetti Sort,500,275,0.00239470
+Spaghetti Sort,500,276,0.00247440
+Spaghetti Sort,500,277,0.00157440
+Spaghetti Sort,500,278,0.00185380
+Spaghetti Sort,500,279,0.00271900
+Spaghetti Sort,500,280,0.00256080
+Spaghetti Sort,500,281,0.00201530
+Spaghetti Sort,500,282,0.00235330
+Spaghetti Sort,500,283,0.00278070
+Spaghetti Sort,500,284,0.00276420
+Spaghetti Sort,500,285,0.00168920
+Spaghetti Sort,500,286,0.00194120
+Spaghetti Sort,500,287,0.00238030
+Spaghetti Sort,500,288,0.00179610
+Spaghetti Sort,500,289,0.00271260
+Spaghetti Sort,500,290,0.00155150
+Spaghetti Sort,500,291,0.00199240
+Spaghetti Sort,500,292,0.00174790
+Spaghetti Sort,500,293,0.00235580
+Spaghetti Sort,500,294,0.00275750
+Spaghetti Sort,500,295,0.00168070
+Spaghetti Sort,500,296,0.00279470
+Spaghetti Sort,500,297,0.00216140
+Spaghetti Sort,500,298,0.00280510
+Spaghetti Sort,500,299,0.00269740
+Spaghetti Sort,500,300,0.00275350
+Spaghetti Sort,500,301,0.00170500
+Spaghetti Sort,500,302,0.00171210
+Spaghetti Sort,500,303,0.00263320
+Spaghetti Sort,500,304,0.00245220
+Spaghetti Sort,500,305,0.00263110
+Spaghetti Sort,500,306,0.00272560
+Spaghetti Sort,500,307,0.00246090
+Spaghetti Sort,500,308,0.00191360
+Spaghetti Sort,500,309,0.00220580
+Spaghetti Sort,500,310,0.00262890
+Spaghetti Sort,500,311,0.00274780
+Spaghetti Sort,500,312,0.00191990
+Spaghetti Sort,500,313,0.00274340
+Spaghetti Sort,500,314,0.00161690
+Spaghetti Sort,500,315,0.00249470
+Spaghetti Sort,500,316,0.00249550
+Spaghetti Sort,500,317,0.00219420
+Spaghetti Sort,500,318,0.00282520
+Spaghetti Sort,500,319,0.00238140
+Spaghetti Sort,500,320,0.00245140
+Spaghetti Sort,500,321,0.00286720
+Spaghetti Sort,500,322,0.00290490
+Spaghetti Sort,500,323,0.00270420
+Spaghetti Sort,500,324,0.00264320
+Spaghetti Sort,500,325,0.00288670
+Spaghetti Sort,500,326,0.00283810
+Spaghetti Sort,500,327,0.00264510
+Spaghetti Sort,500,328,0.00277270
+Spaghetti Sort,500,329,0.00279960
+Spaghetti Sort,500,330,0.00272120
+Spaghetti Sort,500,331,0.00161100
+Spaghetti Sort,500,332,0.00182670
+Spaghetti Sort,500,333,0.00280360
+Spaghetti Sort,500,334,0.00258270
+Spaghetti Sort,500,335,0.00167500
+Spaghetti Sort,500,336,0.00241610
+Spaghetti Sort,500,337,0.00236030
+Spaghetti Sort,500,338,0.00279660
+Spaghetti Sort,500,339,0.00174400
+Spaghetti Sort,500,340,0.00274860
+Spaghetti Sort,500,341,0.00164290
+Spaghetti Sort,500,342,0.00222550
+Spaghetti Sort,500,343,0.00187430
+Spaghetti Sort,500,344,0.00240740
+Spaghetti Sort,500,345,0.00283840
+Spaghetti Sort,500,346,0.00182850
+Spaghetti Sort,500,347,0.00176670
+Spaghetti Sort,500,348,0.00256270
+Spaghetti Sort,500,349,0.00205920
+Spaghetti Sort,500,350,0.00200530
+Spaghetti Sort,500,351,0.00183240
+Spaghetti Sort,500,352,0.00166350
+Spaghetti Sort,500,353,0.00262650
+Spaghetti Sort,500,354,0.00238780
+Spaghetti Sort,500,355,0.00268990
+Spaghetti Sort,500,356,0.00202500
+Spaghetti Sort,500,357,0.00244810
+Spaghetti Sort,500,358,0.00219940
+Spaghetti Sort,500,359,0.00246850
+Spaghetti Sort,500,360,0.00275120
+Spaghetti Sort,500,361,0.00162310
+Spaghetti Sort,500,362,0.00193400
+Spaghetti Sort,500,363,0.00254130
+Spaghetti Sort,500,364,0.00239160
+Spaghetti Sort,500,365,0.00245240
+Spaghetti Sort,500,366,0.00277090
+Spaghetti Sort,500,367,0.00256390
+Spaghetti Sort,500,368,0.00267230
+Spaghetti Sort,500,369,0.00222790
+Spaghetti Sort,500,370,0.00274690
+Spaghetti Sort,500,371,0.00274230
+Spaghetti Sort,500,372,0.00241790
+Spaghetti Sort,500,373,0.00182210
+Spaghetti Sort,500,374,0.00228020
+Spaghetti Sort,500,375,0.00245410
+Spaghetti Sort,500,376,0.00225920
+Spaghetti Sort,500,377,0.00251450
+Spaghetti Sort,500,378,0.00223480
+Spaghetti Sort,500,379,0.00274200
+Spaghetti Sort,500,380,0.00207630
+Spaghetti Sort,500,381,0.00319630
+Spaghetti Sort,500,382,0.00278860
+Spaghetti Sort,500,383,0.00174280
+Spaghetti Sort,500,384,0.00158350
+Spaghetti Sort,500,385,0.00288490
+Spaghetti Sort,500,386,0.00278950
+Spaghetti Sort,500,387,0.00237110
+Spaghetti Sort,500,388,0.00205890
+Spaghetti Sort,500,389,0.00255770
+Spaghetti Sort,500,390,0.00287900
+Spaghetti Sort,500,391,0.00287160
+Spaghetti Sort,500,392,0.00244840
+Spaghetti Sort,500,393,0.00261830
+Spaghetti Sort,500,394,0.00283000
+Spaghetti Sort,500,395,0.00244790
+Spaghetti Sort,500,396,0.00246260
+Spaghetti Sort,500,397,0.00204170
+Spaghetti Sort,500,398,0.00259610
+Spaghetti Sort,500,399,0.00275450
+Spaghetti Sort,500,400,0.00258470
+Spaghetti Sort,500,401,0.00244160
+Spaghetti Sort,500,402,0.00209680
+Spaghetti Sort,500,403,0.00190280
+Spaghetti Sort,500,404,0.00171790
+Spaghetti Sort,500,405,0.00235520
+Spaghetti Sort,500,406,0.00239120
+Spaghetti Sort,500,407,0.00282000
+Spaghetti Sort,500,408,0.00218330
+Spaghetti Sort,500,409,0.00278000
+Spaghetti Sort,500,410,0.00268350
+Spaghetti Sort,500,411,0.00249650
+Spaghetti Sort,500,412,0.00194440
+Spaghetti Sort,500,413,0.00206070
+Spaghetti Sort,500,414,0.00262350
+Spaghetti Sort,500,415,0.00283390
+Spaghetti Sort,500,416,0.00246480
+Spaghetti Sort,500,417,0.00301620
+Spaghetti Sort,500,418,0.00249540
+Spaghetti Sort,500,419,0.00281130
+Spaghetti Sort,500,420,0.00247040
+Spaghetti Sort,500,421,0.00285090
+Spaghetti Sort,500,422,0.00263160
+Spaghetti Sort,500,423,0.00266260
+Spaghetti Sort,500,424,0.00252540
+Spaghetti Sort,500,425,0.00268090
+Spaghetti Sort,500,426,0.00244690
+Spaghetti Sort,500,427,0.00318500
+Spaghetti Sort,500,428,0.00270110
+Spaghetti Sort,500,429,0.00287650
+Spaghetti Sort,500,430,0.00246340
+Spaghetti Sort,500,431,0.00290350
+Spaghetti Sort,500,432,0.00258100
+Spaghetti Sort,500,433,0.00259890
+Spaghetti Sort,500,434,0.00264900
+Spaghetti Sort,500,435,0.00277080
+Spaghetti Sort,500,436,0.00238270
+Spaghetti Sort,500,437,0.00268580
+Spaghetti Sort,500,438,0.00249820
+Spaghetti Sort,500,439,0.00227640
+Spaghetti Sort,500,440,0.00182940
+Spaghetti Sort,500,441,0.00158910
+Spaghetti Sort,500,442,0.00272230
+Spaghetti Sort,500,443,0.00260780
+Spaghetti Sort,500,444,0.00158140
+Spaghetti Sort,500,445,0.00267910
+Spaghetti Sort,500,446,0.00283860
+Spaghetti Sort,500,447,0.00225670
+Spaghetti Sort,500,448,0.00276700
+Spaghetti Sort,500,449,0.00266120
+Spaghetti Sort,500,450,0.00273960
+Spaghetti Sort,500,451,0.00284760
+Spaghetti Sort,500,452,0.00245910
+Spaghetti Sort,500,453,0.00330640
+Spaghetti Sort,500,454,0.00252390
+Spaghetti Sort,500,455,0.00367730
+Spaghetti Sort,500,456,0.00331110
+Spaghetti Sort,500,457,0.00330770
+Spaghetti Sort,500,458,0.00291450
+Spaghetti Sort,500,459,0.00269920
+Spaghetti Sort,500,460,0.00280390
+Spaghetti Sort,500,461,0.00276310
+Spaghetti Sort,500,462,0.00274400
+Spaghetti Sort,500,463,0.00283090
+Spaghetti Sort,500,464,0.00357960
+Spaghetti Sort,500,465,0.00299320
+Spaghetti Sort,500,466,0.00323940
+Spaghetti Sort,500,467,0.00274470
+Spaghetti Sort,500,468,0.00272480
+Spaghetti Sort,500,469,0.00232080
+Spaghetti Sort,500,470,0.00273520
+Spaghetti Sort,500,471,0.00240130
+Spaghetti Sort,500,472,0.00293490
+Spaghetti Sort,500,473,0.00278560
+Spaghetti Sort,500,474,0.00285220
+Spaghetti Sort,500,475,0.00275130
+Spaghetti Sort,500,476,0.00290630
+Spaghetti Sort,500,477,0.00279920
+Spaghetti Sort,500,478,0.00230280
+Spaghetti Sort,500,479,0.00328620
+Spaghetti Sort,500,480,0.00398880
+Spaghetti Sort,500,481,0.00333160
+Spaghetti Sort,500,482,0.00355400
+Spaghetti Sort,500,483,0.00326810
+Spaghetti Sort,500,484,0.00398780
+Spaghetti Sort,500,485,0.00357020
+Spaghetti Sort,500,486,0.00269990
+Spaghetti Sort,500,487,0.00269200
+Spaghetti Sort,500,488,0.00240540
+Spaghetti Sort,500,489,0.00252260
+Spaghetti Sort,500,490,0.00208800
+Spaghetti Sort,500,491,0.00288250
+Spaghetti Sort,500,492,0.00271210
+Spaghetti Sort,500,493,0.00240310
+Spaghetti Sort,500,494,0.00213470
+Spaghetti Sort,500,495,0.00250450
+Spaghetti Sort,500,496,0.00219390
+Spaghetti Sort,500,497,0.00290540
+Spaghetti Sort,500,498,0.00249710
+Spaghetti Sort,500,499,0.00286780
+Spaghetti Sort,500,500,0.00270090
+Spreadsort,500,1,0.00055930
+Spreadsort,500,2,0.00051660
+Spreadsort,500,3,0.00047390
+Spreadsort,500,4,0.00027020
+Spreadsort,500,5,0.00033070
+Spreadsort,500,6,0.00055920
+Spreadsort,500,7,0.00035550
+Spreadsort,500,8,0.00043400
+Spreadsort,500,9,0.00039310
+Spreadsort,500,10,0.00034760
+Spreadsort,500,11,0.00057490
+Spreadsort,500,12,0.00026020
+Spreadsort,500,13,0.00026250
+Spreadsort,500,14,0.00045280
+Spreadsort,500,15,0.00048240
+Spreadsort,500,16,0.00032430
+Spreadsort,500,17,0.00030830
+Spreadsort,500,18,0.00055780
+Spreadsort,500,19,0.00031880
+Spreadsort,500,20,0.00033230
+Spreadsort,500,21,0.00047290
+Spreadsort,500,22,0.00032260
+Spreadsort,500,23,0.00046990
+Spreadsort,500,24,0.00029690
+Spreadsort,500,25,0.00035100
+Spreadsort,500,26,0.00027530
+Spreadsort,500,27,0.00047320
+Spreadsort,500,28,0.00046930
+Spreadsort,500,29,0.00046770
+Spreadsort,500,30,0.00030540
+Spreadsort,500,31,0.00046430
+Spreadsort,500,32,0.00031560
+Spreadsort,500,33,0.00046510
+Spreadsort,500,34,0.00026890
+Spreadsort,500,35,0.00046930
+Spreadsort,500,36,0.00026180
+Spreadsort,500,37,0.00046590
+Spreadsort,500,38,0.00040850
+Spreadsort,500,39,0.00047110
+Spreadsort,500,40,0.00033700
+Spreadsort,500,41,0.00046410
+Spreadsort,500,42,0.00027470
+Spreadsort,500,43,0.00046350
+Spreadsort,500,44,0.00045810
+Spreadsort,500,45,0.00026390
+Spreadsort,500,46,0.00025620
+Spreadsort,500,47,0.00025770
+Spreadsort,500,48,0.00048920
+Spreadsort,500,49,0.00047240
+Spreadsort,500,50,0.00046210
+Spreadsort,500,51,0.00046280
+Spreadsort,500,52,0.00025850
+Spreadsort,500,53,0.00046150
+Spreadsort,500,54,0.00038330
+Spreadsort,500,55,0.00045880
+Spreadsort,500,56,0.00042860
+Spreadsort,500,57,0.00026360
+Spreadsort,500,58,0.00065940
+Spreadsort,500,59,0.00048550
+Spreadsort,500,60,0.00065100
+Spreadsort,500,61,0.00042000
+Spreadsort,500,62,0.00048010
+Spreadsort,500,63,0.00052260
+Spreadsort,500,64,0.00045260
+Spreadsort,500,65,0.00046770
+Spreadsort,500,66,0.00046690
+Spreadsort,500,67,0.00038390
+Spreadsort,500,68,0.00048000
+Spreadsort,500,69,0.00046390
+Spreadsort,500,70,0.00046000
+Spreadsort,500,71,0.00041710
+Spreadsort,500,72,0.00041180
+Spreadsort,500,73,0.00044690
+Spreadsort,500,74,0.00028810
+Spreadsort,500,75,0.00046900
+Spreadsort,500,76,0.00032840
+Spreadsort,500,77,0.00046170
+Spreadsort,500,78,0.00034600
+Spreadsort,500,79,0.00046480
+Spreadsort,500,80,0.00045360
+Spreadsort,500,81,0.00044690
+Spreadsort,500,82,0.00046500
+Spreadsort,500,83,0.00046450
+Spreadsort,500,84,0.00026140
+Spreadsort,500,85,0.00042970
+Spreadsort,500,86,0.00047720
+Spreadsort,500,87,0.00044370
+Spreadsort,500,88,0.00044910
+Spreadsort,500,89,0.00045850
+Spreadsort,500,90,0.00027580
+Spreadsort,500,91,0.00046460
+Spreadsort,500,92,0.00047350
+Spreadsort,500,93,0.00037440
+Spreadsort,500,94,0.00048790
+Spreadsort,500,95,0.00055670
+Spreadsort,500,96,0.00047910
+Spreadsort,500,97,0.00048390
+Spreadsort,500,98,0.00048180
+Spreadsort,500,99,0.00047090
+Spreadsort,500,100,0.00034070
+Spreadsort,500,101,0.00028120
+Spreadsort,500,102,0.00046020
+Spreadsort,500,103,0.00046790
+Spreadsort,500,104,0.00039180
+Spreadsort,500,105,0.00044940
+Spreadsort,500,106,0.00025920
+Spreadsort,500,107,0.00026650
+Spreadsort,500,108,0.00033610
+Spreadsort,500,109,0.00033130
+Spreadsort,500,110,0.00033880
+Spreadsort,500,111,0.00046160
+Spreadsort,500,112,0.00039380
+Spreadsort,500,113,0.00026080
+Spreadsort,500,114,0.00028280
+Spreadsort,500,115,0.00038170
+Spreadsort,500,116,0.00028520
+Spreadsort,500,117,0.00032630
+Spreadsort,500,118,0.00031410
+Spreadsort,500,119,0.00047020
+Spreadsort,500,120,0.00044690
+Spreadsort,500,121,0.00049570
+Spreadsort,500,122,0.00028190
+Spreadsort,500,123,0.00026680
+Spreadsort,500,124,0.00030780
+Spreadsort,500,125,0.00026700
+Spreadsort,500,126,0.00026870
+Spreadsort,500,127,0.00029360
+Spreadsort,500,128,0.00029360
+Spreadsort,500,129,0.00025920
+Spreadsort,500,130,0.00026320
+Spreadsort,500,131,0.00026400
+Spreadsort,500,132,0.00037220
+Spreadsort,500,133,0.00039460
+Spreadsort,500,134,0.00044810
+Spreadsort,500,135,0.00030340
+Spreadsort,500,136,0.00034210
+Spreadsort,500,137,0.00027280
+Spreadsort,500,138,0.00044400
+Spreadsort,500,139,0.00026390
+Spreadsort,500,140,0.00025810
+Spreadsort,500,141,0.00035320
+Spreadsort,500,142,0.00026560
+Spreadsort,500,143,0.00025320
+Spreadsort,500,144,0.00025780
+Spreadsort,500,145,0.00026580
+Spreadsort,500,146,0.00029160
+Spreadsort,500,147,0.00026000
+Spreadsort,500,148,0.00028790
+Spreadsort,500,149,0.00043900
+Spreadsort,500,150,0.00027440
+Spreadsort,500,151,0.00028810
+Spreadsort,500,152,0.00028970
+Spreadsort,500,153,0.00031170
+Spreadsort,500,154,0.00026570
+Spreadsort,500,155,0.00035710
+Spreadsort,500,156,0.00030980
+Spreadsort,500,157,0.00026350
+Spreadsort,500,158,0.00026120
+Spreadsort,500,159,0.00033460
+Spreadsort,500,160,0.00028330
+Spreadsort,500,161,0.00026850
+Spreadsort,500,162,0.00026030
+Spreadsort,500,163,0.00025930
+Spreadsort,500,164,0.00026060
+Spreadsort,500,165,0.00028280
+Spreadsort,500,166,0.00040360
+Spreadsort,500,167,0.00040560
+Spreadsort,500,168,0.00026710
+Spreadsort,500,169,0.00038450
+Spreadsort,500,170,0.00040410
+Spreadsort,500,171,0.00028970
+Spreadsort,500,172,0.00041660
+Spreadsort,500,173,0.00046480
+Spreadsort,500,174,0.00045630
+Spreadsort,500,175,0.00046650
+Spreadsort,500,176,0.00040850
+Spreadsort,500,177,0.00048670
+Spreadsort,500,178,0.00041670
+Spreadsort,500,179,0.00050570
+Spreadsort,500,180,0.00044300
+Spreadsort,500,181,0.00046280
+Spreadsort,500,182,0.00041360
+Spreadsort,500,183,0.00044110
+Spreadsort,500,184,0.00043710
+Spreadsort,500,185,0.00039530
+Spreadsort,500,186,0.00041510
+Spreadsort,500,187,0.00045940
+Spreadsort,500,188,0.00026380
+Spreadsort,500,189,0.00046430
+Spreadsort,500,190,0.00033210
+Spreadsort,500,191,0.00026030
+Spreadsort,500,192,0.00031340
+Spreadsort,500,193,0.00045360
+Spreadsort,500,194,0.00042800
+Spreadsort,500,195,0.00045260
+Spreadsort,500,196,0.00046080
+Spreadsort,500,197,0.00047290
+Spreadsort,500,198,0.00025810
+Spreadsort,500,199,0.00042270
+Spreadsort,500,200,0.00044920
+Spreadsort,500,201,0.00032370
+Spreadsort,500,202,0.00026210
+Spreadsort,500,203,0.00042270
+Spreadsort,500,204,0.00028580
+Spreadsort,500,205,0.00026210
+Spreadsort,500,206,0.00040400
+Spreadsort,500,207,0.00025810
+Spreadsort,500,208,0.00028560
+Spreadsort,500,209,0.00026500
+Spreadsort,500,210,0.00040870
+Spreadsort,500,211,0.00041010
+Spreadsort,500,212,0.00027280
+Spreadsort,500,213,0.00028660
+Spreadsort,500,214,0.00026400
+Spreadsort,500,215,0.00026050
+Spreadsort,500,216,0.00041850
+Spreadsort,500,217,0.00045560
+Spreadsort,500,218,0.00031120
+Spreadsort,500,219,0.00044750
+Spreadsort,500,220,0.00041690
+Spreadsort,500,221,0.00025950
+Spreadsort,500,222,0.00027980
+Spreadsort,500,223,0.00027850
+Spreadsort,500,224,0.00025770
+Spreadsort,500,225,0.00026030
+Spreadsort,500,226,0.00026580
+Spreadsort,500,227,0.00033100
+Spreadsort,500,228,0.00029210
+Spreadsort,500,229,0.00041610
+Spreadsort,500,230,0.00026540
+Spreadsort,500,231,0.00027960
+Spreadsort,500,232,0.00027900
+Spreadsort,500,233,0.00033770
+Spreadsort,500,234,0.00026670
+Spreadsort,500,235,0.00027410
+Spreadsort,500,236,0.00030880
+Spreadsort,500,237,0.00032000
+Spreadsort,500,238,0.00028440
+Spreadsort,500,239,0.00045740
+Spreadsort,500,240,0.00038570
+Spreadsort,500,241,0.00026510
+Spreadsort,500,242,0.00027180
+Spreadsort,500,243,0.00042010
+Spreadsort,500,244,0.00026260
+Spreadsort,500,245,0.00026750
+Spreadsort,500,246,0.00027910
+Spreadsort,500,247,0.00027970
+Spreadsort,500,248,0.00035180
+Spreadsort,500,249,0.00026220
+Spreadsort,500,250,0.00027410
+Spreadsort,500,251,0.00041360
+Spreadsort,500,252,0.00043410
+Spreadsort,500,253,0.00035110
+Spreadsort,500,254,0.00026570
+Spreadsort,500,255,0.00027300
+Spreadsort,500,256,0.00041260
+Spreadsort,500,257,0.00039640
+Spreadsort,500,258,0.00054640
+Spreadsort,500,259,0.00045530
+Spreadsort,500,260,0.00044720
+Spreadsort,500,261,0.00030870
+Spreadsort,500,262,0.00030370
+Spreadsort,500,263,0.00029660
+Spreadsort,500,264,0.00027380
+Spreadsort,500,265,0.00032400
+Spreadsort,500,266,0.00027050
+Spreadsort,500,267,0.00046110
+Spreadsort,500,268,0.00040480
+Spreadsort,500,269,0.00043680
+Spreadsort,500,270,0.00039070
+Spreadsort,500,271,0.00045790
+Spreadsort,500,272,0.00048020
+Spreadsort,500,273,0.00036140
+Spreadsort,500,274,0.00028970
+Spreadsort,500,275,0.00045410
+Spreadsort,500,276,0.00041310
+Spreadsort,500,277,0.00026830
+Spreadsort,500,278,0.00046500
+Spreadsort,500,279,0.00032190
+Spreadsort,500,280,0.00026610
+Spreadsort,500,281,0.00026640
+Spreadsort,500,282,0.00027970
+Spreadsort,500,283,0.00026230
+Spreadsort,500,284,0.00041130
+Spreadsort,500,285,0.00041850
+Spreadsort,500,286,0.00033020
+Spreadsort,500,287,0.00026590
+Spreadsort,500,288,0.00027350
+Spreadsort,500,289,0.00039290
+Spreadsort,500,290,0.00026250
+Spreadsort,500,291,0.00042400
+Spreadsort,500,292,0.00027140
+Spreadsort,500,293,0.00029800
+Spreadsort,500,294,0.00026300
+Spreadsort,500,295,0.00028120
+Spreadsort,500,296,0.00026470
+Spreadsort,500,297,0.00026430
+Spreadsort,500,298,0.00030980
+Spreadsort,500,299,0.00038960
+Spreadsort,500,300,0.00032560
+Spreadsort,500,301,0.00042220
+Spreadsort,500,302,0.00037340
+Spreadsort,500,303,0.00041260
+Spreadsort,500,304,0.00027090
+Spreadsort,500,305,0.00042380
+Spreadsort,500,306,0.00041970
+Spreadsort,500,307,0.00025990
+Spreadsort,500,308,0.00026040
+Spreadsort,500,309,0.00026350
+Spreadsort,500,310,0.00026870
+Spreadsort,500,311,0.00026250
+Spreadsort,500,312,0.00040990
+Spreadsort,500,313,0.00026400
+Spreadsort,500,314,0.00025920
+Spreadsort,500,315,0.00026620
+Spreadsort,500,316,0.00033660
+Spreadsort,500,317,0.00030710
+Spreadsort,500,318,0.00025900
+Spreadsort,500,319,0.00029170
+Spreadsort,500,320,0.00041620
+Spreadsort,500,321,0.00027050
+Spreadsort,500,322,0.00026170
+Spreadsort,500,323,0.00045460
+Spreadsort,500,324,0.00026610
+Spreadsort,500,325,0.00029650
+Spreadsort,500,326,0.00033240
+Spreadsort,500,327,0.00042030
+Spreadsort,500,328,0.00025960
+Spreadsort,500,329,0.00047360
+Spreadsort,500,330,0.00037030
+Spreadsort,500,331,0.00039400
+Spreadsort,500,332,0.00039650
+Spreadsort,500,333,0.00027570
+Spreadsort,500,334,0.00039340
+Spreadsort,500,335,0.00026980
+Spreadsort,500,336,0.00046370
+Spreadsort,500,337,0.00025800
+Spreadsort,500,338,0.00030950
+Spreadsort,500,339,0.00042660
+Spreadsort,500,340,0.00030300
+Spreadsort,500,341,0.00047730
+Spreadsort,500,342,0.00033180
+Spreadsort,500,343,0.00042510
+Spreadsort,500,344,0.00027950
+Spreadsort,500,345,0.00048410
+Spreadsort,500,346,0.00034510
+Spreadsort,500,347,0.00042440
+Spreadsort,500,348,0.00026420
+Spreadsort,500,349,0.00027260
+Spreadsort,500,350,0.00046100
+Spreadsort,500,351,0.00048780
+Spreadsort,500,352,0.00029780
+Spreadsort,500,353,0.00029660
+Spreadsort,500,354,0.00033560
+Spreadsort,500,355,0.00033950
+Spreadsort,500,356,0.00046190
+Spreadsort,500,357,0.00043020
+Spreadsort,500,358,0.00026530
+Spreadsort,500,359,0.00029490
+Spreadsort,500,360,0.00026170
+Spreadsort,500,361,0.00026360
+Spreadsort,500,362,0.00026210
+Spreadsort,500,363,0.00026580
+Spreadsort,500,364,0.00027320
+Spreadsort,500,365,0.00026360
+Spreadsort,500,366,0.00027190
+Spreadsort,500,367,0.00025910
+Spreadsort,500,368,0.00031690
+Spreadsort,500,369,0.00042120
+Spreadsort,500,370,0.00034630
+Spreadsort,500,371,0.00026720
+Spreadsort,500,372,0.00028090
+Spreadsort,500,373,0.00026250
+Spreadsort,500,374,0.00027770
+Spreadsort,500,375,0.00026510
+Spreadsort,500,376,0.00026460
+Spreadsort,500,377,0.00030170
+Spreadsort,500,378,0.00025910
+Spreadsort,500,379,0.00028230
+Spreadsort,500,380,0.00029390
+Spreadsort,500,381,0.00033140
+Spreadsort,500,382,0.00025960
+Spreadsort,500,383,0.00025740
+Spreadsort,500,384,0.00033620
+Spreadsort,500,385,0.00027130
+Spreadsort,500,386,0.00026100
+Spreadsort,500,387,0.00049260
+Spreadsort,500,388,0.00047260
+Spreadsort,500,389,0.00046670
+Spreadsort,500,390,0.00035790
+Spreadsort,500,391,0.00043430
+Spreadsort,500,392,0.00043830
+Spreadsort,500,393,0.00027540
+Spreadsort,500,394,0.00036640
+Spreadsort,500,395,0.00046000
+Spreadsort,500,396,0.00027930
+Spreadsort,500,397,0.00026110
+Spreadsort,500,398,0.00042180
+Spreadsort,500,399,0.00026330
+Spreadsort,500,400,0.00027340
+Spreadsort,500,401,0.00026100
+Spreadsort,500,402,0.00026300
+Spreadsort,500,403,0.00055850
+Spreadsort,500,404,0.00044990
+Spreadsort,500,405,0.00041310
+Spreadsort,500,406,0.00049560
+Spreadsort,500,407,0.00042740
+Spreadsort,500,408,0.00045900
+Spreadsort,500,409,0.00046190
+Spreadsort,500,410,0.00028970
+Spreadsort,500,411,0.00026630
+Spreadsort,500,412,0.00039050
+Spreadsort,500,413,0.00046610
+Spreadsort,500,414,0.00042710
+Spreadsort,500,415,0.00034220
+Spreadsort,500,416,0.00028940
+Spreadsort,500,417,0.00038510
+Spreadsort,500,418,0.00028590
+Spreadsort,500,419,0.00029710
+Spreadsort,500,420,0.00026470
+Spreadsort,500,421,0.00026360
+Spreadsort,500,422,0.00025960
+Spreadsort,500,423,0.00025470
+Spreadsort,500,424,0.00027780
+Spreadsort,500,425,0.00026530
+Spreadsort,500,426,0.00026290
+Spreadsort,500,427,0.00026440
+Spreadsort,500,428,0.00027030
+Spreadsort,500,429,0.00026580
+Spreadsort,500,430,0.00026120
+Spreadsort,500,431,0.00026490
+Spreadsort,500,432,0.00025770
+Spreadsort,500,433,0.00026540
+Spreadsort,500,434,0.00030340
+Spreadsort,500,435,0.00034930
+Spreadsort,500,436,0.00031080
+Spreadsort,500,437,0.00026290
+Spreadsort,500,438,0.00028300
+Spreadsort,500,439,0.00035280
+Spreadsort,500,440,0.00029630
+Spreadsort,500,441,0.00026770
+Spreadsort,500,442,0.00026040
+Spreadsort,500,443,0.00026290
+Spreadsort,500,444,0.00026990
+Spreadsort,500,445,0.00035400
+Spreadsort,500,446,0.00026430
+Spreadsort,500,447,0.00026050
+Spreadsort,500,448,0.00038990
+Spreadsort,500,449,0.00026740
+Spreadsort,500,450,0.00035030
+Spreadsort,500,451,0.00026570
+Spreadsort,500,452,0.00026470
+Spreadsort,500,453,0.00049350
+Spreadsort,500,454,0.00027910
+Spreadsort,500,455,0.00026600
+Spreadsort,500,456,0.00026620
+Spreadsort,500,457,0.00026880
+Spreadsort,500,458,0.00034690
+Spreadsort,500,459,0.00030060
+Spreadsort,500,460,0.00036150
+Spreadsort,500,461,0.00026140
+Spreadsort,500,462,0.00025890
+Spreadsort,500,463,0.00025800
+Spreadsort,500,464,0.00026730
+Spreadsort,500,465,0.00040670
+Spreadsort,500,466,0.00025860
+Spreadsort,500,467,0.00034190
+Spreadsort,500,468,0.00027230
+Spreadsort,500,469,0.00027790
+Spreadsort,500,470,0.00027250
+Spreadsort,500,471,0.00036530
+Spreadsort,500,472,0.00026260
+Spreadsort,500,473,0.00026370
+Spreadsort,500,474,0.00043370
+Spreadsort,500,475,0.00043780
+Spreadsort,500,476,0.00039950
+Spreadsort,500,477,0.00027320
+Spreadsort,500,478,0.00027450
+Spreadsort,500,479,0.00028380
+Spreadsort,500,480,0.00026180
+Spreadsort,500,481,0.00026040
+Spreadsort,500,482,0.00026490
+Spreadsort,500,483,0.00026600
+Spreadsort,500,484,0.00036740
+Spreadsort,500,485,0.00026720
+Spreadsort,500,486,0.00026160
+Spreadsort,500,487,0.00025880
+Spreadsort,500,488,0.00036030
+Spreadsort,500,489,0.00044590
+Spreadsort,500,490,0.00029860
+Spreadsort,500,491,0.00036620
+Spreadsort,500,492,0.00026330
+Spreadsort,500,493,0.00031040
+Spreadsort,500,494,0.00029930
+Spreadsort,500,495,0.00025920
+Spreadsort,500,496,0.00027460
+Spreadsort,500,497,0.00025940
+Spreadsort,500,498,0.00027850
+Spreadsort,500,499,0.00027910
+Spreadsort,500,500,0.00026470
+Stooge Sort,500,1,3.13286020
+Stooge Sort,500,2,3.20418340
+Stooge Sort,500,3,3.13656470
+Stooge Sort,500,4,3.09487620
+Stooge Sort,500,5,3.14811900
+Stooge Sort,500,6,3.16734950
+Stooge Sort,500,7,3.15003660
+Stooge Sort,500,8,3.20896820
+Stooge Sort,500,9,3.15117650
+Stooge Sort,500,10,3.19912210
+Stooge Sort,500,11,3.12757530
+Stooge Sort,500,12,3.15074120
+Stooge Sort,500,13,3.14639700
+Stooge Sort,500,14,3.11401180
+Stooge Sort,500,15,3.17338460
+Stooge Sort,500,16,3.15546030
+Stooge Sort,500,17,2.98037950
+Stooge Sort,500,18,2.95704270
+Stooge Sort,500,19,3.02499920
+Stooge Sort,500,20,3.00077770
+Stooge Sort,500,21,3.01909070
+Stooge Sort,500,22,3.08928490
+Stooge Sort,500,23,3.04618450
+Stooge Sort,500,24,3.08621270
+Stooge Sort,500,25,2.99380560
+Stooge Sort,500,26,3.04525160
+Stooge Sort,500,27,2.99001350
+Stooge Sort,500,28,3.01372060
+Stooge Sort,500,29,3.04892320
+Stooge Sort,500,30,3.06491460
+Stooge Sort,500,31,3.07178770
+Stooge Sort,500,32,3.01612990
+Stooge Sort,500,33,3.04438620
+Stooge Sort,500,34,3.10544180
+Stooge Sort,500,35,3.08372550
+Stooge Sort,500,36,3.14817810
+Stooge Sort,500,37,2.99763390
+Stooge Sort,500,38,2.99878080
+Stooge Sort,500,39,3.09530050
+Stooge Sort,500,40,2.99738630
+Stooge Sort,500,41,3.06586810
+Stooge Sort,500,42,3.04083040
+Stooge Sort,500,43,3.10910800
+Stooge Sort,500,44,3.02643740
+Stooge Sort,500,45,3.04277070
+Stooge Sort,500,46,3.04610340
+Stooge Sort,500,47,3.02797800
+Stooge Sort,500,48,3.04677610
+Stooge Sort,500,49,3.10505710
+Stooge Sort,500,50,3.07747500
+Stooge Sort,500,51,3.12176100
+Stooge Sort,500,52,3.04529110
+Stooge Sort,500,53,3.08432370
+Stooge Sort,500,54,3.08330120
+Stooge Sort,500,55,3.10884920
+Stooge Sort,500,56,3.11594470
+Stooge Sort,500,57,3.05141010
+Stooge Sort,500,58,3.01637910
+Stooge Sort,500,59,3.07784370
+Stooge Sort,500,60,3.03696840
+Stooge Sort,500,61,3.06194110
+Stooge Sort,500,62,3.08107840
+Stooge Sort,500,63,2.98061730
+Stooge Sort,500,64,3.01976180
+Stooge Sort,500,65,2.98663650
+Stooge Sort,500,66,3.05126910
+Stooge Sort,500,67,3.00666650
+Stooge Sort,500,68,3.05659840
+Stooge Sort,500,69,3.03008460
+Stooge Sort,500,70,3.01221150
+Stooge Sort,500,71,3.05156170
+Stooge Sort,500,72,3.01862990
+Stooge Sort,500,73,3.00312890
+Stooge Sort,500,74,3.06584760
+Stooge Sort,500,75,3.02602110
+Stooge Sort,500,76,3.04389720
+Stooge Sort,500,77,3.00257960
+Stooge Sort,500,78,3.01258220
+Stooge Sort,500,79,3.06739200
+Stooge Sort,500,80,2.98390010
+Stooge Sort,500,81,3.00617770
+Stooge Sort,500,82,2.98252060
+Stooge Sort,500,83,3.05722790
+Stooge Sort,500,84,2.97806860
+Stooge Sort,500,85,3.04831410
+Stooge Sort,500,86,3.03233450
+Stooge Sort,500,87,3.11324270
+Stooge Sort,500,88,3.01510580
+Stooge Sort,500,89,3.11349590
+Stooge Sort,500,90,3.19535470
+Stooge Sort,500,91,3.14599540
+Stooge Sort,500,92,3.16778150
+Stooge Sort,500,93,3.21993820
+Stooge Sort,500,94,3.15720410
+Stooge Sort,500,95,3.16851710
+Stooge Sort,500,96,3.13089980
+Stooge Sort,500,97,3.08642920
+Stooge Sort,500,98,3.06545980
+Stooge Sort,500,99,3.09112210
+Stooge Sort,500,100,3.04978450
+Stooge Sort,500,101,2.98564160
+Stooge Sort,500,102,3.07614810
+Stooge Sort,500,103,3.10616600
+Stooge Sort,500,104,3.11488910
+Stooge Sort,500,105,3.25441200
+Stooge Sort,500,106,3.19981350
+Stooge Sort,500,107,3.25675410
+Stooge Sort,500,108,3.33302480
+Stooge Sort,500,109,3.20115090
+Stooge Sort,500,110,3.25747860
+Stooge Sort,500,111,3.20786030
+Stooge Sort,500,112,3.26771750
+Stooge Sort,500,113,3.14483350
+Stooge Sort,500,114,3.20953280
+Stooge Sort,500,115,3.15605340
+Stooge Sort,500,116,3.14212190
+Stooge Sort,500,117,3.16759100
+Stooge Sort,500,118,3.21791750
+Stooge Sort,500,119,3.12289440
+Stooge Sort,500,120,3.19880580
+Stooge Sort,500,121,3.15512450
+Stooge Sort,500,122,3.19417660
+Stooge Sort,500,123,3.20122440
+Stooge Sort,500,124,3.22277460
+Stooge Sort,500,125,3.22040380
+Stooge Sort,500,126,3.22689250
+Stooge Sort,500,127,3.16603620
+Stooge Sort,500,128,3.14520080
+Stooge Sort,500,129,3.10955590
+Stooge Sort,500,130,3.12075560
+Stooge Sort,500,131,3.12092380
+Stooge Sort,500,132,3.05262980
+Stooge Sort,500,133,3.06151920
+Stooge Sort,500,134,3.08864670
+Stooge Sort,500,135,3.06716020
+Stooge Sort,500,136,3.18299530
+Stooge Sort,500,137,3.05585400
+Stooge Sort,500,138,3.09969500
+Stooge Sort,500,139,3.03527860
+Stooge Sort,500,140,3.08796430
+Stooge Sort,500,141,3.10121250
+Stooge Sort,500,142,3.09456990
+Stooge Sort,500,143,3.11957980
+Stooge Sort,500,144,3.11779810
+Stooge Sort,500,145,3.13396250
+Stooge Sort,500,146,3.12103060
+Stooge Sort,500,147,3.09794570
+Stooge Sort,500,148,3.14299660
+Stooge Sort,500,149,3.11376140
+Stooge Sort,500,150,3.16090880
+Stooge Sort,500,151,3.10451210
+Stooge Sort,500,152,3.21750130
+Stooge Sort,500,153,3.24352450
+Stooge Sort,500,154,3.24073950
+Stooge Sort,500,155,3.24349710
+Stooge Sort,500,156,3.24390810
+Stooge Sort,500,157,3.24617540
+Stooge Sort,500,158,3.25442630
+Stooge Sort,500,159,3.27200700
+Stooge Sort,500,160,3.24700110
+Stooge Sort,500,161,3.28903560
+Stooge Sort,500,162,3.30251690
+Stooge Sort,500,163,3.28391700
+Stooge Sort,500,164,3.28992300
+Stooge Sort,500,165,3.22989460
+Stooge Sort,500,166,3.29576420
+Stooge Sort,500,167,3.30526430
+Stooge Sort,500,168,3.30622560
+Stooge Sort,500,169,3.19276450
+Stooge Sort,500,170,3.11925070
+Stooge Sort,500,171,3.19489230
+Stooge Sort,500,172,3.17251210
+Stooge Sort,500,173,3.13811330
+Stooge Sort,500,174,3.15808460
+Stooge Sort,500,175,3.14523270
+Stooge Sort,500,176,3.12756290
+Stooge Sort,500,177,3.09953910
+Stooge Sort,500,178,3.08497480
+Stooge Sort,500,179,3.14975050
+Stooge Sort,500,180,3.07112960
+Stooge Sort,500,181,3.15722580
+Stooge Sort,500,182,3.08505970
+Stooge Sort,500,183,3.08782230
+Stooge Sort,500,184,3.13376080
+Stooge Sort,500,185,3.03256890
+Stooge Sort,500,186,3.07416430
+Stooge Sort,500,187,3.09226880
+Stooge Sort,500,188,3.09332180
+Stooge Sort,500,189,3.12092100
+Stooge Sort,500,190,3.09657000
+Stooge Sort,500,191,3.03191620
+Stooge Sort,500,192,2.98464340
+Stooge Sort,500,193,3.02965530
+Stooge Sort,500,194,3.08120820
+Stooge Sort,500,195,3.10020720
+Stooge Sort,500,196,3.02944360
+Stooge Sort,500,197,3.05926900
+Stooge Sort,500,198,2.96506750
+Stooge Sort,500,199,3.03535320
+Stooge Sort,500,200,3.14380170
+Stooge Sort,500,201,3.10379560
+Stooge Sort,500,202,3.08638100
+Stooge Sort,500,203,3.09554300
+Stooge Sort,500,204,3.07676620
+Stooge Sort,500,205,3.06921440
+Stooge Sort,500,206,3.06561280
+Stooge Sort,500,207,3.03925170
+Stooge Sort,500,208,3.10344760
+Stooge Sort,500,209,3.08329290
+Stooge Sort,500,210,3.21300550
+Stooge Sort,500,211,3.17765140
+Stooge Sort,500,212,3.20504070
+Stooge Sort,500,213,3.22359900
+Stooge Sort,500,214,3.26435800
+Stooge Sort,500,215,3.17119700
+Stooge Sort,500,216,3.32807650
+Stooge Sort,500,217,3.38448440
+Stooge Sort,500,218,3.35929200
+Stooge Sort,500,219,3.32162370
+Stooge Sort,500,220,3.37329510
+Stooge Sort,500,221,3.30867470
+Stooge Sort,500,222,3.31583170
+Stooge Sort,500,223,3.32006960
+Stooge Sort,500,224,3.25104690
+Stooge Sort,500,225,3.26884800
+Stooge Sort,500,226,3.20494820
+Stooge Sort,500,227,3.22370870
+Stooge Sort,500,228,3.27411190
+Stooge Sort,500,229,3.27471030
+Stooge Sort,500,230,3.19701060
+Stooge Sort,500,231,3.26227100
+Stooge Sort,500,232,3.27336060
+Stooge Sort,500,233,3.10806720
+Stooge Sort,500,234,3.02099500
+Stooge Sort,500,235,3.06206750
+Stooge Sort,500,236,3.08703430
+Stooge Sort,500,237,3.14200540
+Stooge Sort,500,238,3.07113170
+Stooge Sort,500,239,3.08894580
+Stooge Sort,500,240,3.18024520
+Stooge Sort,500,241,3.13317200
+Stooge Sort,500,242,3.21765510
+Stooge Sort,500,243,3.15190740
+Stooge Sort,500,244,3.19106230
+Stooge Sort,500,245,3.18099420
+Stooge Sort,500,246,3.25608920
+Stooge Sort,500,247,3.21887480
+Stooge Sort,500,248,3.17517530
+Stooge Sort,500,249,3.13788600
+Stooge Sort,500,250,3.06688780
+Stooge Sort,500,251,3.07039230
+Stooge Sort,500,252,3.08799540
+Stooge Sort,500,253,3.03516700
+Stooge Sort,500,254,3.09221630
+Stooge Sort,500,255,3.02888020
+Stooge Sort,500,256,3.04404290
+Stooge Sort,500,257,2.96763940
+Stooge Sort,500,258,3.02626250
+Stooge Sort,500,259,3.02213550
+Stooge Sort,500,260,3.03550600
+Stooge Sort,500,261,3.07503430
+Stooge Sort,500,262,2.99937960
+Stooge Sort,500,263,3.05394840
+Stooge Sort,500,264,3.02652390
+Stooge Sort,500,265,2.95757150
+Stooge Sort,500,266,3.08720050
+Stooge Sort,500,267,2.99474930
+Stooge Sort,500,268,3.07468270
+Stooge Sort,500,269,3.04711120
+Stooge Sort,500,270,3.08168320
+Stooge Sort,500,271,3.04307030
+Stooge Sort,500,272,3.05529100
+Stooge Sort,500,273,3.00277500
+Stooge Sort,500,274,3.00527400
+Stooge Sort,500,275,2.98925750
+Stooge Sort,500,276,3.02172950
+Stooge Sort,500,277,3.01609740
+Stooge Sort,500,278,2.99201270
+Stooge Sort,500,279,2.95498080
+Stooge Sort,500,280,3.03289810
+Stooge Sort,500,281,3.08123170
+Stooge Sort,500,282,3.01883160
+Stooge Sort,500,283,3.03974490
+Stooge Sort,500,284,3.03082890
+Stooge Sort,500,285,3.01036320
+Stooge Sort,500,286,3.08624690
+Stooge Sort,500,287,3.04471590
+Stooge Sort,500,288,3.01463280
+Stooge Sort,500,289,3.00417810
+Stooge Sort,500,290,3.01424860
+Stooge Sort,500,291,2.96493760
+Stooge Sort,500,292,3.01581550
+Stooge Sort,500,293,3.04736740
+Stooge Sort,500,294,2.96707230
+Stooge Sort,500,295,3.00886990
+Stooge Sort,500,296,3.02903620
+Stooge Sort,500,297,3.04076890
+Stooge Sort,500,298,3.01451170
+Stooge Sort,500,299,2.97061280
+Stooge Sort,500,300,3.13281820
+Stooge Sort,500,301,3.04644590
+Stooge Sort,500,302,3.06487700
+Stooge Sort,500,303,3.08136170
+Stooge Sort,500,304,3.10199830
+Stooge Sort,500,305,3.06215510
+Stooge Sort,500,306,3.10555920
+Stooge Sort,500,307,2.99695680
+Stooge Sort,500,308,3.06025090
+Stooge Sort,500,309,3.11684090
+Stooge Sort,500,310,3.11639000
+Stooge Sort,500,311,3.07401710
+Stooge Sort,500,312,3.14387330
+Stooge Sort,500,313,3.07162540
+Stooge Sort,500,314,3.09542720
+Stooge Sort,500,315,3.04703140
+Stooge Sort,500,316,3.09276270
+Stooge Sort,500,317,3.06549440
+Stooge Sort,500,318,3.13768700
+Stooge Sort,500,319,3.14948370
+Stooge Sort,500,320,3.12180320
+Stooge Sort,500,321,3.07545290
+Stooge Sort,500,322,3.07942870
+Stooge Sort,500,323,3.11824240
+Stooge Sort,500,324,3.10087880
+Stooge Sort,500,325,3.09807570
+Stooge Sort,500,326,3.12843340
+Stooge Sort,500,327,3.08435300
+Stooge Sort,500,328,3.10977000
+Stooge Sort,500,329,3.07388350
+Stooge Sort,500,330,3.04475800
+Stooge Sort,500,331,3.00940120
+Stooge Sort,500,332,3.15669900
+Stooge Sort,500,333,3.09660960
+Stooge Sort,500,334,3.19524690
+Stooge Sort,500,335,3.09032030
+Stooge Sort,500,336,3.17033620
+Stooge Sort,500,337,3.40017130
+Stooge Sort,500,338,3.41854490
+Stooge Sort,500,339,3.47282320
+Stooge Sort,500,340,3.36604770
+Stooge Sort,500,341,3.32923590
+Stooge Sort,500,342,3.36539350
+Stooge Sort,500,343,3.35522050
+Stooge Sort,500,344,3.39987050
+Stooge Sort,500,345,3.27276450
+Stooge Sort,500,346,3.25719700
+Stooge Sort,500,347,3.28653370
+Stooge Sort,500,348,3.28646360
+Stooge Sort,500,349,3.32001060
+Stooge Sort,500,350,3.33007990
+Stooge Sort,500,351,3.31230210
+Stooge Sort,500,352,3.30470250
+Stooge Sort,500,353,3.33245370
+Stooge Sort,500,354,3.25687350
+Stooge Sort,500,355,3.28611710
+Stooge Sort,500,356,3.34913370
+Stooge Sort,500,357,3.34831220
+Stooge Sort,500,358,3.36435590
+Stooge Sort,500,359,3.34020130
+Stooge Sort,500,360,3.51682600
+Stooge Sort,500,361,3.46469350
+Stooge Sort,500,362,3.42895830
+Stooge Sort,500,363,3.48966130
+Stooge Sort,500,364,3.39050780
+Stooge Sort,500,365,3.42456620
+Stooge Sort,500,366,3.45537620
+Stooge Sort,500,367,3.32350490
+Stooge Sort,500,368,3.16890310
+Stooge Sort,500,369,3.03798870
+Stooge Sort,500,370,3.06989290
+Stooge Sort,500,371,2.99912970
+Stooge Sort,500,372,3.07246360
+Stooge Sort,500,373,3.03002050
+Stooge Sort,500,374,3.08464550
+Stooge Sort,500,375,3.08386060
+Stooge Sort,500,376,3.13115940
+Stooge Sort,500,377,3.14801360
+Stooge Sort,500,378,3.10551340
+Stooge Sort,500,379,3.16018540
+Stooge Sort,500,380,3.15185210
+Stooge Sort,500,381,3.10069870
+Stooge Sort,500,382,3.16349970
+Stooge Sort,500,383,3.11370840
+Stooge Sort,500,384,3.07844530
+Stooge Sort,500,385,3.04676970
+Stooge Sort,500,386,3.08149510
+Stooge Sort,500,387,3.03066710
+Stooge Sort,500,388,3.09674420
+Stooge Sort,500,389,3.15108730
+Stooge Sort,500,390,3.07224660
+Stooge Sort,500,391,3.04059510
+Stooge Sort,500,392,3.14320660
+Stooge Sort,500,393,3.11725670
+Stooge Sort,500,394,3.11552080
+Stooge Sort,500,395,3.09932560
+Stooge Sort,500,396,3.18688670
+Stooge Sort,500,397,3.18997940
+Stooge Sort,500,398,3.12938190
+Stooge Sort,500,399,3.19684070
+Stooge Sort,500,400,3.16307580
+Stooge Sort,500,401,3.16712920
+Stooge Sort,500,402,3.15965050
+Stooge Sort,500,403,3.14672210
+Stooge Sort,500,404,3.12324920
+Stooge Sort,500,405,3.09190900
+Stooge Sort,500,406,3.05615880
+Stooge Sort,500,407,3.09842450
+Stooge Sort,500,408,3.12311150
+Stooge Sort,500,409,3.08851720
+Stooge Sort,500,410,3.11644730
+Stooge Sort,500,411,3.10715440
+Stooge Sort,500,412,3.15223900
+Stooge Sort,500,413,3.18792340
+Stooge Sort,500,414,3.12593060
+Stooge Sort,500,415,3.15111900
+Stooge Sort,500,416,3.12677270
+Stooge Sort,500,417,3.09831980
+Stooge Sort,500,418,3.07422620
+Stooge Sort,500,419,3.11201840
+Stooge Sort,500,420,3.08937340
+Stooge Sort,500,421,3.08849470
+Stooge Sort,500,422,3.13102640
+Stooge Sort,500,423,3.10845070
+Stooge Sort,500,424,3.08875460
+Stooge Sort,500,425,3.16520080
+Stooge Sort,500,426,3.14186610
+Stooge Sort,500,427,3.12202490
+Stooge Sort,500,428,3.17182890
+Stooge Sort,500,429,3.13056840
+Stooge Sort,500,430,3.15486060
+Stooge Sort,500,431,3.15887840
+Stooge Sort,500,432,3.12616620
+Stooge Sort,500,433,3.07799010
+Stooge Sort,500,434,3.06604860
+Stooge Sort,500,435,3.06343420
+Stooge Sort,500,436,3.04859140
+Stooge Sort,500,437,3.08101890
+Stooge Sort,500,438,3.05721620
+Stooge Sort,500,439,3.07812750
+Stooge Sort,500,440,3.15385300
+Stooge Sort,500,441,3.11266670
+Stooge Sort,500,442,3.09030840
+Stooge Sort,500,443,3.06630040
+Stooge Sort,500,444,3.12471920
+Stooge Sort,500,445,3.15436350
+Stooge Sort,500,446,3.15335000
+Stooge Sort,500,447,3.13663660
+Stooge Sort,500,448,3.11078680
+Stooge Sort,500,449,3.13313910
+Stooge Sort,500,450,3.14362790
+Stooge Sort,500,451,3.13005930
+Stooge Sort,500,452,3.14737650
+Stooge Sort,500,453,3.13758950
+Stooge Sort,500,454,3.18109260
+Stooge Sort,500,455,3.21172120
+Stooge Sort,500,456,3.21680790
+Stooge Sort,500,457,3.06761250
+Stooge Sort,500,458,3.11626180
+Stooge Sort,500,459,3.12057860
+Stooge Sort,500,460,3.07821430
+Stooge Sort,500,461,3.10194550
+Stooge Sort,500,462,3.11318350
+Stooge Sort,500,463,3.07704230
+Stooge Sort,500,464,3.15831460
+Stooge Sort,500,465,3.08714280
+Stooge Sort,500,466,3.07591050
+Stooge Sort,500,467,3.12278250
+Stooge Sort,500,468,3.13634650
+Stooge Sort,500,469,3.15465830
+Stooge Sort,500,470,3.16041640
+Stooge Sort,500,471,3.13400050
+Stooge Sort,500,472,3.19070690
+Stooge Sort,500,473,3.18035000
+Stooge Sort,500,474,3.14590720
+Stooge Sort,500,475,3.17254410
+Stooge Sort,500,476,3.10408370
+Stooge Sort,500,477,3.10623860
+Stooge Sort,500,478,3.09495700
+Stooge Sort,500,479,3.09123350
+Stooge Sort,500,480,3.08274390
+Stooge Sort,500,481,3.07317480
+Stooge Sort,500,482,3.05730810
+Stooge Sort,500,483,3.07750020
+Stooge Sort,500,484,3.10390230
+Stooge Sort,500,485,3.13393490
+Stooge Sort,500,486,3.09512620
+Stooge Sort,500,487,3.08930380
+Stooge Sort,500,488,3.20931870
+Stooge Sort,500,489,3.15376660
+Stooge Sort,500,490,3.16368800
+Stooge Sort,500,491,3.17770020
+Stooge Sort,500,492,3.16357560
+Stooge Sort,500,493,3.14672470
+Stooge Sort,500,494,3.16645150
+Stooge Sort,500,495,3.19152060
+Stooge Sort,500,496,3.19818180
+Stooge Sort,500,497,3.09981730
+Stooge Sort,500,498,3.13202980
+Stooge Sort,500,499,3.09450860
+Stooge Sort,500,500,2.95530280
+Strand Sort,500,1,0.00174560
+Strand Sort,500,2,0.00159570
+Strand Sort,500,3,0.00215710
+Strand Sort,500,4,0.00238860
+Strand Sort,500,5,0.00222470
+Strand Sort,500,6,0.00249080
+Strand Sort,500,7,0.00221810
+Strand Sort,500,8,0.00229110
+Strand Sort,500,9,0.00156130
+Strand Sort,500,10,0.00142990
+Strand Sort,500,11,0.00231280
+Strand Sort,500,12,0.00222640
+Strand Sort,500,13,0.00181540
+Strand Sort,500,14,0.00174510
+Strand Sort,500,15,0.00234970
+Strand Sort,500,16,0.00221730
+Strand Sort,500,17,0.00261100
+Strand Sort,500,18,0.00196550
+Strand Sort,500,19,0.00219840
+Strand Sort,500,20,0.00218780
+Strand Sort,500,21,0.00195610
+Strand Sort,500,22,0.00133040
+Strand Sort,500,23,0.00132430
+Strand Sort,500,24,0.00135060
+Strand Sort,500,25,0.00132590
+Strand Sort,500,26,0.00172620
+Strand Sort,500,27,0.00200150
+Strand Sort,500,28,0.00235370
+Strand Sort,500,29,0.00173090
+Strand Sort,500,30,0.00228850
+Strand Sort,500,31,0.00249260
+Strand Sort,500,32,0.00171340
+Strand Sort,500,33,0.00222440
+Strand Sort,500,34,0.00200900
+Strand Sort,500,35,0.00234150
+Strand Sort,500,36,0.00137910
+Strand Sort,500,37,0.00173710
+Strand Sort,500,38,0.00127550
+Strand Sort,500,39,0.00126610
+Strand Sort,500,40,0.00130500
+Strand Sort,500,41,0.00255440
+Strand Sort,500,42,0.00168430
+Strand Sort,500,43,0.00243170
+Strand Sort,500,44,0.00262540
+Strand Sort,500,45,0.00196360
+Strand Sort,500,46,0.00227950
+Strand Sort,500,47,0.00136150
+Strand Sort,500,48,0.00221010
+Strand Sort,500,49,0.00234380
+Strand Sort,500,50,0.00214380
+Strand Sort,500,51,0.00216690
+Strand Sort,500,52,0.00143570
+Strand Sort,500,53,0.00230550
+Strand Sort,500,54,0.00177530
+Strand Sort,500,55,0.00229750
+Strand Sort,500,56,0.00212940
+Strand Sort,500,57,0.00234870
+Strand Sort,500,58,0.00172670
+Strand Sort,500,59,0.00219870
+Strand Sort,500,60,0.00231000
+Strand Sort,500,61,0.00246100
+Strand Sort,500,62,0.00235070
+Strand Sort,500,63,0.00199970
+Strand Sort,500,64,0.00233510
+Strand Sort,500,65,0.00257830
+Strand Sort,500,66,0.00124280
+Strand Sort,500,67,0.00184750
+Strand Sort,500,68,0.00232240
+Strand Sort,500,69,0.00168340
+Strand Sort,500,70,0.00193900
+Strand Sort,500,71,0.00148810
+Strand Sort,500,72,0.00227610
+Strand Sort,500,73,0.00121060
+Strand Sort,500,74,0.00144470
+Strand Sort,500,75,0.00240660
+Strand Sort,500,76,0.00183940
+Strand Sort,500,77,0.00225560
+Strand Sort,500,78,0.00153350
+Strand Sort,500,79,0.00192650
+Strand Sort,500,80,0.00204410
+Strand Sort,500,81,0.00228330
+Strand Sort,500,82,0.00236510
+Strand Sort,500,83,0.00120080
+Strand Sort,500,84,0.00198650
+Strand Sort,500,85,0.00123400
+Strand Sort,500,86,0.00131910
+Strand Sort,500,87,0.00219170
+Strand Sort,500,88,0.00139880
+Strand Sort,500,89,0.00247630
+Strand Sort,500,90,0.00124720
+Strand Sort,500,91,0.00162270
+Strand Sort,500,92,0.00169440
+Strand Sort,500,93,0.00125470
+Strand Sort,500,94,0.00183840
+Strand Sort,500,95,0.00146310
+Strand Sort,500,96,0.00219930
+Strand Sort,500,97,0.00197090
+Strand Sort,500,98,0.00137010
+Strand Sort,500,99,0.00241510
+Strand Sort,500,100,0.00136910
+Strand Sort,500,101,0.00173160
+Strand Sort,500,102,0.00227340
+Strand Sort,500,103,0.00198700
+Strand Sort,500,104,0.00138590
+Strand Sort,500,105,0.00181110
+Strand Sort,500,106,0.00191200
+Strand Sort,500,107,0.00180280
+Strand Sort,500,108,0.00127580
+Strand Sort,500,109,0.00226420
+Strand Sort,500,110,0.00221790
+Strand Sort,500,111,0.00123920
+Strand Sort,500,112,0.00249010
+Strand Sort,500,113,0.00225530
+Strand Sort,500,114,0.00150880
+Strand Sort,500,115,0.00176980
+Strand Sort,500,116,0.00231300
+Strand Sort,500,117,0.00239350
+Strand Sort,500,118,0.00142570
+Strand Sort,500,119,0.00197240
+Strand Sort,500,120,0.00229500
+Strand Sort,500,121,0.00215160
+Strand Sort,500,122,0.00177550
+Strand Sort,500,123,0.00162100
+Strand Sort,500,124,0.00225990
+Strand Sort,500,125,0.00138210
+Strand Sort,500,126,0.00212030
+Strand Sort,500,127,0.00234960
+Strand Sort,500,128,0.00122950
+Strand Sort,500,129,0.00172010
+Strand Sort,500,130,0.00192890
+Strand Sort,500,131,0.00221890
+Strand Sort,500,132,0.00228270
+Strand Sort,500,133,0.00219930
+Strand Sort,500,134,0.00210550
+Strand Sort,500,135,0.00192690
+Strand Sort,500,136,0.00219020
+Strand Sort,500,137,0.00224520
+Strand Sort,500,138,0.00139510
+Strand Sort,500,139,0.00227400
+Strand Sort,500,140,0.00221630
+Strand Sort,500,141,0.00232500
+Strand Sort,500,142,0.00238870
+Strand Sort,500,143,0.00171900
+Strand Sort,500,144,0.00254460
+Strand Sort,500,145,0.00156140
+Strand Sort,500,146,0.00156390
+Strand Sort,500,147,0.00244120
+Strand Sort,500,148,0.00164570
+Strand Sort,500,149,0.00228280
+Strand Sort,500,150,0.00231540
+Strand Sort,500,151,0.00204760
+Strand Sort,500,152,0.00220960
+Strand Sort,500,153,0.00122050
+Strand Sort,500,154,0.00216470
+Strand Sort,500,155,0.00216260
+Strand Sort,500,156,0.00229590
+Strand Sort,500,157,0.00193580
+Strand Sort,500,158,0.00231120
+Strand Sort,500,159,0.00205700
+Strand Sort,500,160,0.00217510
+Strand Sort,500,161,0.00137220
+Strand Sort,500,162,0.00125890
+Strand Sort,500,163,0.00249390
+Strand Sort,500,164,0.00222990
+Strand Sort,500,165,0.00142120
+Strand Sort,500,166,0.00217770
+Strand Sort,500,167,0.00223200
+Strand Sort,500,168,0.00132960
+Strand Sort,500,169,0.00137580
+Strand Sort,500,170,0.00161890
+Strand Sort,500,171,0.00220020
+Strand Sort,500,172,0.00127510
+Strand Sort,500,173,0.00182430
+Strand Sort,500,174,0.00170640
+Strand Sort,500,175,0.00237390
+Strand Sort,500,176,0.00207680
+Strand Sort,500,177,0.00220780
+Strand Sort,500,178,0.00197490
+Strand Sort,500,179,0.00166080
+Strand Sort,500,180,0.00235130
+Strand Sort,500,181,0.00216970
+Strand Sort,500,182,0.00233990
+Strand Sort,500,183,0.00186770
+Strand Sort,500,184,0.00222630
+Strand Sort,500,185,0.00230410
+Strand Sort,500,186,0.00129160
+Strand Sort,500,187,0.00237520
+Strand Sort,500,188,0.00220430
+Strand Sort,500,189,0.00147170
+Strand Sort,500,190,0.00123150
+Strand Sort,500,191,0.00269260
+Strand Sort,500,192,0.00242950
+Strand Sort,500,193,0.00232920
+Strand Sort,500,194,0.00207200
+Strand Sort,500,195,0.00223080
+Strand Sort,500,196,0.00263250
+Strand Sort,500,197,0.00242430
+Strand Sort,500,198,0.00208130
+Strand Sort,500,199,0.00231210
+Strand Sort,500,200,0.00266060
+Strand Sort,500,201,0.00197980
+Strand Sort,500,202,0.00225440
+Strand Sort,500,203,0.00232530
+Strand Sort,500,204,0.00185050
+Strand Sort,500,205,0.00231650
+Strand Sort,500,206,0.00236070
+Strand Sort,500,207,0.00146620
+Strand Sort,500,208,0.00219380
+Strand Sort,500,209,0.00191140
+Strand Sort,500,210,0.00244400
+Strand Sort,500,211,0.00174090
+Strand Sort,500,212,0.00189500
+Strand Sort,500,213,0.00254470
+Strand Sort,500,214,0.00208540
+Strand Sort,500,215,0.00217590
+Strand Sort,500,216,0.00204350
+Strand Sort,500,217,0.00208180
+Strand Sort,500,218,0.00203590
+Strand Sort,500,219,0.00223390
+Strand Sort,500,220,0.00144960
+Strand Sort,500,221,0.00224490
+Strand Sort,500,222,0.00165810
+Strand Sort,500,223,0.00216430
+Strand Sort,500,224,0.00189480
+Strand Sort,500,225,0.00212480
+Strand Sort,500,226,0.00227260
+Strand Sort,500,227,0.00252540
+Strand Sort,500,228,0.00238850
+Strand Sort,500,229,0.00232230
+Strand Sort,500,230,0.00217400
+Strand Sort,500,231,0.00168950
+Strand Sort,500,232,0.00198200
+Strand Sort,500,233,0.00181470
+Strand Sort,500,234,0.00223760
+Strand Sort,500,235,0.00206590
+Strand Sort,500,236,0.00230510
+Strand Sort,500,237,0.00232740
+Strand Sort,500,238,0.00184910
+Strand Sort,500,239,0.00210240
+Strand Sort,500,240,0.00230470
+Strand Sort,500,241,0.00237080
+Strand Sort,500,242,0.00226500
+Strand Sort,500,243,0.00201940
+Strand Sort,500,244,0.00201900
+Strand Sort,500,245,0.00189210
+Strand Sort,500,246,0.00222530
+Strand Sort,500,247,0.00180840
+Strand Sort,500,248,0.00175630
+Strand Sort,500,249,0.00239500
+Strand Sort,500,250,0.00228300
+Strand Sort,500,251,0.00223860
+Strand Sort,500,252,0.00210690
+Strand Sort,500,253,0.00225770
+Strand Sort,500,254,0.00237370
+Strand Sort,500,255,0.00227760
+Strand Sort,500,256,0.00250430
+Strand Sort,500,257,0.00136370
+Strand Sort,500,258,0.00223820
+Strand Sort,500,259,0.00236210
+Strand Sort,500,260,0.00128060
+Strand Sort,500,261,0.00134450
+Strand Sort,500,262,0.00219870
+Strand Sort,500,263,0.00245290
+Strand Sort,500,264,0.00217220
+Strand Sort,500,265,0.00191080
+Strand Sort,500,266,0.00221320
+Strand Sort,500,267,0.00229140
+Strand Sort,500,268,0.00189940
+Strand Sort,500,269,0.00229690
+Strand Sort,500,270,0.00221460
+Strand Sort,500,271,0.00170750
+Strand Sort,500,272,0.00213160
+Strand Sort,500,273,0.00172210
+Strand Sort,500,274,0.00222640
+Strand Sort,500,275,0.00130440
+Strand Sort,500,276,0.00190260
+Strand Sort,500,277,0.00230130
+Strand Sort,500,278,0.00155800
+Strand Sort,500,279,0.00232120
+Strand Sort,500,280,0.00215030
+Strand Sort,500,281,0.00125600
+Strand Sort,500,282,0.00218560
+Strand Sort,500,283,0.00140560
+Strand Sort,500,284,0.00192650
+Strand Sort,500,285,0.00125940
+Strand Sort,500,286,0.00252850
+Strand Sort,500,287,0.00223270
+Strand Sort,500,288,0.00131100
+Strand Sort,500,289,0.00214740
+Strand Sort,500,290,0.00249400
+Strand Sort,500,291,0.00186990
+Strand Sort,500,292,0.00168800
+Strand Sort,500,293,0.00237610
+Strand Sort,500,294,0.00226500
+Strand Sort,500,295,0.00146420
+Strand Sort,500,296,0.00224530
+Strand Sort,500,297,0.00201960
+Strand Sort,500,298,0.00204380
+Strand Sort,500,299,0.00252170
+Strand Sort,500,300,0.00248500
+Strand Sort,500,301,0.00181760
+Strand Sort,500,302,0.00221410
+Strand Sort,500,303,0.00222160
+Strand Sort,500,304,0.00242800
+Strand Sort,500,305,0.00228980
+Strand Sort,500,306,0.00196960
+Strand Sort,500,307,0.00229050
+Strand Sort,500,308,0.00223730
+Strand Sort,500,309,0.00164840
+Strand Sort,500,310,0.00211310
+Strand Sort,500,311,0.00129650
+Strand Sort,500,312,0.00195510
+Strand Sort,500,313,0.00233420
+Strand Sort,500,314,0.00148700
+Strand Sort,500,315,0.00199440
+Strand Sort,500,316,0.00170420
+Strand Sort,500,317,0.00227380
+Strand Sort,500,318,0.00224520
+Strand Sort,500,319,0.00226950
+Strand Sort,500,320,0.00215000
+Strand Sort,500,321,0.00185870
+Strand Sort,500,322,0.00217210
+Strand Sort,500,323,0.00219090
+Strand Sort,500,324,0.00223400
+Strand Sort,500,325,0.00219290
+Strand Sort,500,326,0.00153710
+Strand Sort,500,327,0.00213790
+Strand Sort,500,328,0.00131920
+Strand Sort,500,329,0.00136660
+Strand Sort,500,330,0.00210070
+Strand Sort,500,331,0.00128500
+Strand Sort,500,332,0.00142180
+Strand Sort,500,333,0.00216640
+Strand Sort,500,334,0.00222800
+Strand Sort,500,335,0.00145230
+Strand Sort,500,336,0.00178880
+Strand Sort,500,337,0.00245770
+Strand Sort,500,338,0.00207000
+Strand Sort,500,339,0.00150530
+Strand Sort,500,340,0.00219150
+Strand Sort,500,341,0.00217340
+Strand Sort,500,342,0.00157990
+Strand Sort,500,343,0.00205870
+Strand Sort,500,344,0.00211920
+Strand Sort,500,345,0.00160170
+Strand Sort,500,346,0.00232960
+Strand Sort,500,347,0.00250650
+Strand Sort,500,348,0.00222390
+Strand Sort,500,349,0.00227440
+Strand Sort,500,350,0.00218400
+Strand Sort,500,351,0.00251080
+Strand Sort,500,352,0.00135880
+Strand Sort,500,353,0.00141850
+Strand Sort,500,354,0.00217400
+Strand Sort,500,355,0.00151680
+Strand Sort,500,356,0.00162180
+Strand Sort,500,357,0.00244160
+Strand Sort,500,358,0.00141220
+Strand Sort,500,359,0.00203110
+Strand Sort,500,360,0.00172900
+Strand Sort,500,361,0.00222240
+Strand Sort,500,362,0.00129230
+Strand Sort,500,363,0.00168400
+Strand Sort,500,364,0.00132120
+Strand Sort,500,365,0.00238860
+Strand Sort,500,366,0.00195820
+Strand Sort,500,367,0.00185990
+Strand Sort,500,368,0.00218490
+Strand Sort,500,369,0.00178000
+Strand Sort,500,370,0.00144230
+Strand Sort,500,371,0.00122550
+Strand Sort,500,372,0.00138760
+Strand Sort,500,373,0.00178850
+Strand Sort,500,374,0.00141160
+Strand Sort,500,375,0.00179470
+Strand Sort,500,376,0.00212050
+Strand Sort,500,377,0.00218260
+Strand Sort,500,378,0.00146680
+Strand Sort,500,379,0.00247780
+Strand Sort,500,380,0.00226120
+Strand Sort,500,381,0.00163100
+Strand Sort,500,382,0.00258090
+Strand Sort,500,383,0.00142580
+Strand Sort,500,384,0.00231090
+Strand Sort,500,385,0.00165220
+Strand Sort,500,386,0.00230030
+Strand Sort,500,387,0.00228820
+Strand Sort,500,388,0.00230610
+Strand Sort,500,389,0.00150290
+Strand Sort,500,390,0.00245620
+Strand Sort,500,391,0.00209980
+Strand Sort,500,392,0.00154100
+Strand Sort,500,393,0.00263440
+Strand Sort,500,394,0.00140590
+Strand Sort,500,395,0.00142930
+Strand Sort,500,396,0.00219130
+Strand Sort,500,397,0.00221570
+Strand Sort,500,398,0.00245370
+Strand Sort,500,399,0.00222110
+Strand Sort,500,400,0.00153340
+Strand Sort,500,401,0.00250360
+Strand Sort,500,402,0.00180120
+Strand Sort,500,403,0.00215700
+Strand Sort,500,404,0.00214160
+Strand Sort,500,405,0.00138010
+Strand Sort,500,406,0.00191710
+Strand Sort,500,407,0.00164540
+Strand Sort,500,408,0.00258850
+Strand Sort,500,409,0.00222990
+Strand Sort,500,410,0.00229600
+Strand Sort,500,411,0.00233200
+Strand Sort,500,412,0.00183040
+Strand Sort,500,413,0.00233080
+Strand Sort,500,414,0.00170240
+Strand Sort,500,415,0.00224650
+Strand Sort,500,416,0.00250380
+Strand Sort,500,417,0.00192750
+Strand Sort,500,418,0.00223670
+Strand Sort,500,419,0.00173020
+Strand Sort,500,420,0.00176980
+Strand Sort,500,421,0.00238430
+Strand Sort,500,422,0.00245460
+Strand Sort,500,423,0.00159460
+Strand Sort,500,424,0.00226690
+Strand Sort,500,425,0.00173520
+Strand Sort,500,426,0.00210720
+Strand Sort,500,427,0.00222130
+Strand Sort,500,428,0.00194100
+Strand Sort,500,429,0.00199770
+Strand Sort,500,430,0.00176210
+Strand Sort,500,431,0.00227830
+Strand Sort,500,432,0.00122140
+Strand Sort,500,433,0.00197600
+Strand Sort,500,434,0.00225540
+Strand Sort,500,435,0.00179240
+Strand Sort,500,436,0.00216870
+Strand Sort,500,437,0.00236020
+Strand Sort,500,438,0.00230680
+Strand Sort,500,439,0.00214720
+Strand Sort,500,440,0.00260040
+Strand Sort,500,441,0.00210520
+Strand Sort,500,442,0.00240870
+Strand Sort,500,443,0.00156310
+Strand Sort,500,444,0.00199760
+Strand Sort,500,445,0.00219690
+Strand Sort,500,446,0.00228170
+Strand Sort,500,447,0.00236940
+Strand Sort,500,448,0.00208140
+Strand Sort,500,449,0.00190690
+Strand Sort,500,450,0.00234250
+Strand Sort,500,451,0.00195620
+Strand Sort,500,452,0.00231150
+Strand Sort,500,453,0.00214560
+Strand Sort,500,454,0.00178590
+Strand Sort,500,455,0.00209990
+Strand Sort,500,456,0.00243320
+Strand Sort,500,457,0.00201740
+Strand Sort,500,458,0.00191580
+Strand Sort,500,459,0.00224720
+Strand Sort,500,460,0.00182250
+Strand Sort,500,461,0.00183500
+Strand Sort,500,462,0.00254610
+Strand Sort,500,463,0.00183160
+Strand Sort,500,464,0.00211960
+Strand Sort,500,465,0.00197750
+Strand Sort,500,466,0.00227200
+Strand Sort,500,467,0.00205500
+Strand Sort,500,468,0.00169180
+Strand Sort,500,469,0.00242310
+Strand Sort,500,470,0.00198080
+Strand Sort,500,471,0.00219560
+Strand Sort,500,472,0.00131120
+Strand Sort,500,473,0.00242680
+Strand Sort,500,474,0.00147530
+Strand Sort,500,475,0.00174380
+Strand Sort,500,476,0.00236430
+Strand Sort,500,477,0.00274560
+Strand Sort,500,478,0.00215890
+Strand Sort,500,479,0.00219230
+Strand Sort,500,480,0.00205800
+Strand Sort,500,481,0.00200230
+Strand Sort,500,482,0.00243170
+Strand Sort,500,483,0.00238180
+Strand Sort,500,484,0.00270340
+Strand Sort,500,485,0.00225950
+Strand Sort,500,486,0.00229120
+Strand Sort,500,487,0.00246130
+Strand Sort,500,488,0.00207050
+Strand Sort,500,489,0.00163780
+Strand Sort,500,490,0.00245380
+Strand Sort,500,491,0.00195930
+Strand Sort,500,492,0.00232750
+Strand Sort,500,493,0.00253220
+Strand Sort,500,494,0.00175560
+Strand Sort,500,495,0.00207730
+Strand Sort,500,496,0.00179880
+Strand Sort,500,497,0.00226410
+Strand Sort,500,498,0.00134560
+Strand Sort,500,499,0.00122310
+Strand Sort,500,500,0.00157920
+Tim Sort,500,1,0.00098420
+Tim Sort,500,2,0.00103440
+Tim Sort,500,3,0.00107240
+Tim Sort,500,4,0.00098470
+Tim Sort,500,5,0.00096790
+Tim Sort,500,6,0.00097110
+Tim Sort,500,7,0.00099340
+Tim Sort,500,8,0.00063440
+Tim Sort,500,9,0.00080540
+Tim Sort,500,10,0.00097000
+Tim Sort,500,11,0.00098460
+Tim Sort,500,12,0.00075020
+Tim Sort,500,13,0.00098370
+Tim Sort,500,14,0.00097360
+Tim Sort,500,15,0.00068600
+Tim Sort,500,16,0.00081710
+Tim Sort,500,17,0.00096220
+Tim Sort,500,18,0.00099480
+Tim Sort,500,19,0.00103020
+Tim Sort,500,20,0.00096750
+Tim Sort,500,21,0.00098970
+Tim Sort,500,22,0.00087420
+Tim Sort,500,23,0.00086050
+Tim Sort,500,24,0.00097620
+Tim Sort,500,25,0.00094550
+Tim Sort,500,26,0.00092100
+Tim Sort,500,27,0.00099220
+Tim Sort,500,28,0.00100750
+Tim Sort,500,29,0.00072760
+Tim Sort,500,30,0.00098920
+Tim Sort,500,31,0.00071310
+Tim Sort,500,32,0.00076830
+Tim Sort,500,33,0.00102240
+Tim Sort,500,34,0.00079470
+Tim Sort,500,35,0.00078200
+Tim Sort,500,36,0.00070610
+Tim Sort,500,37,0.00097250
+Tim Sort,500,38,0.00068880
+Tim Sort,500,39,0.00070230
+Tim Sort,500,40,0.00072730
+Tim Sort,500,41,0.00096610
+Tim Sort,500,42,0.00071580
+Tim Sort,500,43,0.00087290
+Tim Sort,500,44,0.00071700
+Tim Sort,500,45,0.00104510
+Tim Sort,500,46,0.00061160
+Tim Sort,500,47,0.00057140
+Tim Sort,500,48,0.00103520
+Tim Sort,500,49,0.00060070
+Tim Sort,500,50,0.00066820
+Tim Sort,500,51,0.00077250
+Tim Sort,500,52,0.00077090
+Tim Sort,500,53,0.00071510
+Tim Sort,500,54,0.00064520
+Tim Sort,500,55,0.00058140
+Tim Sort,500,56,0.00069500
+Tim Sort,500,57,0.00057210
+Tim Sort,500,58,0.00057990
+Tim Sort,500,59,0.00067720
+Tim Sort,500,60,0.00061330
+Tim Sort,500,61,0.00059300
+Tim Sort,500,62,0.00068660
+Tim Sort,500,63,0.00073600
+Tim Sort,500,64,0.00065750
+Tim Sort,500,65,0.00082890
+Tim Sort,500,66,0.00057830
+Tim Sort,500,67,0.00059790
+Tim Sort,500,68,0.00069870
+Tim Sort,500,69,0.00059500
+Tim Sort,500,70,0.00099840
+Tim Sort,500,71,0.00069470
+Tim Sort,500,72,0.00066200
+Tim Sort,500,73,0.00109180
+Tim Sort,500,74,0.00076200
+Tim Sort,500,75,0.00088890
+Tim Sort,500,76,0.00105920
+Tim Sort,500,77,0.00073540
+Tim Sort,500,78,0.00096590
+Tim Sort,500,79,0.00104530
+Tim Sort,500,80,0.00056940
+Tim Sort,500,81,0.00057040
+Tim Sort,500,82,0.00080930
+Tim Sort,500,83,0.00063810
+Tim Sort,500,84,0.00099090
+Tim Sort,500,85,0.00096990
+Tim Sort,500,86,0.00058010
+Tim Sort,500,87,0.00076290
+Tim Sort,500,88,0.00063290
+Tim Sort,500,89,0.00095640
+Tim Sort,500,90,0.00058600
+Tim Sort,500,91,0.00068990
+Tim Sort,500,92,0.00060660
+Tim Sort,500,93,0.00095490
+Tim Sort,500,94,0.00078420
+Tim Sort,500,95,0.00056130
+Tim Sort,500,96,0.00070730
+Tim Sort,500,97,0.00099330
+Tim Sort,500,98,0.00058040
+Tim Sort,500,99,0.00069090
+Tim Sort,500,100,0.00056150
+Tim Sort,500,101,0.00097820
+Tim Sort,500,102,0.00072120
+Tim Sort,500,103,0.00056430
+Tim Sort,500,104,0.00066410
+Tim Sort,500,105,0.00099520
+Tim Sort,500,106,0.00071550
+Tim Sort,500,107,0.00058020
+Tim Sort,500,108,0.00072700
+Tim Sort,500,109,0.00104870
+Tim Sort,500,110,0.00057240
+Tim Sort,500,111,0.00068040
+Tim Sort,500,112,0.00057030
+Tim Sort,500,113,0.00074290
+Tim Sort,500,114,0.00068780
+Tim Sort,500,115,0.00096820
+Tim Sort,500,116,0.00101990
+Tim Sort,500,117,0.00058630
+Tim Sort,500,118,0.00079830
+Tim Sort,500,119,0.00076590
+Tim Sort,500,120,0.00069720
+Tim Sort,500,121,0.00067910
+Tim Sort,500,122,0.00101380
+Tim Sort,500,123,0.00103530
+Tim Sort,500,124,0.00077870
+Tim Sort,500,125,0.00087250
+Tim Sort,500,126,0.00073610
+Tim Sort,500,127,0.00056720
+Tim Sort,500,128,0.00064750
+Tim Sort,500,129,0.00091410
+Tim Sort,500,130,0.00067040
+Tim Sort,500,131,0.00061310
+Tim Sort,500,132,0.00104640
+Tim Sort,500,133,0.00092040
+Tim Sort,500,134,0.00105010
+Tim Sort,500,135,0.00093440
+Tim Sort,500,136,0.00104670
+Tim Sort,500,137,0.00095680
+Tim Sort,500,138,0.00091410
+Tim Sort,500,139,0.00088640
+Tim Sort,500,140,0.00096270
+Tim Sort,500,141,0.00092050
+Tim Sort,500,142,0.00103310
+Tim Sort,500,143,0.00100170
+Tim Sort,500,144,0.00087150
+Tim Sort,500,145,0.00073650
+Tim Sort,500,146,0.00096960
+Tim Sort,500,147,0.00097660
+Tim Sort,500,148,0.00091670
+Tim Sort,500,149,0.00074890
+Tim Sort,500,150,0.00117040
+Tim Sort,500,151,0.00102010
+Tim Sort,500,152,0.00063660
+Tim Sort,500,153,0.00093780
+Tim Sort,500,154,0.00102560
+Tim Sort,500,155,0.00058720
+Tim Sort,500,156,0.00068970
+Tim Sort,500,157,0.00117860
+Tim Sort,500,158,0.00099490
+Tim Sort,500,159,0.00064210
+Tim Sort,500,160,0.00106080
+Tim Sort,500,161,0.00099030
+Tim Sort,500,162,0.00057710
+Tim Sort,500,163,0.00057370
+Tim Sort,500,164,0.00094960
+Tim Sort,500,165,0.00101090
+Tim Sort,500,166,0.00074820
+Tim Sort,500,167,0.00080440
+Tim Sort,500,168,0.00090830
+Tim Sort,500,169,0.00071450
+Tim Sort,500,170,0.00070100
+Tim Sort,500,171,0.00073080
+Tim Sort,500,172,0.00059890
+Tim Sort,500,173,0.00070250
+Tim Sort,500,174,0.00060090
+Tim Sort,500,175,0.00104260
+Tim Sort,500,176,0.00102990
+Tim Sort,500,177,0.00109570
+Tim Sort,500,178,0.00098450
+Tim Sort,500,179,0.00103050
+Tim Sort,500,180,0.00113300
+Tim Sort,500,181,0.00094070
+Tim Sort,500,182,0.00106510
+Tim Sort,500,183,0.00105690
+Tim Sort,500,184,0.00105300
+Tim Sort,500,185,0.00103980
+Tim Sort,500,186,0.00099950
+Tim Sort,500,187,0.00102010
+Tim Sort,500,188,0.00109340
+Tim Sort,500,189,0.00104810
+Tim Sort,500,190,0.00110480
+Tim Sort,500,191,0.00096450
+Tim Sort,500,192,0.00098850
+Tim Sort,500,193,0.00095110
+Tim Sort,500,194,0.00081710
+Tim Sort,500,195,0.00363290
+Tim Sort,500,196,0.00104020
+Tim Sort,500,197,0.00090470
+Tim Sort,500,198,0.00097310
+Tim Sort,500,199,0.00179630
+Tim Sort,500,200,0.00101630
+Tim Sort,500,201,0.00097230
+Tim Sort,500,202,0.00095920
+Tim Sort,500,203,0.00103340
+Tim Sort,500,204,0.00130420
+Tim Sort,500,205,0.00099090
+Tim Sort,500,206,0.00103780
+Tim Sort,500,207,0.00112100
+Tim Sort,500,208,0.00104420
+Tim Sort,500,209,0.00111060
+Tim Sort,500,210,0.00106940
+Tim Sort,500,211,0.00098380
+Tim Sort,500,212,0.00129970
+Tim Sort,500,213,0.00095530
+Tim Sort,500,214,0.00098210
+Tim Sort,500,215,0.00091180
+Tim Sort,500,216,0.00097980
+Tim Sort,500,217,0.01395900
+Tim Sort,500,218,0.00099930
+Tim Sort,500,219,0.00099090
+Tim Sort,500,220,0.00136800
+Tim Sort,500,221,0.00099040
+Tim Sort,500,222,0.00100500
+Tim Sort,500,223,0.00125700
+Tim Sort,500,224,0.00101100
+Tim Sort,500,225,0.00122420
+Tim Sort,500,226,0.00098600
+Tim Sort,500,227,0.00101960
+Tim Sort,500,228,0.00101670
+Tim Sort,500,229,0.00105760
+Tim Sort,500,230,0.00096320
+Tim Sort,500,231,0.00103260
+Tim Sort,500,232,0.00094050
+Tim Sort,500,233,0.00104130
+Tim Sort,500,234,0.00100320
+Tim Sort,500,235,0.00096140
+Tim Sort,500,236,0.00097980
+Tim Sort,500,237,0.00122750
+Tim Sort,500,238,0.00097410
+Tim Sort,500,239,0.00098540
+Tim Sort,500,240,0.00092760
+Tim Sort,500,241,0.00094490
+Tim Sort,500,242,0.00092420
+Tim Sort,500,243,0.00094420
+Tim Sort,500,244,0.00094120
+Tim Sort,500,245,0.00102150
+Tim Sort,500,246,0.00098410
+Tim Sort,500,247,0.00109550
+Tim Sort,500,248,0.00098510
+Tim Sort,500,249,0.00128760
+Tim Sort,500,250,0.00099340
+Tim Sort,500,251,0.00108440
+Tim Sort,500,252,0.00104360
+Tim Sort,500,253,0.00097930
+Tim Sort,500,254,0.00093730
+Tim Sort,500,255,0.00102320
+Tim Sort,500,256,0.00098450
+Tim Sort,500,257,0.00059770
+Tim Sort,500,258,0.00097070
+Tim Sort,500,259,0.00103280
+Tim Sort,500,260,0.00092240
+Tim Sort,500,261,0.00083050
+Tim Sort,500,262,0.00088670
+Tim Sort,500,263,0.00096070
+Tim Sort,500,264,0.00079000
+Tim Sort,500,265,0.00057210
+Tim Sort,500,266,0.00092890
+Tim Sort,500,267,0.00178310
+Tim Sort,500,268,0.00088530
+Tim Sort,500,269,0.00108510
+Tim Sort,500,270,0.00121950
+Tim Sort,500,271,0.00099280
+Tim Sort,500,272,0.00100880
+Tim Sort,500,273,0.00186580
+Tim Sort,500,274,0.00122260
+Tim Sort,500,275,0.00111640
+Tim Sort,500,276,0.00111830
+Tim Sort,500,277,0.00106390
+Tim Sort,500,278,0.00108360
+Tim Sort,500,279,0.00128340
+Tim Sort,500,280,0.00100190
+Tim Sort,500,281,0.00105670
+Tim Sort,500,282,0.00097460
+Tim Sort,500,283,0.00100180
+Tim Sort,500,284,0.00099080
+Tim Sort,500,285,0.00097620
+Tim Sort,500,286,0.00089580
+Tim Sort,500,287,0.00084650
+Tim Sort,500,288,0.00096700
+Tim Sort,500,289,0.00081660
+Tim Sort,500,290,0.00083410
+Tim Sort,500,291,0.00097300
+Tim Sort,500,292,0.00057800
+Tim Sort,500,293,0.00076000
+Tim Sort,500,294,0.00063570
+Tim Sort,500,295,0.00079180
+Tim Sort,500,296,0.00076040
+Tim Sort,500,297,0.00058490
+Tim Sort,500,298,0.00057540
+Tim Sort,500,299,0.00057560
+Tim Sort,500,300,0.00082690
+Tim Sort,500,301,0.00065940
+Tim Sort,500,302,0.00059390
+Tim Sort,500,303,0.00068070
+Tim Sort,500,304,0.00057530
+Tim Sort,500,305,0.00059050
+Tim Sort,500,306,0.00100520
+Tim Sort,500,307,0.00083930
+Tim Sort,500,308,0.00097020
+Tim Sort,500,309,0.00064960
+Tim Sort,500,310,0.00102150
+Tim Sort,500,311,0.00097490
+Tim Sort,500,312,0.00062010
+Tim Sort,500,313,0.00097770
+Tim Sort,500,314,0.00065370
+Tim Sort,500,315,0.00097320
+Tim Sort,500,316,0.00099250
+Tim Sort,500,317,0.00071990
+Tim Sort,500,318,0.00098400
+Tim Sort,500,319,0.00080380
+Tim Sort,500,320,0.00097900
+Tim Sort,500,321,0.00098530
+Tim Sort,500,322,0.00071570
+Tim Sort,500,323,0.00097390
+Tim Sort,500,324,0.00091150
+Tim Sort,500,325,0.00080220
+Tim Sort,500,326,0.00098310
+Tim Sort,500,327,0.00083580
+Tim Sort,500,328,0.00063460
+Tim Sort,500,329,0.00069560
+Tim Sort,500,330,0.00095350
+Tim Sort,500,331,0.00078320
+Tim Sort,500,332,0.00067390
+Tim Sort,500,333,0.00095180
+Tim Sort,500,334,0.00098600
+Tim Sort,500,335,0.00061770
+Tim Sort,500,336,0.00096810
+Tim Sort,500,337,0.00072460
+Tim Sort,500,338,0.00103330
+Tim Sort,500,339,0.00073240
+Tim Sort,500,340,0.00073970
+Tim Sort,500,341,0.00101410
+Tim Sort,500,342,0.00091350
+Tim Sort,500,343,0.00106050
+Tim Sort,500,344,0.00104470
+Tim Sort,500,345,0.00058520
+Tim Sort,500,346,0.00077420
+Tim Sort,500,347,0.00101140
+Tim Sort,500,348,0.00104470
+Tim Sort,500,349,0.00090820
+Tim Sort,500,350,0.00105680
+Tim Sort,500,351,0.00096920
+Tim Sort,500,352,0.00103070
+Tim Sort,500,353,0.00105770
+Tim Sort,500,354,0.00097460
+Tim Sort,500,355,0.00107110
+Tim Sort,500,356,0.00095310
+Tim Sort,500,357,0.00102220
+Tim Sort,500,358,0.00095610
+Tim Sort,500,359,0.00076580
+Tim Sort,500,360,0.00074010
+Tim Sort,500,361,0.00091260
+Tim Sort,500,362,0.00058450
+Tim Sort,500,363,0.00070110
+Tim Sort,500,364,0.00100940
+Tim Sort,500,365,0.00083480
+Tim Sort,500,366,0.00071890
+Tim Sort,500,367,0.00096480
+Tim Sort,500,368,0.00079360
+Tim Sort,500,369,0.00098410
+Tim Sort,500,370,0.00088940
+Tim Sort,500,371,0.00106760
+Tim Sort,500,372,0.00068790
+Tim Sort,500,373,0.00098370
+Tim Sort,500,374,0.00096910
+Tim Sort,500,375,0.00090120
+Tim Sort,500,376,0.00073070
+Tim Sort,500,377,0.00097050
+Tim Sort,500,378,0.00069930
+Tim Sort,500,379,0.00090090
+Tim Sort,500,380,0.00089910
+Tim Sort,500,381,0.00093080
+Tim Sort,500,382,0.00098880
+Tim Sort,500,383,0.00102830
+Tim Sort,500,384,0.00059570
+Tim Sort,500,385,0.00069290
+Tim Sort,500,386,0.00087750
+Tim Sort,500,387,0.00103000
+Tim Sort,500,388,0.00089320
+Tim Sort,500,389,0.00059270
+Tim Sort,500,390,0.00100510
+Tim Sort,500,391,0.00060790
+Tim Sort,500,392,0.00067520
+Tim Sort,500,393,0.00100960
+Tim Sort,500,394,0.00058930
+Tim Sort,500,395,0.00057520
+Tim Sort,500,396,0.00056730
+Tim Sort,500,397,0.00069390
+Tim Sort,500,398,0.00101560
+Tim Sort,500,399,0.00058860
+Tim Sort,500,400,0.00077570
+Tim Sort,500,401,0.00063040
+Tim Sort,500,402,0.00094870
+Tim Sort,500,403,0.00064700
+Tim Sort,500,404,0.00060810
+Tim Sort,500,405,0.00074280
+Tim Sort,500,406,0.00072120
+Tim Sort,500,407,0.00059000
+Tim Sort,500,408,0.00068960
+Tim Sort,500,409,0.00073730
+Tim Sort,500,410,0.00058060
+Tim Sort,500,411,0.00103040
+Tim Sort,500,412,0.00059970
+Tim Sort,500,413,0.00096420
+Tim Sort,500,414,0.00065230
+Tim Sort,500,415,0.00101390
+Tim Sort,500,416,0.00096230
+Tim Sort,500,417,0.00059760
+Tim Sort,500,418,0.00107010
+Tim Sort,500,419,0.00064740
+Tim Sort,500,420,0.00097410
+Tim Sort,500,421,0.00057900
+Tim Sort,500,422,0.00103960
+Tim Sort,500,423,0.00095510
+Tim Sort,500,424,0.00057540
+Tim Sort,500,425,0.00058440
+Tim Sort,500,426,0.00104180
+Tim Sort,500,427,0.00056330
+Tim Sort,500,428,0.00058740
+Tim Sort,500,429,0.00062930
+Tim Sort,500,430,0.00067430
+Tim Sort,500,431,0.00102110
+Tim Sort,500,432,0.00057880
+Tim Sort,500,433,0.00060340
+Tim Sort,500,434,0.00063590
+Tim Sort,500,435,0.00101040
+Tim Sort,500,436,0.00058850
+Tim Sort,500,437,0.00057130
+Tim Sort,500,438,0.00059300
+Tim Sort,500,439,0.00103700
+Tim Sort,500,440,0.00068600
+Tim Sort,500,441,0.00097940
+Tim Sort,500,442,0.00071360
+Tim Sort,500,443,0.00076240
+Tim Sort,500,444,0.00094540
+Tim Sort,500,445,0.00075700
+Tim Sort,500,446,0.00068030
+Tim Sort,500,447,0.00057550
+Tim Sort,500,448,0.00096410
+Tim Sort,500,449,0.00111110
+Tim Sort,500,450,0.00060900
+Tim Sort,500,451,0.00097640
+Tim Sort,500,452,0.00056550
+Tim Sort,500,453,0.00105830
+Tim Sort,500,454,0.00058080
+Tim Sort,500,455,0.00098140
+Tim Sort,500,456,0.00057160
+Tim Sort,500,457,0.00069450
+Tim Sort,500,458,0.00062200
+Tim Sort,500,459,0.00098130
+Tim Sort,500,460,0.00116570
+Tim Sort,500,461,0.00060500
+Tim Sort,500,462,0.00080460
+Tim Sort,500,463,0.00065420
+Tim Sort,500,464,0.00068380
+Tim Sort,500,465,0.00060790
+Tim Sort,500,466,0.00058340
+Tim Sort,500,467,0.00083300
+Tim Sort,500,468,0.00068930
+Tim Sort,500,469,0.00060700
+Tim Sort,500,470,0.00069840
+Tim Sort,500,471,0.00059460
+Tim Sort,500,472,0.00056890
+Tim Sort,500,473,0.00096780
+Tim Sort,500,474,0.00074890
+Tim Sort,500,475,0.00058330
+Tim Sort,500,476,0.00054930
+Tim Sort,500,477,0.00072020
+Tim Sort,500,478,0.00097680
+Tim Sort,500,479,0.00057050
+Tim Sort,500,480,0.00071270
+Tim Sort,500,481,0.00058090
+Tim Sort,500,482,0.00098250
+Tim Sort,500,483,0.00108170
+Tim Sort,500,484,0.00057100
+Tim Sort,500,485,0.00097460
+Tim Sort,500,486,0.00056990
+Tim Sort,500,487,0.00115350
+Tim Sort,500,488,0.00057370
+Tim Sort,500,489,0.00092970
+Tim Sort,500,490,0.00057680
+Tim Sort,500,491,0.00078180
+Tim Sort,500,492,0.00058420
+Tim Sort,500,493,0.00101900
+Tim Sort,500,494,0.00057650
+Tim Sort,500,495,0.00094150
+Tim Sort,500,496,0.00056590
+Tim Sort,500,497,0.00070090
+Tim Sort,500,498,0.00095380
+Tim Sort,500,499,0.00057470
+Tim Sort,500,500,0.00100650
+Tournament Sort,500,1,0.00916680
+Tournament Sort,500,2,0.00799750
+Tournament Sort,500,3,0.00769870
+Tournament Sort,500,4,0.01098430
+Tournament Sort,500,5,0.00741980
+Tournament Sort,500,6,0.00954680
+Tournament Sort,500,7,0.00806460
+Tournament Sort,500,8,0.00916050
+Tournament Sort,500,9,0.01030750
+Tournament Sort,500,10,0.00928540
+Tournament Sort,500,11,0.00759280
+Tournament Sort,500,12,0.00753930
+Tournament Sort,500,13,0.01239240
+Tournament Sort,500,14,0.00695630
+Tournament Sort,500,15,0.00979010
+Tournament Sort,500,16,0.01032390
+Tournament Sort,500,17,0.01052920
+Tournament Sort,500,18,0.00764510
+Tournament Sort,500,19,0.01121080
+Tournament Sort,500,20,0.00833160
+Tournament Sort,500,21,0.00818100
+Tournament Sort,500,22,0.00962170
+Tournament Sort,500,23,0.01115860
+Tournament Sort,500,24,0.01271980
+Tournament Sort,500,25,0.01140900
+Tournament Sort,500,26,0.01020930
+Tournament Sort,500,27,0.00945300
+Tournament Sort,500,28,0.00980190
+Tournament Sort,500,29,0.01209190
+Tournament Sort,500,30,0.01011130
+Tournament Sort,500,31,0.00980770
+Tournament Sort,500,32,0.01022680
+Tournament Sort,500,33,0.01052310
+Tournament Sort,500,34,0.01118970
+Tournament Sort,500,35,0.00925700
+Tournament Sort,500,36,0.01063730
+Tournament Sort,500,37,0.01194540
+Tournament Sort,500,38,0.00870950
+Tournament Sort,500,39,0.00880490
+Tournament Sort,500,40,0.00780930
+Tournament Sort,500,41,0.01056910
+Tournament Sort,500,42,0.00944860
+Tournament Sort,500,43,0.01026590
+Tournament Sort,500,44,0.00908620
+Tournament Sort,500,45,0.00971080
+Tournament Sort,500,46,0.00931270
+Tournament Sort,500,47,0.00898330
+Tournament Sort,500,48,0.00754560
+Tournament Sort,500,49,0.00760900
+Tournament Sort,500,50,0.00715930
+Tournament Sort,500,51,0.00745150
+Tournament Sort,500,52,0.01042760
+Tournament Sort,500,53,0.00968750
+Tournament Sort,500,54,0.00962150
+Tournament Sort,500,55,0.01151050
+Tournament Sort,500,56,0.00922270
+Tournament Sort,500,57,0.00900130
+Tournament Sort,500,58,0.01203340
+Tournament Sort,500,59,0.00969860
+Tournament Sort,500,60,0.00720680
+Tournament Sort,500,61,0.00885930
+Tournament Sort,500,62,0.01078080
+Tournament Sort,500,63,0.00983900
+Tournament Sort,500,64,0.00935470
+Tournament Sort,500,65,0.01042290
+Tournament Sort,500,66,0.00977950
+Tournament Sort,500,67,0.00920170
+Tournament Sort,500,68,0.01037590
+Tournament Sort,500,69,0.00804730
+Tournament Sort,500,70,0.00709240
+Tournament Sort,500,71,0.00798880
+Tournament Sort,500,72,0.01185170
+Tournament Sort,500,73,0.00974390
+Tournament Sort,500,74,0.01212520
+Tournament Sort,500,75,0.00989780
+Tournament Sort,500,76,0.01024220
+Tournament Sort,500,77,0.00812690
+Tournament Sort,500,78,0.01190650
+Tournament Sort,500,79,0.00983800
+Tournament Sort,500,80,0.00792610
+Tournament Sort,500,81,0.00845060
+Tournament Sort,500,82,0.01169270
+Tournament Sort,500,83,0.00998410
+Tournament Sort,500,84,0.01201610
+Tournament Sort,500,85,0.01107230
+Tournament Sort,500,86,0.01165490
+Tournament Sort,500,87,0.01011500
+Tournament Sort,500,88,0.00950300
+Tournament Sort,500,89,0.00807660
+Tournament Sort,500,90,0.00748890
+Tournament Sort,500,91,0.01059080
+Tournament Sort,500,92,0.00837650
+Tournament Sort,500,93,0.00954590
+Tournament Sort,500,94,0.01053110
+Tournament Sort,500,95,0.01225010
+Tournament Sort,500,96,0.00806570
+Tournament Sort,500,97,0.00656150
+Tournament Sort,500,98,0.00826320
+Tournament Sort,500,99,0.00713470
+Tournament Sort,500,100,0.00898290
+Tournament Sort,500,101,0.01107090
+Tournament Sort,500,102,0.00832040
+Tournament Sort,500,103,0.01099190
+Tournament Sort,500,104,0.00984250
+Tournament Sort,500,105,0.00990390
+Tournament Sort,500,106,0.00709710
+Tournament Sort,500,107,0.01039520
+Tournament Sort,500,108,0.00667120
+Tournament Sort,500,109,0.00823160
+Tournament Sort,500,110,0.01184670
+Tournament Sort,500,111,0.01086020
+Tournament Sort,500,112,0.00913630
+Tournament Sort,500,113,0.01220980
+Tournament Sort,500,114,0.00868300
+Tournament Sort,500,115,0.00985430
+Tournament Sort,500,116,0.00762330
+Tournament Sort,500,117,0.01081360
+Tournament Sort,500,118,0.01067520
+Tournament Sort,500,119,0.00962270
+Tournament Sort,500,120,0.00783960
+Tournament Sort,500,121,0.01071860
+Tournament Sort,500,122,0.00952500
+Tournament Sort,500,123,0.00915010
+Tournament Sort,500,124,0.00860080
+Tournament Sort,500,125,0.00792990
+Tournament Sort,500,126,0.00884130
+Tournament Sort,500,127,0.00891080
+Tournament Sort,500,128,0.00859570
+Tournament Sort,500,129,0.01138000
+Tournament Sort,500,130,0.01121840
+Tournament Sort,500,131,0.00724370
+Tournament Sort,500,132,0.00767170
+Tournament Sort,500,133,0.00965960
+Tournament Sort,500,134,0.01117120
+Tournament Sort,500,135,0.01121560
+Tournament Sort,500,136,0.00878290
+Tournament Sort,500,137,0.00963630
+Tournament Sort,500,138,0.01094240
+Tournament Sort,500,139,0.00968160
+Tournament Sort,500,140,0.00950160
+Tournament Sort,500,141,0.01142950
+Tournament Sort,500,142,0.00947700
+Tournament Sort,500,143,0.00920830
+Tournament Sort,500,144,0.01128090
+Tournament Sort,500,145,0.01105300
+Tournament Sort,500,146,0.01168630
+Tournament Sort,500,147,0.01180530
+Tournament Sort,500,148,0.00942340
+Tournament Sort,500,149,0.00865560
+Tournament Sort,500,150,0.00955800
+Tournament Sort,500,151,0.00759370
+Tournament Sort,500,152,0.00818930
+Tournament Sort,500,153,0.00932340
+Tournament Sort,500,154,0.00990490
+Tournament Sort,500,155,0.00992520
+Tournament Sort,500,156,0.01014200
+Tournament Sort,500,157,0.00710080
+Tournament Sort,500,158,0.00856560
+Tournament Sort,500,159,0.00816480
+Tournament Sort,500,160,0.00946750
+Tournament Sort,500,161,0.00855620
+Tournament Sort,500,162,0.00841880
+Tournament Sort,500,163,0.00781310
+Tournament Sort,500,164,0.01009420
+Tournament Sort,500,165,0.00812610
+Tournament Sort,500,166,0.00886050
+Tournament Sort,500,167,0.00767190
+Tournament Sort,500,168,0.00852450
+Tournament Sort,500,169,0.00944290
+Tournament Sort,500,170,0.00916060
+Tournament Sort,500,171,0.01083530
+Tournament Sort,500,172,0.00758920
+Tournament Sort,500,173,0.01104050
+Tournament Sort,500,174,0.00962140
+Tournament Sort,500,175,0.00841190
+Tournament Sort,500,176,0.01032250
+Tournament Sort,500,177,0.00779470
+Tournament Sort,500,178,0.00900290
+Tournament Sort,500,179,0.00666710
+Tournament Sort,500,180,0.01160640
+Tournament Sort,500,181,0.00870240
+Tournament Sort,500,182,0.00834550
+Tournament Sort,500,183,0.00919080
+Tournament Sort,500,184,0.00850980
+Tournament Sort,500,185,0.01137650
+Tournament Sort,500,186,0.00801270
+Tournament Sort,500,187,0.00727070
+Tournament Sort,500,188,0.00974710
+Tournament Sort,500,189,0.00981470
+Tournament Sort,500,190,0.00924630
+Tournament Sort,500,191,0.01212620
+Tournament Sort,500,192,0.00797950
+Tournament Sort,500,193,0.01092490
+Tournament Sort,500,194,0.00939910
+Tournament Sort,500,195,0.01081080
+Tournament Sort,500,196,0.01010090
+Tournament Sort,500,197,0.01185200
+Tournament Sort,500,198,0.00921590
+Tournament Sort,500,199,0.00935110
+Tournament Sort,500,200,0.01140770
+Tournament Sort,500,201,0.00839040
+Tournament Sort,500,202,0.01182980
+Tournament Sort,500,203,0.00876500
+Tournament Sort,500,204,0.00694450
+Tournament Sort,500,205,0.01176440
+Tournament Sort,500,206,0.01023140
+Tournament Sort,500,207,0.00833470
+Tournament Sort,500,208,0.00819000
+Tournament Sort,500,209,0.01102370
+Tournament Sort,500,210,0.01133270
+Tournament Sort,500,211,0.00879340
+Tournament Sort,500,212,0.00704650
+Tournament Sort,500,213,0.00977050
+Tournament Sort,500,214,0.00935020
+Tournament Sort,500,215,0.00873930
+Tournament Sort,500,216,0.00912080
+Tournament Sort,500,217,0.00929670
+Tournament Sort,500,218,0.01047230
+Tournament Sort,500,219,0.01114130
+Tournament Sort,500,220,0.01098460
+Tournament Sort,500,221,0.01064210
+Tournament Sort,500,222,0.01132770
+Tournament Sort,500,223,0.00914350
+Tournament Sort,500,224,0.00885470
+Tournament Sort,500,225,0.01122010
+Tournament Sort,500,226,0.01058370
+Tournament Sort,500,227,0.01067610
+Tournament Sort,500,228,0.00787450
+Tournament Sort,500,229,0.00836380
+Tournament Sort,500,230,0.00882490
+Tournament Sort,500,231,0.01026210
+Tournament Sort,500,232,0.01059390
+Tournament Sort,500,233,0.01151530
+Tournament Sort,500,234,0.00690800
+Tournament Sort,500,235,0.01159040
+Tournament Sort,500,236,0.01132740
+Tournament Sort,500,237,0.00819520
+Tournament Sort,500,238,0.00962520
+Tournament Sort,500,239,0.00971900
+Tournament Sort,500,240,0.00814870
+Tournament Sort,500,241,0.01029210
+Tournament Sort,500,242,0.00795890
+Tournament Sort,500,243,0.00927330
+Tournament Sort,500,244,0.00963850
+Tournament Sort,500,245,0.00760210
+Tournament Sort,500,246,0.00687400
+Tournament Sort,500,247,0.01057030
+Tournament Sort,500,248,0.00919110
+Tournament Sort,500,249,0.00972190
+Tournament Sort,500,250,0.00871500
+Tournament Sort,500,251,0.00814140
+Tournament Sort,500,252,0.01142890
+Tournament Sort,500,253,0.00875640
+Tournament Sort,500,254,0.01177370
+Tournament Sort,500,255,0.01133380
+Tournament Sort,500,256,0.01031300
+Tournament Sort,500,257,0.00993390
+Tournament Sort,500,258,0.01224490
+Tournament Sort,500,259,0.01029150
+Tournament Sort,500,260,0.00787670
+Tournament Sort,500,261,0.00823910
+Tournament Sort,500,262,0.01023670
+Tournament Sort,500,263,0.00723580
+Tournament Sort,500,264,0.00837210
+Tournament Sort,500,265,0.01050750
+Tournament Sort,500,266,0.00883100
+Tournament Sort,500,267,0.00974690
+Tournament Sort,500,268,0.01034160
+Tournament Sort,500,269,0.00803880
+Tournament Sort,500,270,0.00879110
+Tournament Sort,500,271,0.00943550
+Tournament Sort,500,272,0.00942810
+Tournament Sort,500,273,0.00748830
+Tournament Sort,500,274,0.01059720
+Tournament Sort,500,275,0.00706440
+Tournament Sort,500,276,0.00959040
+Tournament Sort,500,277,0.00895690
+Tournament Sort,500,278,0.00707250
+Tournament Sort,500,279,0.01197360
+Tournament Sort,500,280,0.00803180
+Tournament Sort,500,281,0.00787130
+Tournament Sort,500,282,0.00768050
+Tournament Sort,500,283,0.00991110
+Tournament Sort,500,284,0.01067370
+Tournament Sort,500,285,0.00910270
+Tournament Sort,500,286,0.01166130
+Tournament Sort,500,287,0.00922130
+Tournament Sort,500,288,0.01050550
+Tournament Sort,500,289,0.00876360
+Tournament Sort,500,290,0.00926170
+Tournament Sort,500,291,0.01009650
+Tournament Sort,500,292,0.00883820
+Tournament Sort,500,293,0.00878640
+Tournament Sort,500,294,0.01075060
+Tournament Sort,500,295,0.00854300
+Tournament Sort,500,296,0.01157240
+Tournament Sort,500,297,0.00902260
+Tournament Sort,500,298,0.01165030
+Tournament Sort,500,299,0.00839580
+Tournament Sort,500,300,0.00668950
+Tournament Sort,500,301,0.00992640
+Tournament Sort,500,302,0.00954900
+Tournament Sort,500,303,0.01193440
+Tournament Sort,500,304,0.00820230
+Tournament Sort,500,305,0.00813830
+Tournament Sort,500,306,0.01005100
+Tournament Sort,500,307,0.00677870
+Tournament Sort,500,308,0.00899840
+Tournament Sort,500,309,0.00846600
+Tournament Sort,500,310,0.01208090
+Tournament Sort,500,311,0.00920900
+Tournament Sort,500,312,0.00850450
+Tournament Sort,500,313,0.00949770
+Tournament Sort,500,314,0.00811940
+Tournament Sort,500,315,0.00816240
+Tournament Sort,500,316,0.01025220
+Tournament Sort,500,317,0.01047900
+Tournament Sort,500,318,0.00718590
+Tournament Sort,500,319,0.00933110
+Tournament Sort,500,320,0.01050210
+Tournament Sort,500,321,0.01073830
+Tournament Sort,500,322,0.00926290
+Tournament Sort,500,323,0.00795210
+Tournament Sort,500,324,0.00997400
+Tournament Sort,500,325,0.01195430
+Tournament Sort,500,326,0.00862440
+Tournament Sort,500,327,0.01162610
+Tournament Sort,500,328,0.00876200
+Tournament Sort,500,329,0.00851900
+Tournament Sort,500,330,0.00930160
+Tournament Sort,500,331,0.00749070
+Tournament Sort,500,332,0.00853600
+Tournament Sort,500,333,0.00767460
+Tournament Sort,500,334,0.01015150
+Tournament Sort,500,335,0.01022540
+Tournament Sort,500,336,0.00709290
+Tournament Sort,500,337,0.00814430
+Tournament Sort,500,338,0.01067330
+Tournament Sort,500,339,0.01038800
+Tournament Sort,500,340,0.00964300
+Tournament Sort,500,341,0.01024130
+Tournament Sort,500,342,0.00996630
+Tournament Sort,500,343,0.00800760
+Tournament Sort,500,344,0.01137010
+Tournament Sort,500,345,0.01042250
+Tournament Sort,500,346,0.01000070
+Tournament Sort,500,347,0.00842010
+Tournament Sort,500,348,0.01025430
+Tournament Sort,500,349,0.01048380
+Tournament Sort,500,350,0.00922010
+Tournament Sort,500,351,0.01150020
+Tournament Sort,500,352,0.00956810
+Tournament Sort,500,353,0.01045860
+Tournament Sort,500,354,0.01108440
+Tournament Sort,500,355,0.01137690
+Tournament Sort,500,356,0.01153370
+Tournament Sort,500,357,0.01068050
+Tournament Sort,500,358,0.01074100
+Tournament Sort,500,359,0.01004540
+Tournament Sort,500,360,0.00975110
+Tournament Sort,500,361,0.00793870
+Tournament Sort,500,362,0.01157160
+Tournament Sort,500,363,0.01050630
+Tournament Sort,500,364,0.01090620
+Tournament Sort,500,365,0.01093830
+Tournament Sort,500,366,0.00823840
+Tournament Sort,500,367,0.00873550
+Tournament Sort,500,368,0.00692320
+Tournament Sort,500,369,0.00892630
+Tournament Sort,500,370,0.00916250
+Tournament Sort,500,371,0.00836800
+Tournament Sort,500,372,0.00700450
+Tournament Sort,500,373,0.00711700
+Tournament Sort,500,374,0.00719980
+Tournament Sort,500,375,0.00728770
+Tournament Sort,500,376,0.00670490
+Tournament Sort,500,377,0.00673100
+Tournament Sort,500,378,0.00818060
+Tournament Sort,500,379,0.00835150
+Tournament Sort,500,380,0.01045760
+Tournament Sort,500,381,0.00872770
+Tournament Sort,500,382,0.00752970
+Tournament Sort,500,383,0.00679590
+Tournament Sort,500,384,0.00846400
+Tournament Sort,500,385,0.00727800
+Tournament Sort,500,386,0.00923710
+Tournament Sort,500,387,0.00952690
+Tournament Sort,500,388,0.01039520
+Tournament Sort,500,389,0.00953090
+Tournament Sort,500,390,0.01206310
+Tournament Sort,500,391,0.01096950
+Tournament Sort,500,392,0.00948380
+Tournament Sort,500,393,0.01071870
+Tournament Sort,500,394,0.00971940
+Tournament Sort,500,395,0.00715050
+Tournament Sort,500,396,0.01040830
+Tournament Sort,500,397,0.00909450
+Tournament Sort,500,398,0.00768030
+Tournament Sort,500,399,0.01009620
+Tournament Sort,500,400,0.00708670
+Tournament Sort,500,401,0.00958910
+Tournament Sort,500,402,0.00686700
+Tournament Sort,500,403,0.00760150
+Tournament Sort,500,404,0.01145370
+Tournament Sort,500,405,0.00859040
+Tournament Sort,500,406,0.00717590
+Tournament Sort,500,407,0.01295980
+Tournament Sort,500,408,0.00721020
+Tournament Sort,500,409,0.00913440
+Tournament Sort,500,410,0.00917960
+Tournament Sort,500,411,0.00706260
+Tournament Sort,500,412,0.01142800
+Tournament Sort,500,413,0.01001310
+Tournament Sort,500,414,0.01014550
+Tournament Sort,500,415,0.00873670
+Tournament Sort,500,416,0.00936500
+Tournament Sort,500,417,0.01135400
+Tournament Sort,500,418,0.00903560
+Tournament Sort,500,419,0.00763790
+Tournament Sort,500,420,0.00953990
+Tournament Sort,500,421,0.00815940
+Tournament Sort,500,422,0.01021390
+Tournament Sort,500,423,0.00841870
+Tournament Sort,500,424,0.00881570
+Tournament Sort,500,425,0.01040430
+Tournament Sort,500,426,0.00870080
+Tournament Sort,500,427,0.01138800
+Tournament Sort,500,428,0.00979120
+Tournament Sort,500,429,0.00971460
+Tournament Sort,500,430,0.00996630
+Tournament Sort,500,431,0.01037720
+Tournament Sort,500,432,0.00959760
+Tournament Sort,500,433,0.01056320
+Tournament Sort,500,434,0.01014560
+Tournament Sort,500,435,0.00739180
+Tournament Sort,500,436,0.01070790
+Tournament Sort,500,437,0.01087980
+Tournament Sort,500,438,0.00999490
+Tournament Sort,500,439,0.01072840
+Tournament Sort,500,440,0.00826430
+Tournament Sort,500,441,0.01031500
+Tournament Sort,500,442,0.01067480
+Tournament Sort,500,443,0.01095450
+Tournament Sort,500,444,0.00889000
+Tournament Sort,500,445,0.01083740
+Tournament Sort,500,446,0.01102340
+Tournament Sort,500,447,0.00860890
+Tournament Sort,500,448,0.00972400
+Tournament Sort,500,449,0.00838480
+Tournament Sort,500,450,0.00914780
+Tournament Sort,500,451,0.00762690
+Tournament Sort,500,452,0.00876620
+Tournament Sort,500,453,0.00766090
+Tournament Sort,500,454,0.01164620
+Tournament Sort,500,455,0.01151960
+Tournament Sort,500,456,0.00840910
+Tournament Sort,500,457,0.00675670
+Tournament Sort,500,458,0.01103200
+Tournament Sort,500,459,0.01092010
+Tournament Sort,500,460,0.01117170
+Tournament Sort,500,461,0.00699000
+Tournament Sort,500,462,0.00985650
+Tournament Sort,500,463,0.00810740
+Tournament Sort,500,464,0.01055110
+Tournament Sort,500,465,0.00936830
+Tournament Sort,500,466,0.00946450
+Tournament Sort,500,467,0.00817730
+Tournament Sort,500,468,0.01002530
+Tournament Sort,500,469,0.01092340
+Tournament Sort,500,470,0.01089090
+Tournament Sort,500,471,0.00774130
+Tournament Sort,500,472,0.00732100
+Tournament Sort,500,473,0.00905900
+Tournament Sort,500,474,0.00761750
+Tournament Sort,500,475,0.00886580
+Tournament Sort,500,476,0.00852530
+Tournament Sort,500,477,0.00734610
+Tournament Sort,500,478,0.00689040
+Tournament Sort,500,479,0.00695220
+Tournament Sort,500,480,0.00976040
+Tournament Sort,500,481,0.00796500
+Tournament Sort,500,482,0.00731490
+Tournament Sort,500,483,0.00986050
+Tournament Sort,500,484,0.00841770
+Tournament Sort,500,485,0.00690100
+Tournament Sort,500,486,0.00755640
+Tournament Sort,500,487,0.00878350
+Tournament Sort,500,488,0.00826940
+Tournament Sort,500,489,0.00955900
+Tournament Sort,500,490,0.00988990
+Tournament Sort,500,491,0.01042310
+Tournament Sort,500,492,0.01184100
+Tournament Sort,500,493,0.01138290
+Tournament Sort,500,494,0.00758590
+Tournament Sort,500,495,0.00950100
+Tournament Sort,500,496,0.00878540
+Tournament Sort,500,497,0.01106170
+Tournament Sort,500,498,0.00942210
+Tournament Sort,500,499,0.01023810
+Tournament Sort,500,500,0.01255490
+Tree Sort,500,1,0.00080950
+Tree Sort,500,2,0.00046630
+Tree Sort,500,3,0.00056420
+Tree Sort,500,4,0.00084070
+Tree Sort,500,5,0.00055690
+Tree Sort,500,6,0.00064620
+Tree Sort,500,7,0.00069560
+Tree Sort,500,8,0.00069580
+Tree Sort,500,9,0.00048520
+Tree Sort,500,10,0.00046850
+Tree Sort,500,11,0.00055720
+Tree Sort,500,12,0.00056650
+Tree Sort,500,13,0.00069850
+Tree Sort,500,14,0.00075360
+Tree Sort,500,15,0.00091350
+Tree Sort,500,16,0.00102490
+Tree Sort,500,17,0.00083890
+Tree Sort,500,18,0.00077630
+Tree Sort,500,19,0.00129690
+Tree Sort,500,20,0.00119170
+Tree Sort,500,21,0.00103620
+Tree Sort,500,22,0.00079660
+Tree Sort,500,23,0.00077980
+Tree Sort,500,24,0.00084660
+Tree Sort,500,25,0.00076310
+Tree Sort,500,26,0.00074220
+Tree Sort,500,27,0.00076560
+Tree Sort,500,28,0.00056790
+Tree Sort,500,29,0.00081780
+Tree Sort,500,30,0.00075010
+Tree Sort,500,31,0.00075280
+Tree Sort,500,32,0.00078600
+Tree Sort,500,33,0.00071090
+Tree Sort,500,34,0.00081540
+Tree Sort,500,35,0.00074220
+Tree Sort,500,36,0.00078000
+Tree Sort,500,37,0.00079420
+Tree Sort,500,38,0.00078090
+Tree Sort,500,39,0.00075470
+Tree Sort,500,40,0.00072420
+Tree Sort,500,41,0.00072570
+Tree Sort,500,42,0.00079160
+Tree Sort,500,43,0.00073190
+Tree Sort,500,44,0.00068890
+Tree Sort,500,45,0.00049500
+Tree Sort,500,46,0.00055880
+Tree Sort,500,47,0.00081870
+Tree Sort,500,48,0.00068470
+Tree Sort,500,49,0.00060710
+Tree Sort,500,50,0.00076640
+Tree Sort,500,51,0.00072880
+Tree Sort,500,52,0.00051870
+Tree Sort,500,53,0.00078670
+Tree Sort,500,54,0.00063230
+Tree Sort,500,55,0.00079990
+Tree Sort,500,56,0.00078600
+Tree Sort,500,57,0.00078100
+Tree Sort,500,58,0.00057680
+Tree Sort,500,59,0.00083210
+Tree Sort,500,60,0.00061930
+Tree Sort,500,61,0.00088830
+Tree Sort,500,62,0.00052590
+Tree Sort,500,63,0.00048470
+Tree Sort,500,64,0.00086810
+Tree Sort,500,65,0.00044230
+Tree Sort,500,66,0.00079590
+Tree Sort,500,67,0.00049520
+Tree Sort,500,68,0.00055220
+Tree Sort,500,69,0.00067270
+Tree Sort,500,70,0.00066440
+Tree Sort,500,71,0.00048620
+Tree Sort,500,72,0.00079390
+Tree Sort,500,73,0.00054740
+Tree Sort,500,74,0.00046960
+Tree Sort,500,75,0.00068740
+Tree Sort,500,76,0.00060510
+Tree Sort,500,77,0.00064530
+Tree Sort,500,78,0.00047580
+Tree Sort,500,79,0.00061740
+Tree Sort,500,80,0.00085040
+Tree Sort,500,81,0.00082420
+Tree Sort,500,82,0.00084790
+Tree Sort,500,83,0.00072420
+Tree Sort,500,84,0.00061510
+Tree Sort,500,85,0.00062550
+Tree Sort,500,86,0.00077370
+Tree Sort,500,87,0.00078170
+Tree Sort,500,88,0.00056910
+Tree Sort,500,89,0.00049320
+Tree Sort,500,90,0.00056500
+Tree Sort,500,91,0.00057620
+Tree Sort,500,92,0.00052750
+Tree Sort,500,93,0.00048220
+Tree Sort,500,94,0.00071980
+Tree Sort,500,95,0.00045820
+Tree Sort,500,96,0.00076580
+Tree Sort,500,97,0.00081190
+Tree Sort,500,98,0.00075480
+Tree Sort,500,99,0.00077670
+Tree Sort,500,100,0.00077310
+Tree Sort,500,101,0.00065550
+Tree Sort,500,102,0.00071280
+Tree Sort,500,103,0.00081270
+Tree Sort,500,104,0.00046750
+Tree Sort,500,105,0.00079890
+Tree Sort,500,106,0.00075680
+Tree Sort,500,107,0.00069620
+Tree Sort,500,108,0.00053220
+Tree Sort,500,109,0.00081170
+Tree Sort,500,110,0.00079360
+Tree Sort,500,111,0.00058280
+Tree Sort,500,112,0.00050680
+Tree Sort,500,113,0.00077040
+Tree Sort,500,114,0.00053550
+Tree Sort,500,115,0.00050840
+Tree Sort,500,116,0.00092710
+Tree Sort,500,117,0.00071720
+Tree Sort,500,118,0.00057740
+Tree Sort,500,119,0.00081440
+Tree Sort,500,120,0.00058360
+Tree Sort,500,121,0.00079770
+Tree Sort,500,122,0.00047660
+Tree Sort,500,123,0.00077170
+Tree Sort,500,124,0.00078180
+Tree Sort,500,125,0.00073560
+Tree Sort,500,126,0.00048510
+Tree Sort,500,127,0.00063540
+Tree Sort,500,128,0.00067320
+Tree Sort,500,129,0.00080700
+Tree Sort,500,130,0.00053010
+Tree Sort,500,131,0.00076180
+Tree Sort,500,132,0.00055700
+Tree Sort,500,133,0.00072770
+Tree Sort,500,134,0.00075840
+Tree Sort,500,135,0.00048100
+Tree Sort,500,136,0.00076480
+Tree Sort,500,137,0.00077050
+Tree Sort,500,138,0.00079780
+Tree Sort,500,139,0.00063130
+Tree Sort,500,140,0.00073610
+Tree Sort,500,141,0.00074850
+Tree Sort,500,142,0.00087510
+Tree Sort,500,143,0.00071500
+Tree Sort,500,144,0.00066840
+Tree Sort,500,145,0.00073230
+Tree Sort,500,146,0.00072950
+Tree Sort,500,147,0.00062040
+Tree Sort,500,148,0.00064540
+Tree Sort,500,149,0.00073480
+Tree Sort,500,150,0.00081100
+Tree Sort,500,151,0.00066100
+Tree Sort,500,152,0.00072380
+Tree Sort,500,153,0.00075530
+Tree Sort,500,154,0.00056950
+Tree Sort,500,155,0.00074170
+Tree Sort,500,156,0.00073020
+Tree Sort,500,157,0.00067900
+Tree Sort,500,158,0.00079610
+Tree Sort,500,159,0.00080710
+Tree Sort,500,160,0.00078150
+Tree Sort,500,161,0.00054850
+Tree Sort,500,162,0.00067300
+Tree Sort,500,163,0.00074950
+Tree Sort,500,164,0.00078280
+Tree Sort,500,165,0.00057020
+Tree Sort,500,166,0.00055180
+Tree Sort,500,167,0.00048500
+Tree Sort,500,168,0.00061180
+Tree Sort,500,169,0.00071560
+Tree Sort,500,170,0.00048050
+Tree Sort,500,171,0.00046510
+Tree Sort,500,172,0.00059310
+Tree Sort,500,173,0.00071480
+Tree Sort,500,174,0.00053160
+Tree Sort,500,175,0.00051830
+Tree Sort,500,176,0.00067110
+Tree Sort,500,177,0.00052420
+Tree Sort,500,178,0.00070930
+Tree Sort,500,179,0.00089290
+Tree Sort,500,180,0.00080400
+Tree Sort,500,181,0.00077020
+Tree Sort,500,182,0.00074030
+Tree Sort,500,183,0.00085180
+Tree Sort,500,184,0.00078130
+Tree Sort,500,185,0.00080440
+Tree Sort,500,186,0.00071400
+Tree Sort,500,187,0.00080240
+Tree Sort,500,188,0.00081500
+Tree Sort,500,189,0.00084180
+Tree Sort,500,190,0.00070480
+Tree Sort,500,191,0.00078020
+Tree Sort,500,192,0.00064540
+Tree Sort,500,193,0.00091170
+Tree Sort,500,194,0.00078240
+Tree Sort,500,195,0.00055350
+Tree Sort,500,196,0.00075060
+Tree Sort,500,197,0.00066000
+Tree Sort,500,198,0.00079370
+Tree Sort,500,199,0.00070120
+Tree Sort,500,200,0.00077150
+Tree Sort,500,201,0.00064380
+Tree Sort,500,202,0.00061330
+Tree Sort,500,203,0.00070040
+Tree Sort,500,204,0.00078240
+Tree Sort,500,205,0.00079370
+Tree Sort,500,206,0.00067410
+Tree Sort,500,207,0.00047640
+Tree Sort,500,208,0.00076160
+Tree Sort,500,209,0.00077200
+Tree Sort,500,210,0.00051440
+Tree Sort,500,211,0.00080260
+Tree Sort,500,212,0.00075300
+Tree Sort,500,213,0.00074330
+Tree Sort,500,214,0.00068010
+Tree Sort,500,215,0.00071770
+Tree Sort,500,216,0.00074600
+Tree Sort,500,217,0.00048690
+Tree Sort,500,218,0.00074880
+Tree Sort,500,219,0.00072650
+Tree Sort,500,220,0.00070800
+Tree Sort,500,221,0.00076260
+Tree Sort,500,222,0.00079470
+Tree Sort,500,223,0.00077250
+Tree Sort,500,224,0.00078590
+Tree Sort,500,225,0.00076640
+Tree Sort,500,226,0.00073910
+Tree Sort,500,227,0.00075760
+Tree Sort,500,228,0.00076220
+Tree Sort,500,229,0.00088220
+Tree Sort,500,230,0.00080650
+Tree Sort,500,231,0.00074670
+Tree Sort,500,232,0.00079220
+Tree Sort,500,233,0.00079070
+Tree Sort,500,234,0.00074630
+Tree Sort,500,235,0.00078430
+Tree Sort,500,236,0.00079820
+Tree Sort,500,237,0.00047260
+Tree Sort,500,238,0.00048160
+Tree Sort,500,239,0.00085830
+Tree Sort,500,240,0.00077820
+Tree Sort,500,241,0.00064890
+Tree Sort,500,242,0.00056770
+Tree Sort,500,243,0.00085500
+Tree Sort,500,244,0.00061890
+Tree Sort,500,245,0.00055120
+Tree Sort,500,246,0.00073780
+Tree Sort,500,247,0.00047640
+Tree Sort,500,248,0.00059910
+Tree Sort,500,249,0.00075770
+Tree Sort,500,250,0.00080600
+Tree Sort,500,251,0.00046920
+Tree Sort,500,252,0.00048070
+Tree Sort,500,253,0.00075620
+Tree Sort,500,254,0.00058420
+Tree Sort,500,255,0.00080530
+Tree Sort,500,256,0.00050240
+Tree Sort,500,257,0.00067560
+Tree Sort,500,258,0.00078110
+Tree Sort,500,259,0.00047640
+Tree Sort,500,260,0.00078130
+Tree Sort,500,261,0.00048660
+Tree Sort,500,262,0.00070970
+Tree Sort,500,263,0.00077570
+Tree Sort,500,264,0.00080220
+Tree Sort,500,265,0.00049530
+Tree Sort,500,266,0.00066680
+Tree Sort,500,267,0.00072140
+Tree Sort,500,268,0.00079350
+Tree Sort,500,269,0.00073640
+Tree Sort,500,270,0.00054670
+Tree Sort,500,271,0.00050860
+Tree Sort,500,272,0.00048090
+Tree Sort,500,273,0.00078260
+Tree Sort,500,274,0.00088410
+Tree Sort,500,275,0.00045890
+Tree Sort,500,276,0.00064180
+Tree Sort,500,277,0.00077910
+Tree Sort,500,278,0.00063760
+Tree Sort,500,279,0.00079280
+Tree Sort,500,280,0.00080540
+Tree Sort,500,281,0.00045620
+Tree Sort,500,282,0.00078980
+Tree Sort,500,283,0.00055530
+Tree Sort,500,284,0.00075210
+Tree Sort,500,285,0.00073450
+Tree Sort,500,286,0.00078020
+Tree Sort,500,287,0.00049570
+Tree Sort,500,288,0.00077040
+Tree Sort,500,289,0.00076360
+Tree Sort,500,290,0.00057800
+Tree Sort,500,291,0.00081080
+Tree Sort,500,292,0.00073980
+Tree Sort,500,293,0.00073120
+Tree Sort,500,294,0.00049070
+Tree Sort,500,295,0.00064520
+Tree Sort,500,296,0.00055690
+Tree Sort,500,297,0.00070630
+Tree Sort,500,298,0.00063100
+Tree Sort,500,299,0.00051240
+Tree Sort,500,300,0.00060560
+Tree Sort,500,301,0.00080040
+Tree Sort,500,302,0.00051590
+Tree Sort,500,303,0.00050640
+Tree Sort,500,304,0.00068530
+Tree Sort,500,305,0.00046180
+Tree Sort,500,306,0.00049660
+Tree Sort,500,307,0.00055640
+Tree Sort,500,308,0.00071880
+Tree Sort,500,309,0.00057280
+Tree Sort,500,310,0.00046880
+Tree Sort,500,311,0.00080830
+Tree Sort,500,312,0.00078400
+Tree Sort,500,313,0.00052760
+Tree Sort,500,314,0.00076560
+Tree Sort,500,315,0.00051010
+Tree Sort,500,316,0.00078590
+Tree Sort,500,317,0.00065060
+Tree Sort,500,318,0.00079290
+Tree Sort,500,319,0.00053000
+Tree Sort,500,320,0.00051270
+Tree Sort,500,321,0.00078530
+Tree Sort,500,322,0.00076830
+Tree Sort,500,323,0.00046430
+Tree Sort,500,324,0.00069670
+Tree Sort,500,325,0.00053230
+Tree Sort,500,326,0.00075220
+Tree Sort,500,327,0.00077560
+Tree Sort,500,328,0.00054530
+Tree Sort,500,329,0.00049280
+Tree Sort,500,330,0.00073650
+Tree Sort,500,331,0.00060530
+Tree Sort,500,332,0.00074270
+Tree Sort,500,333,0.00051470
+Tree Sort,500,334,0.00075780
+Tree Sort,500,335,0.00066090
+Tree Sort,500,336,0.00057410
+Tree Sort,500,337,0.00080050
+Tree Sort,500,338,0.00079030
+Tree Sort,500,339,0.00083450
+Tree Sort,500,340,0.00079790
+Tree Sort,500,341,0.00083720
+Tree Sort,500,342,0.00077240
+Tree Sort,500,343,0.00054500
+Tree Sort,500,344,0.00077620
+Tree Sort,500,345,0.00071890
+Tree Sort,500,346,0.00064190
+Tree Sort,500,347,0.00073120
+Tree Sort,500,348,0.00072140
+Tree Sort,500,349,0.00058390
+Tree Sort,500,350,0.00076890
+Tree Sort,500,351,0.00078050
+Tree Sort,500,352,0.00065270
+Tree Sort,500,353,0.00047700
+Tree Sort,500,354,0.00048440
+Tree Sort,500,355,0.00075020
+Tree Sort,500,356,0.00048340
+Tree Sort,500,357,0.00064130
+Tree Sort,500,358,0.00049400
+Tree Sort,500,359,0.00051670
+Tree Sort,500,360,0.00074610
+Tree Sort,500,361,0.00052740
+Tree Sort,500,362,0.00057560
+Tree Sort,500,363,0.00049600
+Tree Sort,500,364,0.00048030
+Tree Sort,500,365,0.00057230
+Tree Sort,500,366,0.00083970
+Tree Sort,500,367,0.00046980
+Tree Sort,500,368,0.00049690
+Tree Sort,500,369,0.00075370
+Tree Sort,500,370,0.00050200
+Tree Sort,500,371,0.00047940
+Tree Sort,500,372,0.00078380
+Tree Sort,500,373,0.00051990
+Tree Sort,500,374,0.00070790
+Tree Sort,500,375,0.00076080
+Tree Sort,500,376,0.00059990
+Tree Sort,500,377,0.00075600
+Tree Sort,500,378,0.00071870
+Tree Sort,500,379,0.00075760
+Tree Sort,500,380,0.00049660
+Tree Sort,500,381,0.00079580
+Tree Sort,500,382,0.00073980
+Tree Sort,500,383,0.00066150
+Tree Sort,500,384,0.00076480
+Tree Sort,500,385,0.00074260
+Tree Sort,500,386,0.00066960
+Tree Sort,500,387,0.00047700
+Tree Sort,500,388,0.00077390
+Tree Sort,500,389,0.00073270
+Tree Sort,500,390,0.00048860
+Tree Sort,500,391,0.00069920
+Tree Sort,500,392,0.00060720
+Tree Sort,500,393,0.00074610
+Tree Sort,500,394,0.00070060
+Tree Sort,500,395,0.00057110
+Tree Sort,500,396,0.00074770
+Tree Sort,500,397,0.00087660
+Tree Sort,500,398,0.00081210
+Tree Sort,500,399,0.00084810
+Tree Sort,500,400,0.00078200
+Tree Sort,500,401,0.00075450
+Tree Sort,500,402,0.00075490
+Tree Sort,500,403,0.00067950
+Tree Sort,500,404,0.00049600
+Tree Sort,500,405,0.00062400
+Tree Sort,500,406,0.00074810
+Tree Sort,500,407,0.00077510
+Tree Sort,500,408,0.00056010
+Tree Sort,500,409,0.00070500
+Tree Sort,500,410,0.00052580
+Tree Sort,500,411,0.00077150
+Tree Sort,500,412,0.00081340
+Tree Sort,500,413,0.00047810
+Tree Sort,500,414,0.00073810
+Tree Sort,500,415,0.00081900
+Tree Sort,500,416,0.00074280
+Tree Sort,500,417,0.00051920
+Tree Sort,500,418,0.00059610
+Tree Sort,500,419,0.00051040
+Tree Sort,500,420,0.00055490
+Tree Sort,500,421,0.00076350
+Tree Sort,500,422,0.00062930
+Tree Sort,500,423,0.00072210
+Tree Sort,500,424,0.00059960
+Tree Sort,500,425,0.00080430
+Tree Sort,500,426,0.00078380
+Tree Sort,500,427,0.00074840
+Tree Sort,500,428,0.00062870
+Tree Sort,500,429,0.00079800
+Tree Sort,500,430,0.00082280
+Tree Sort,500,431,0.00074050
+Tree Sort,500,432,0.00088220
+Tree Sort,500,433,0.00092470
+Tree Sort,500,434,0.00066730
+Tree Sort,500,435,0.00071800
+Tree Sort,500,436,0.00070990
+Tree Sort,500,437,0.00080330
+Tree Sort,500,438,0.00074660
+Tree Sort,500,439,0.00073100
+Tree Sort,500,440,0.00065410
+Tree Sort,500,441,0.00080910
+Tree Sort,500,442,0.00078030
+Tree Sort,500,443,0.00075370
+Tree Sort,500,444,0.00068960
+Tree Sort,500,445,0.00058450
+Tree Sort,500,446,0.00062910
+Tree Sort,500,447,0.00082390
+Tree Sort,500,448,0.00076390
+Tree Sort,500,449,0.00070730
+Tree Sort,500,450,0.00089860
+Tree Sort,500,451,0.00066700
+Tree Sort,500,452,0.00091110
+Tree Sort,500,453,0.00072380
+Tree Sort,500,454,0.00056730
+Tree Sort,500,455,0.00054350
+Tree Sort,500,456,0.00075930
+Tree Sort,500,457,0.00056010
+Tree Sort,500,458,0.00052690
+Tree Sort,500,459,0.00077010
+Tree Sort,500,460,0.00071920
+Tree Sort,500,461,0.00078380
+Tree Sort,500,462,0.00066250
+Tree Sort,500,463,0.00080560
+Tree Sort,500,464,0.00076240
+Tree Sort,500,465,0.00071710
+Tree Sort,500,466,0.00073060
+Tree Sort,500,467,0.00079230
+Tree Sort,500,468,0.00075180
+Tree Sort,500,469,0.00051630
+Tree Sort,500,470,0.00077830
+Tree Sort,500,471,0.00076080
+Tree Sort,500,472,0.00066790
+Tree Sort,500,473,0.00053200
+Tree Sort,500,474,0.00068180
+Tree Sort,500,475,0.00083340
+Tree Sort,500,476,0.00078210
+Tree Sort,500,477,0.00048000
+Tree Sort,500,478,0.00050680
+Tree Sort,500,479,0.00053920
+Tree Sort,500,480,0.00073940
+Tree Sort,500,481,0.00095680
+Tree Sort,500,482,0.00061330
+Tree Sort,500,483,0.00049840
+Tree Sort,500,484,0.00064010
+Tree Sort,500,485,0.00051380
+Tree Sort,500,486,0.00051130
+Tree Sort,500,487,0.00063100
+Tree Sort,500,488,0.00050460
+Tree Sort,500,489,0.00073040
+Tree Sort,500,490,0.00047860
+Tree Sort,500,491,0.00053470
+Tree Sort,500,492,0.00053680
+Tree Sort,500,493,0.00047510
+Tree Sort,500,494,0.00072950
+Tree Sort,500,495,0.00049580
+Tree Sort,500,496,0.00053370
+Tree Sort,500,497,0.00050570
+Tree Sort,500,498,0.00048240
+Tree Sort,500,499,0.00051550
+Tree Sort,500,500,0.00051620


### PR DESCRIPTION
Include benchmark results for array sizes 333 and 500 in the README, while enhancing CSV result processing with a max_iterations parameter for better error handling and limiting entries.